### PR TITLE
Fix 'rpc error: code = InvalidArgument desc = Invalid parent id!' errors

### DIFF
--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -84,7 +84,7 @@ func protoFromSpanData(s *export.SpanData, projectID string) *tracepb.Span {
 		SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: !s.HasRemoteParent},
 	}
 	if s.ParentSpanID != s.SpanContext.SpanID && s.ParentSpanID.IsValid() {
-		sp.ParentSpanId = fmt.Sprintf("%.16x", s.ParentSpanID)
+		sp.ParentSpanId = s.ParentSpanID.String()
 	}
 	if s.StatusCode != codes.OK {
 		sp.Status = &statuspb.Status{Code: int32(s.StatusCode)}


### PR DESCRIPTION
The parent span ID was being formatted incorrectly, which meant all spans except the root span were rejected by the GCP tracing API.

If clients did not have error logging hooked up to [`WithOnError()`](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/966afdc5d38c2087e1f9c546dec5a62dda7aadd5/exporter/trace/cloudtrace.go#L126), this would cause child spans to be silently dropped.

[The API documentation](https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects.traces#TraceSpan) says the span ID should be formatted as a 64-bit integer encoded as a string, but appears to accept a span ID or parent span ID in the hexadecimal format returned by `SpanID.String()`.

I couldn't see any tests for this functionality, so I haven't added any - happy to add some.