### PR TITLE
Added create trace pipeline method (Breaking Change: removes implementation of "SpanBatcher")

### DIFF
--- a/example/trace/http/client/client.go
+++ b/example/trace/http/client/client.go
@@ -39,12 +39,11 @@ func initTracer() func() {
 
 	// Create Google Cloud Trace exporter to be able to retrieve
 	// the collected spans.
-	_, flush, err := texporter.NewExportPipeline(
-		texporter.WithProjectID(projectID),
+	_, flush, err := texporter.InstallNewPipeline(
+		[]texporter.Option {texporter.WithProjectID(projectID)},
 		// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
 		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
-		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		texporter.RegisterAsGlobal(),
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/example/trace/http/client/client.go
+++ b/example/trace/http/client/client.go
@@ -54,6 +54,7 @@ func initTracer() func() {
 
 func main() {
 	flush := initTracer()
+	defer flush()
 	tr := global.TraceProvider().Tracer("cloudtrace/example/client")
 
 	client := http.DefaultClient
@@ -88,6 +89,4 @@ func main() {
 
 	fmt.Printf("Response Received: %s\n\n\n", body)
 	fmt.Printf("Waiting to export spans ...\n\n")
-	flush()
-	fmt.Println("Check traces on Google Cloud Trace")
 }

--- a/example/trace/http/client/client.go
+++ b/example/trace/http/client/client.go
@@ -41,7 +41,7 @@ func initTracer() func() {
 	// the collected spans.
 	_, flush, err := texporter.InstallNewPipeline(
 		[]texporter.Option {texporter.WithProjectID(projectID)},
-		// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
+		// For this example code we use sdktrace.AlwaysSample sampler to sample all traces.
 		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
 		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)

--- a/example/trace/http/server/server.go
+++ b/example/trace/http/server/server.go
@@ -35,7 +35,7 @@ func initTracer() func() {
 	// the collected spans.
 	_, flush, err := cloudtrace.InstallNewPipeline(
 		[]cloudtrace.Option {cloudtrace.WithProjectID(projectID)},
-		// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
+		// For this example code we use sdktrace.AlwaysSample sampler to sample all traces.
 		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
 		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)

--- a/example/trace/http/server/server.go
+++ b/example/trace/http/server/server.go
@@ -47,7 +47,8 @@ func initTracer() func () {
 }
 
 func main() {
-	_ = initTracer()
+	flush := initTracer()
+	defer flush()
 
 	tr := global.TraceProvider().Tracer("cloudtrace/example/server")
 

--- a/example/trace/http/server/server.go
+++ b/example/trace/http/server/server.go
@@ -28,17 +28,16 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-func initTracer() func () {
+func initTracer() func() {
 	projectID := os.Getenv("PROJECT_ID")
 
 	// Create Google Cloud Trace exporter to be able to retrieve
 	// the collected spans.
-	_, flush, err := cloudtrace.NewExportPipeline(
-		cloudtrace.WithProjectID(projectID),
+	_, flush, err := cloudtrace.InstallNewPipeline(
+		[]cloudtrace.Option {cloudtrace.WithProjectID(projectID)},
 		// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
 		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
-		cloudtrace.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		cloudtrace.RegisterAsGlobal(),
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -21,7 +21,7 @@ Add `github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace` 
 import texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 ```
 
-Once you import the trace exporter package, then register the exporter to the application, and start tracing. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instruction in [Authentication](#Authentication).
+Once you import the trace exporter package, create and install a new export pipeline, and then you can start tracing. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instruction in [Authentication](#Authentication).
 
 ```go
 // Create exporter and trace provider pipeline, and register provider.

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -24,25 +24,25 @@ import texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exp
 Once you import the trace exporter package, then register the exporter to the application, and start tracing. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instruction in [Authentication](#Authentication).
 
 ```go
-// Create exporter.
+// Create exporter and trace provider using pipeline.
 projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-exporter, err := texporter.NewExporter(texporter.WithProjectID(projectID))
+_, flush, err := texporter.NewExportPipeline(
+        texporter.WithProjectID(projectID),
+        // For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
+        // In a production environment or high QPS setup please use ProbabilitySampler 
+        // set at the desired probability.
+        // Example:
+        // texporter.WithSDKConfig(&sdktrace.Config{
+        //        DefaultSampler: sdktrace.ProbabilitySampler(0.0001),
+        // })
+        texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+        texporter.RegisterAsGlobal(),
+)
 if err != nil {
-    log.Fatalf("texporter.NewExporter: %v", err)
+    log.Fatalf("texporter.NewExportPipeline: %v", err)
 }
-// Create trace provider with the exporter.
-//
-// By default it uses AlwaysSample() which samples all traces.
-// In a production environment or high QPS setup please use
-// ProbabilitySampler set at the desired probability.
-// Example:
-//   config := sdktrace.Config{DefaultSampler:sdktrace.ProbabilitySampler(0.0001)}
-//   tp, err := sdktrace.NewProvider(sdktrace.WithConfig(config), ...)
-tp, err := sdktrace.NewProvider(sdktrace.WithSyncer(exporter))
-if err != nil {
-        log.Fatal(err)
-}
-global.SetTraceProvider(tp)
+// before ending program, wait for all enqueued spans to be exported
+defer flush()
 
 // Create custom span.
 tracer := global.TraceProvider().Tracer("example.com/trace")

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -31,7 +31,7 @@ _, flush, err := texporter.InstallNewPipeline(
                 texporter.WithProjectID(projectID),
                 // other optional exporter options
         },
-        // For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
+        // This example code uses sdktrace.AlwaysSample sampler to sample all traces.
         // In a production environment or high QPS setup please use ProbabilitySampler
         // set at the desired probability.
         // Example:

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -29,7 +29,7 @@ projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 _, flush, err := texporter.NewExportPipeline(
         texporter.WithProjectID(projectID),
         // For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
-        // In a production environment or high QPS setup please use ProbabilitySampler 
+        // In a production environment or high QPS setup please use ProbabilitySampler
         // set at the desired probability.
         // Example:
         // texporter.WithSDKConfig(&sdktrace.Config{

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -27,7 +27,7 @@ Once you import the trace exporter package, create and install a new export pipe
 // Create exporter and trace provider pipeline, and register provider.
 projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 _, flush, err := texporter.InstallNewPipeline(
-        []texporter.Option {
+        []texporter.Option{
                 texporter.WithProjectID(projectID),
                 // other optional exporter options
         },

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -27,7 +27,7 @@ Once you import the trace exporter package, create and install a new export pipe
 // Create exporter and trace provider pipeline, and register provider.
 projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 _, flush, err := texporter.InstallNewPipeline(
-        []texporter.Option{
+        []texporter.Option {
                 texporter.WithProjectID(projectID),
                 // other optional exporter options
         },

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -24,22 +24,25 @@ import texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exp
 Once you import the trace exporter package, then register the exporter to the application, and start tracing. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instruction in [Authentication](#Authentication).
 
 ```go
-// Create exporter and trace provider using pipeline.
+// Create exporter and trace provider pipeline, and register provider.
 projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-_, flush, err := texporter.NewExportPipeline(
-        texporter.WithProjectID(projectID),
+_, flush, err := texporter.InstallNewPipeline(
+        []texporter.Option {
+                texporter.WithProjectID(projectID),
+                // other optional exporter options
+        },
         // For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
         // In a production environment or high QPS setup please use ProbabilitySampler
         // set at the desired probability.
         // Example:
-        // texporter.WithSDKConfig(&sdktrace.Config{
+        // sdktrace.WithConfig(sdktrace.Config {
         //        DefaultSampler: sdktrace.ProbabilitySampler(0.0001),
         // })
-        texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-        texporter.RegisterAsGlobal(),
+        sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+        // other optional provider options
 )
 if err != nil {
-    log.Fatalf("texporter.NewExportPipeline: %v", err)
+    log.Fatalf("texporter.InstallNewPipeline: %v", err)
 }
 // before ending program, wait for all enqueued spans to be exported
 defer flush()

--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -210,7 +210,7 @@ func WithTimeout(t time.Duration) func(o *options) {
 func WithDisplayNameFormatter(f DisplayNameFormatter) func(o *options) {
 	return func(o *options) {
 		o.DisplayNameFormatter = f
-  }
+	}
 }
 
 func (o *options) handleError(err error) {

--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -318,11 +318,6 @@ func (e *Exporter) ExportSpan(ctx context.Context, sd *export.SpanData) {
 	e.traceExporter.ExportSpan(ctx, sd)
 }
 
-// ExportSpans exports a slice of SpanData to Stackdriver Trace in batch
-func (e *Exporter) ExportSpans(ctx context.Context, sds []*export.SpanData) {
-	e.traceExporter.ExportSpans(ctx, sds)
-}
-
 func (e *Exporter) sdWithDefaultTraceAttributes(sd *export.SpanData) *export.SpanData {
 	newSD := *sd
 	for k, v := range e.traceExporter.o.DefaultTraceAttributes {

--- a/exporter/trace/cloudtrace_test.go
+++ b/exporter/trace/cloudtrace_test.go
@@ -127,7 +127,6 @@ func TestExporter_Timeout(t *testing.T) {
 	mockTrace.spansUploaded = nil
 	mockTrace.delay = 20 * time.Millisecond
 	var exportErrors []error
-	//ch := make(chan error)
 
 	// Create Google Cloud Trace Exporter
 	_, flush, err := texporter.NewExportPipeline(
@@ -138,7 +137,6 @@ func TestExporter_Timeout(t *testing.T) {
 		texporter.WithBundleCountThreshold(1),
 		texporter.WithOnError(func(err error) {
 			exportErrors = append(exportErrors, err)
-			//ch <- err
 		}),
 		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 		texporter.RegisterAsGlobal(),

--- a/exporter/trace/cloudtrace_test.go
+++ b/exporter/trace/cloudtrace_test.go
@@ -104,13 +104,14 @@ func TestExporter_ExportSpan(t *testing.T) {
 	mockTrace.delay = 0
 
 	// Create Google Cloud Trace Exporter
-	_, flush, err := texporter.NewExportPipeline(
-		texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
-		texporter.WithTraceClientOptions(clientOpt),
-		// handle bundle as soon as span is received
-		texporter.WithBundleCountThreshold(1),
-		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		texporter.RegisterAsGlobal(),
+	_, flush, err := texporter.InstallNewPipeline(
+		[]texporter.Option {
+			texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
+			texporter.WithTraceClientOptions(clientOpt),
+			// handle bundle as soon as span is received
+			texporter.WithBundleCountThreshold(1),
+		},
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	assert.NoError(t, err)
 
@@ -134,13 +135,14 @@ func TestExporter_DisplayNameFormatter(t *testing.T) {
 	}
 
 	// Create Google Cloud Trace Exporter
-	_, flush, err := texporter.NewExportPipeline(
-		texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
-		texporter.WithTraceClientOptions(clientOpt),
-		texporter.WithBundleCountThreshold(1),
-		texporter.WithDisplayNameFormatter(format),
-		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		texporter.RegisterAsGlobal(),
+	_, flush, err := texporter.InstallNewPipeline(
+		[]texporter.Option {
+			texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
+			texporter.WithTraceClientOptions(clientOpt),
+			texporter.WithBundleCountThreshold(1),
+			texporter.WithDisplayNameFormatter(format),
+		},
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	assert.NoError(t, err)
 
@@ -161,17 +163,18 @@ func TestExporter_Timeout(t *testing.T) {
 	var exportErrors []error
 
 	// Create Google Cloud Trace Exporter
-	_, flush, err := texporter.NewExportPipeline(
-		texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
-		texporter.WithTraceClientOptions(clientOpt),
-		texporter.WithTimeout(1*time.Millisecond),
-		// handle bundle as soon as span is received
-		texporter.WithBundleCountThreshold(1),
-		texporter.WithOnError(func(err error) {
-			exportErrors = append(exportErrors, err)
-		}),
-		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		texporter.RegisterAsGlobal(),
+	_, flush, err := texporter.InstallNewPipeline(
+		[]texporter.Option {
+			texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
+			texporter.WithTraceClientOptions(clientOpt),
+			texporter.WithTimeout(1*time.Millisecond),
+			// handle bundle as soon as span is received
+			texporter.WithBundleCountThreshold(1),
+			texporter.WithOnError(func(err error) {
+				exportErrors = append(exportErrors, err)
+			}),
+		},
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	assert.NoError(t, err)
 
@@ -200,13 +203,14 @@ func TestBundling(t *testing.T) {
 	}
 	mockTrace.mu.Unlock()
 
-	_, _, err := texporter.NewExportPipeline(
-		texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
-		texporter.WithTraceClientOptions(clientOpt),
-		texporter.WithBundleDelayThreshold(time.Second / 10),
-		texporter.WithBundleCountThreshold(10),
-		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		texporter.RegisterAsGlobal(),
+	_, _, err := texporter.InstallNewPipeline(
+		[]texporter.Option {
+			texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
+			texporter.WithTraceClientOptions(clientOpt),
+			texporter.WithBundleDelayThreshold(time.Second / 10),
+			texporter.WithBundleCountThreshold(10),
+		},
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	assert.NoError(t, err)
 
@@ -259,14 +263,15 @@ func TestBundling_ConcurrentExports(t *testing.T) {
 	workers := 3
 	spansPerWorker := 50
 	delay := 2 * time.Second
-	_, _, err := texporter.NewExportPipeline(
-		texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
-		texporter.WithTraceClientOptions(clientOpt),
-		texporter.WithBundleDelayThreshold(delay),
-		texporter.WithBundleCountThreshold(spansPerWorker),
-		texporter.WithMaxNumberOfWorkers(workers),
-		texporter.WithSDKConfig(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		texporter.RegisterAsGlobal(),
+	_, _, err := texporter.InstallNewPipeline(
+		[]texporter.Option {
+			texporter.WithProjectID("PROJECT_ID_NOT_REAL"),
+			texporter.WithTraceClientOptions(clientOpt),
+			texporter.WithBundleDelayThreshold(delay),
+			texporter.WithBundleCountThreshold(spansPerWorker),
+			texporter.WithMaxNumberOfWorkers(workers),
+		},
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
 	assert.NoError(t, err)
 

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -161,6 +161,10 @@ func (e *traceExporter) uploadSpans(ctx context.Context, spans []*tracepb.Span) 
 	}
 }
 
+func (e *traceExporter) Flush() {
+	e.bundler.Flush()
+}
+
 // contextAndSpan stores both a context and spans for use with a bundler.
 type contextAndSpans struct {
 	ctx context.Context

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -119,18 +119,6 @@ func (e *traceExporter) ExportSpan(ctx context.Context, sd *export.SpanData) {
 	e.checkBundlerError(err)
 }
 
-// ExportSpans exports a slice of SpanData to Stackdriver Trace in batch
-func (e *traceExporter) ExportSpans(ctx context.Context, sds []*export.SpanData) {
-	pbSpans := make([]*tracepb.Span, len(sds))
-	var protoSize int = 0
-	for i, sd := range sds {
-		pbSpans[i] = protoFromSpanData(sd, e.projectID)
-		protoSize += proto.Size(pbSpans[i])
-	}
-	err := e.bundler.Add(&contextAndSpans{ctx, pbSpans}, protoSize)
-	e.checkBundlerError(err)
-}
-
 // uploadSpans sends a set of spans to Stackdriver.
 func (e *traceExporter) uploadSpans(ctx context.Context, spans []*tracepb.Span) {
 	req := tracepb.BatchWriteSpansRequest{


### PR DESCRIPTION
Pipeline method to create exporter and provider in one method. Also updated tests, example, and readme to use pipeline.

This PR also removes the `ExportSpans` method, so the provider can no longer use the `withBatcher` option when creating the exporter.
(NOTE: THIS IS A BREAKING CHANGE)