### PR TITLE
Fix minimal reporting duration

### DIFF
--- a/exporter/metric/cloudmonitoring.go
+++ b/exporter/metric/cloudmonitoring.go
@@ -32,8 +32,8 @@ const (
 	defaultReportingDuration = 60 * time.Second
 
 	// minimumReportingDuration is the minimum duration supported by Google Cloud Monitoring.
-	// As of Apr 2020, the minimum duration is 1 second for custom metrics.
-	minimumReportingDuration = 1 * time.Second
+	// As of Apr 2020, the minimum duration is 10 second for custom metrics.
+	minimumReportingDuration = 10 * time.Second
 )
 
 var (

--- a/exporter/metric/cloudmonitoring.go
+++ b/exporter/metric/cloudmonitoring.go
@@ -28,11 +28,11 @@ import (
 
 const (
 	// defaultReportingDuration defaults to 60 seconds.
-	// https://cloud.google.com/monitoring/custom-metrics/creating-metrics#monitoring_write_timeseries-go
 	defaultReportingDuration = 60 * time.Second
 
 	// minimumReportingDuration is the minimum duration supported by Google Cloud Monitoring.
 	// As of Apr 2020, the minimum duration is 10 second for custom metrics.
+	// https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts
 	minimumReportingDuration = 10 * time.Second
 )
 


### PR DESCRIPTION
Minimal reporting duration is defined to 10 seconds as of July 2nd, 2020. The original value in the source code is incorrect.

https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts