### PR TITLE
Update format of g.co/agent label in spans (#54)

### DIFF
--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -58,7 +58,7 @@ const (
 	version = "0.1.0"
 )
 
-var userAgent = fmt.Sprintf("opentelemetry-go %s; cloudtrace-exporter %s", opentelemetry.Version(), version)
+var userAgent = fmt.Sprintf("opentelemetry-go %s; google-cloud-trace-exporter %s", opentelemetry.Version(), version)
 
 func generateDisplayName(s *export.SpanData, format DisplayNameFormatter) string {
 	if format != nil {


### PR DESCRIPTION
Change agent label to follow the [GCP exporter spec](https://docs.google.com/document/d/1eeGeSYlE2F-Dc-5_yLXnIlj7e--BYFeWlzWy6qBV2cg/edit?ts=5ef1fde7#heading=h.8ta8507cza65).

Addressing issue #54 