### PR TITLE
inject labels

### DIFF
--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -72,9 +72,14 @@ func generateDisplayName(s *export.SpanData, format DisplayNameFormatter) string
 }
 
 func injectLabelsFromResources(sd *export.SpanData) {
-	if sd.Resource.Len() > 0 {
-		for _, ele := range sd.Resource.Attributes() {
-			sd.Attributes = append(sd.Attributes, ele)
+	existingAttrs := make(map[kv.KeyValue]bool)
+	for _, attr := range sd.Attributes {
+		existingAttrs[attr] = true	
+	}
+	for _, attr := range sd.Resource.Attributes() {
+		if !existingAttrs[attr] {
+			existingAttrs[attr] = true	
+			sd.Attributes = append(sd.Attributes, attr)
 		}
 	}
 }

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -75,15 +75,16 @@ func injectLabelsFromResources(sd *export.SpanData) {
 	if sd.Resource.Len() == 0 {
 		return
 	}
-	uniqueAttrs := make(map[kv.KeyValue]bool)
+	uniqueAttrs := make(map[kv.Key]bool, len(sd.Attributes))
 	for _, attr := range sd.Attributes {
-		uniqueAttrs[attr] = true	
+		uniqueAttrs[attr.Key] = true	
 	}
 	for _, attr := range sd.Resource.Attributes() {
-		if !uniqueAttrs[attr] {
-			uniqueAttrs[attr] = true	
-			sd.Attributes = append(sd.Attributes, attr)
+		if uniqueAttrs[attr.Key] {
+			continue // skip resource attributes which conflict with span attributes
 		}
+		uniqueAttrs[attr.Key] = true	
+		sd.Attributes = append(sd.Attributes, attr)
 	}
 }
 

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -72,13 +72,16 @@ func generateDisplayName(s *export.SpanData, format DisplayNameFormatter) string
 }
 
 func injectLabelsFromResources(sd *export.SpanData) {
-	existingAttrs := make(map[kv.KeyValue]bool)
+	if sd.Resource.Len() == 0 {
+		return
+	}
+	uniqueAttrs := make(map[kv.KeyValue]bool)
 	for _, attr := range sd.Attributes {
-		existingAttrs[attr] = true	
+		uniqueAttrs[attr] = true	
 	}
 	for _, attr := range sd.Resource.Attributes() {
-		if !existingAttrs[attr] {
-			existingAttrs[attr] = true	
+		if !uniqueAttrs[attr] {
+			uniqueAttrs[attr] = true	
 			sd.Attributes = append(sd.Attributes, attr)
 		}
 	}

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -71,10 +71,20 @@ func generateDisplayName(s *export.SpanData, format DisplayNameFormatter) string
 	}
 }
 
+func injectLabelsFromResources(sd *export.SpanData) {
+	if sd.Resource.Len() > 0 {
+		for _, ele := range sd.Resource.Attributes() {
+			sd.Attributes = append(sd.Attributes, ele)
+		}
+	}
+}
+
 func protoFromSpanData(s *export.SpanData, projectID string, format DisplayNameFormatter) *tracepb.Span {
 	if s == nil {
 		return nil
 	}
+
+	injectLabelsFromResources(s)
 
 	traceIDString := s.SpanContext.TraceID.String()
 	spanIDString := s.SpanContext.SpanID.String()

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -71,6 +71,9 @@ func generateDisplayName(s *export.SpanData, format DisplayNameFormatter) string
 	}
 }
 
+
+// If there are duplicate keys present in the list of attributes, 
+// then the first value found for the key is preserved.
 func injectLabelsFromResources(sd *export.SpanData) {
 	if sd.Resource.Len() == 0 {
 		return


### PR DESCRIPTION
Put the logic of injecting labels into span in the trace_proto.go because
1) The semantic of injecting labels is on the level of building spans, not implementing trace exporter.
2) func protoFromSpanData would be used by both func ExportSpan() and func ExportSpans() in trace.go. It would have  duplicate callings if we put the code in trace.go or cloudtrace.go.