### PR TITLE
Added scripts to automate release process and related docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,69 @@
+# Release Process
+
+## Pre-Release
+
+Update go.mod for submodules to depend on the new release which will happen in the next step.
+
+1. Run the pre-release script. It creates a branch `pre_release_<new tag>` that will contain all release changes.
+
+    ```
+    ./pre_release.sh -t <new tag>
+    ```
+
+2. Verify the changes.
+
+    ```
+    git diff master
+    ```
+
+    This should have changed the version for all modules to be `<new tag>`.
+
+3. TODO: Consider adding [Changelog](./CHANGELOG.md) and update this for each release.
+
+4. Push the changes to upstream and create a Pull Request on GitHub.
+    Be sure to include the curated changes from the [Changelog](./CHANGELOG.md) in the description.
+
+
+## Tag
+
+Once the Pull Request with all the version changes has been approved and merged it is time to tag the merged commit.
+
+***IMPORTANT***: It is critical you use the same tag that you used in the Pre-Release step!
+Failure to do so will leave things in a broken state.
+
+***IMPORTANT***: [There is currently no way to remove an incorrectly tagged version of a Go module](https://github.com/golang/go/issues/34189).
+It is critical you make sure the version you push upstream is correct.
+[Failure to do so will lead to minor emergencies and tough to work around](https://github.com/open-telemetry/opentelemetry-go/issues/331).
+
+1. Run the tag.sh script using the `<commit-hash>` of the commit on the master branch for the merged Pull Request.
+
+    ```
+    ./tag.sh <new tag> <commit-hash>
+    ```
+
+2. Push tags to the upstream remote (not your fork: `github.com/GoogleCloudPlatform/opentelemetry-operations-go.git`).
+
+    ```
+    git push upstream <new tag>
+    ```
+
+## Release
+
+Finally create a Release for the new `<new tag>` on GitHub.
+
+Make sure all relevant changes for this release are included in the release notes and are in language that non-contributors to the project can understand. The `tag.sh` script generates commit logs since last release which can be used to derive the release notes from. These are generated using:
+
+```
+git --no-pager log --pretty=oneline "<last tag>..HEAD"
+```
+
+## Verify Examples
+
+After releasing verify that examples build outside of the repository.
+
+```
+./verify_examples.sh
+```
+
+The script copies examples into a different directory removes any `replace` declarations in `go.mod` and builds them.
+This ensures they build with the published release, not the local copy.

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -14,7 +14,8 @@
 
 package metric
 
-// Version is the current release version of OpenTelemetry in use.
+// Version is the current release version of the OpenTelemetry
+// Operations Metric Exporter in use.
 func Version() string {
-	return "0.10.0"
+	return "0.2.1"
 }

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -1,0 +1,20 @@
+// Copyright 2020, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+// Version is the current release version of OpenTelemetry in use.
+func Version() string {
+	return "0.10.0"
+}

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -14,7 +14,8 @@
 
 package trace
 
-// Version is the current release version of OpenTelemetry in use.
+// Version is the current release version of the OpenTelemetry
+// Operations Trace Exporter in use.
 func Version() string {
 	return "0.2.1"
 }

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -1,0 +1,20 @@
+// Copyright 2020, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+// Version is the current release version of OpenTelemetry in use.
+func Version() string {
+	return "0.2.1"
+}

--- a/get_main_pkgs.sh
+++ b/get_main_pkgs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2020, Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+top_dir='.'
+if [[ $# -gt 0 ]]; then
+    top_dir="${1}"
+fi
+
+p=$(pwd)
+mod_dirs=()
+mapfile -t mod_dirs < <(find "${top_dir}" -type f -name 'go.mod' -exec dirname {} \; | sort)
+
+for mod_dir in "${mod_dirs[@]}"; do
+    cd "${mod_dir}"
+    main_dirs=()
+    mapfile -t main_dirs < <(go list --find -f '{{.Name}}|{{.Dir}}' ./... | grep '^main|' | cut -f 2- -d '|')
+    for main_dir in "${main_dirs[@]}"; do
+        echo ".${main_dir#${p}}"
+    done
+    cd "${p}"
+done

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -68,6 +68,10 @@ if ! git diff --quiet; then \
 	exit 1
 fi
 
+# Update go.mod
+git checkout -b pre_release_${TAG} master
+PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep -v 'tools' | sed 's/^\.\///' | sort)
+
 # Update exporter/trace/version.go
 cp ./exporter/trace/version.go ./exporter/trace/version.go.bak
 sed "s/\(return \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${OTELOPS_VERSION}\"/" ./exporter/trace/version.go.bak >./exporter/trace/version.go
@@ -77,10 +81,6 @@ rm -f ./exporter/trace/version.go.bak
 cp ./exporter/metric/version.go ./exporter/metric/version.go.bak
 sed "s/\(return \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${OTELOPS_VERSION}\"/" ./exporter/metric/version.go.bak >./exporter/metric/version.go
 rm -f ./exporter/metric/version.go.bak
-
-# Update go.mod
-git checkout -b pre_release_${TAG} master
-PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep -v 'tools' | sed 's/^\.\///' | sort)
 
 for dir in $PACKAGE_DIRS; do
 	cp "${dir}/go.mod" "${dir}/go.mod.bak"

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Copyright 2020, Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+help()
+{
+   printf "\n"
+   printf "Usage: $0 -t tag\n"
+   printf "\t-t Unreleased tag. Update all go.mod with this tag.\n"
+   exit 1 # Exit script after printing help
+}
+
+while getopts "t:" opt
+do
+   case "$opt" in
+      t ) TAG="$OPTARG" ;;
+      ? ) help ;; # Print help
+   esac
+done
+
+# Print help in case parameters are empty
+if [ -z "$TAG" ]
+then
+   printf "Tag is missing\n";
+   help
+fi
+
+# Validate semver
+SEMVER_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+if [[ "${TAG}" =~ ${SEMVER_REGEX} ]]; then
+	printf "${TAG} is valid semver tag.\n"
+else
+	printf "${TAG} is not a valid semver tag.\n"
+	exit -1
+fi
+
+TAG_FOUND=`git tag --list ${TAG}`
+if [[ ${TAG_FOUND} = ${TAG} ]] ; then
+        printf "Tag ${TAG} already exists\n"
+        exit -1
+fi
+
+# Get version for exporter/<trace|metric>/version.go
+OTELOPS_VERSION=$(echo "${TAG}" | grep -o '^v[0-9]\+\.[0-9]\+\.[0-9]\+')
+# Strip leading v
+OTELOPS_VERSION="${OTELOPS_VERSION#v}"
+
+cd $(dirname $0)
+
+if ! git diff --quiet; then \
+	printf "Working tree is not clean, can't proceed with the release process\n"
+	git status
+	git diff
+	exit 1
+fi
+
+# Update exporter/trace/version.go
+cp ./exporter/trace/version.go ./exporter/trace/version.go.bak
+sed "s/\(return \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${OTELOPS_VERSION}\"/" ./exporter/trace/version.go.bak >./exporter/trace/version.go
+rm -f ./exporter/trace/version.go.bak
+
+# Update exporter/metric/version.go
+cp ./exporter/metric/version.go ./exporter/metric/version.go.bak
+sed "s/\(return \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${OTELOPS_VERSION}\"/" ./exporter/metric/version.go.bak >./exporter/metric/version.go
+rm -f ./exporter/metric/version.go.bak
+
+# Update go.mod
+git checkout -b pre_release_${TAG} master
+PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep -v 'tools' | sed 's/^\.\///' | sort)
+
+for dir in $PACKAGE_DIRS; do
+	cp "${dir}/go.mod" "${dir}/go.mod.bak"
+	sed "s/GoogleCloudPlatform\/opentelemetry-operations-go\([^ ]*\) v[0-9]*\.[0-9]*\.[0-9]/GoogleCloudPlatform\/opentelemetry-operations-go\1 ${TAG}/" "${dir}/go.mod.bak" >"${dir}/go.mod"
+	rm -f "${dir}/go.mod.bak"
+done
+
+# Run lint to update go.sum
+make lint
+
+# Add changes and commit.
+git add .
+make ci
+git commit -m "Prepare for releasing $TAG"
+
+printf "Now run following to verify the changes.\ngit diff master\n"
+printf "\nThen push the changes to upstream\n"

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# Copyright 2020, Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly PROGNAME=$(basename "$0")
+readonly PROGDIR=$(readlink -m "$(dirname "$0")")
+
+readonly EXCLUDE_PACKAGES="tools"
+readonly SEMVER_REGEX="v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?"
+
+usage() {
+    cat <<- EOF
+Usage: $PROGNAME [OPTIONS] SEMVER_TAG COMMIT_HASH
+Creates git tag for all Go packages in project.
+OPTIONS:
+  -h --help        Show this help.
+ARGUMENTS:
+  SEMVER_TAG       Semantic version to tag with.
+  COMMIT_HASH      Git commit hash to tag.
+EOF
+}
+
+cmdline() {
+    local arg commit
+
+    for arg
+    do
+        local delim=""
+        case "$arg" in
+            # Translate long form options to short form.
+            --help)           args="${args}-h ";;
+            # Pass through for everything else.
+            *) [[ "${arg:0:1}" == "-" ]] || delim="\""
+                args="${args}${delim}${arg}${delim} ";;
+        esac
+    done
+
+    # Reset and process short form options.
+    eval set -- "$args"
+
+    while getopts "h" OPTION
+    do
+         case $OPTION in
+         h)
+             usage
+             exit 0
+             ;;
+         *)
+             echo "unknown option: $OPTION"
+             usage
+             exit 1
+             ;;
+        esac
+    done
+
+    # Positional arguments.
+    shift $((OPTIND-1))
+    readonly TAG="$1"
+    if [ -z "$TAG" ]
+    then
+        echo "missing SEMVER_TAG"
+        usage
+        exit 1
+    fi
+    if [[ ! "$TAG" =~ $SEMVER_REGEX ]]
+    then
+        printf "invalid semantic version: %s\n" "$TAG"
+        exit 2
+    fi
+    if [[ "$( git tag --list "$TAG" )" ]]
+    then
+        printf "tag already exists: %s\n" "$TAG"
+        exit 2
+    fi
+
+    shift
+    commit="$1"
+    if [ -z "$commit" ]
+    then
+        echo "missing COMMIT_HASH"
+        usage
+        exit 1
+    fi
+    # Verify rev is for a commit and unify hashes into a complete SHA1.
+    readonly SHA="$( git rev-parse --quiet --verify "${commit}^{commit}" )"
+    if [ -z "$SHA" ]
+    then
+        printf "invalid commit hash: %s\n" "$commit"
+        exit 2
+    fi
+    if [ "$( git merge-base "$SHA" HEAD )" != "$SHA" ]
+    then
+        printf "commit '%s' not found on this branch\n" "$commit"
+        exit 2
+    fi
+}
+
+package_dirs() {
+    # Return a list of package directories in the form:
+    #
+    #  package/directory/a
+    #  package/directory/b
+    #  deeper/package/directory/a
+    #  ...
+    #
+    # Making sure to exclude any packages in the EXCLUDE_PACKAGES regexp.
+    find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; \
+        | grep -E -v "$EXCLUDE_PACKAGES" \
+        | sed 's/^\.\///' \
+        | sort
+}
+
+git_tag() {
+    local tag="$1"
+    local commit="$2"
+
+    git tag -a "$tag" -s -m "Version $tag" "$commit"
+}
+
+previous_version() {
+    local current="$1"
+
+    # Requires git > 2.0
+    git tag -l --sort=v:refname \
+        | grep -E "^${SEMVER_REGEX}$" \
+        | grep -v "$current" \
+        | tail -1
+}
+
+print_changes() {
+    local tag="$1"
+    local previous
+
+    previous="$( previous_version "$tag" )"
+    if [ -n "$previous" ]
+    then
+        printf "\nRaw changes made between %s and %s\n" "$previous" "$tag"
+        printf "======================================\n"
+        git --no-pager log --pretty=oneline "${previous}..$tag"
+    fi
+}
+
+main() {
+    local dir
+
+    cmdline "$@"
+
+    cd "$PROGDIR" || exit 3
+
+    # Create tag for root package.
+    git_tag "$TAG" "$SHA"
+    printf "created tag: %s\n" "$TAG"
+
+    # Create tag for all sub-packages.
+    for dir in $( package_dirs )
+    do
+        git_tag "${dir}/$TAG" "$SHA"
+        printf "created tag: %s\n" "${dir}/$TAG"
+    done
+
+    print_changes "$TAG"
+}
+main "$@"

--- a/verify_examples.sh
+++ b/verify_examples.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2020, Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)
+TOOLS_DIR=$(pwd)/.tools
+
+if [ -z "${GOPATH}" ] ; then
+	printf "GOPATH is not defined.\n"
+	exit -1
+fi
+
+if [ ! -d "${GOPATH}" ] ; then
+	printf "GOPATH ${GOPATH} is invalid \n"
+	exit -1
+fi
+
+# Pre-requisites
+if ! git diff --quiet; then \
+	git status
+	printf "\n\nError: working tree is not clean\n"
+	exit -1
+fi
+
+if [ "$(git tag --contains $(git log -1 --pretty=format:"%H"))" = "" ] ; then
+	printf "$(git log -1)"
+	printf "\n\nError: HEAD is not pointing to a tagged version"
+fi
+
+make ${TOOLS_DIR}/gojq
+
+DIR_TMP="${GOPATH}/src/otelopstmp/"
+rm -rf $DIR_TMP
+mkdir -p $DIR_TMP
+
+printf "Copy examples to ${DIR_TMP}\n"
+cp -a ./example ${DIR_TMP}
+
+# Update go.mod files
+printf "Update go.mod: rename module and remove replace\n"
+
+PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep 'example' | sed 's/^\.\///' | sort)
+
+for dir in $PACKAGE_DIRS; do
+	printf "  Update go.mod for $dir\n"
+	(cd "${DIR_TMP}/${dir}" && \
+	 # replaces is ("mod1" "mod2" …)
+	 replaces=($(go mod edit -json | ${TOOLS_DIR}/gojq '.Replace[].Old.Path')) && \
+	 # strip double quotes
+	 replaces=("${replaces[@]%\"}") && \
+	 replaces=("${replaces[@]#\"}") && \
+	 # make an array (-dropreplace=mod1 -dropreplace=mod2 …)
+	 dropreplaces=("${replaces[@]/#/-dropreplace=}") && \
+	 go mod edit -module "oteltmp/${dir}" "${dropreplaces[@]}" && \
+	 go mod tidy)
+done
+printf "Update done:\n\n"
+
+# Build directories that contain main package. These directories are different than
+# directories that contain go.mod files.
+printf "Build examples:\n"
+EXAMPLES=$(./get_main_pkgs.sh ./example)
+for ex in $EXAMPLES; do
+	printf "  Build $ex in ${DIR_TMP}/${ex}\n"
+	(cd "${DIR_TMP}/${ex}" && \
+	 go build .)
+done
+
+# Cleanup
+printf "Remove copied files.\n"
+rm -rf $DIR_TMP


### PR DESCRIPTION
Issue: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/70

I brought these scripts / docs over from opentelemetry-go and made the following changes:

- Removed part of pre_release script that updated the version used in code by the OpenTelemetry SDK. We don't have any equivalent of that in this repo yet.
- Updated pre_release script to update `opentelemetry-operations-go` dependencies instead of `otel` SDK dependencies
- Removed references to updating CHANGELOG file (can add this later if needed)

Other than that it was just a few minor changes re updating directory names, etc, but for the most part the scripts were able to be brought over as is.

Left for future work:

- Add script to automate updating the Otel SDK version
- Consider automatically enforcing pinning the version of the exporter to the SDK version. On a related note, should I make the next release v0.9.0 to match the SDK?
- Consider adding a CHANGELOG file (for now the changes are just documented as release notes)

See related PR: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/79