### PR TITLE
Add pass through of status message

### DIFF
--- a/exporter/trace/cloudtrace_test.go
+++ b/exporter/trace/cloudtrace_test.go
@@ -16,11 +16,12 @@ package trace_test
 
 import (
 	"context"
-	"google.golang.org/grpc/codes"
 	"regexp"
 	"sync"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
 
 	"github.com/googleinterns/cloud-operations-api-mock/cloudmock"
 	"github.com/stretchr/testify/assert"

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -114,7 +114,10 @@ func protoFromSpanData(s *export.SpanData, projectID string, format DisplayNameF
 		sp.ParentSpanId = s.ParentSpanID.String()
 	}
 	if s.StatusCode != codes.OK {
-		sp.Status = &statuspb.Status{Code: int32(s.StatusCode)}
+		sp.Status = &statuspb.Status{Code: int32(s.StatusCode), Message: s.StatusMessage}
+	}
+	if s.StatusCode == codes.OK && s.StatusMessage != "" {
+		sp.Status = &statuspb.Status{Code: int32(s.StatusCode), Message: s.StatusMessage}
 	}
 
 	copyAttributes(&sp.Attributes, s.Attributes)


### PR DESCRIPTION
When setting the the status of a span with `span.SetStatus(codes.Unknown, "Error message")`, the error message didn't get send to the server. This PR adds the status message to the grpc request if a message is given.