### PR TITLE
Release script fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ $(TOOLS_DIR)/stringer: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_M
 	cd $(TOOLS_MOD_DIR) && \
 	go build -o $(TOOLS_DIR)/stringer golang.org/x/tools/cmd/stringer
 
+$(TOOLS_DIR)/gojq: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_MOD_DIR)/tools.go
+	cd $(TOOLS_MOD_DIR) && \
+	go build -o $(TOOLS_DIR)/gojq github.com/itchyny/gojq/cmd/gojq
+
 precommit: generate build lint test
 
 .PHONY: test-with-coverage

--- a/tag.sh
+++ b/tag.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 readonly PROGNAME=$(basename "$0")
-readonly PROGDIR=$(readlink -m "$(dirname "$0")")
+readonly PROGDIR=$(pwd)
 
 readonly EXCLUDE_PACKAGES="tools"
 readonly SEMVER_REGEX="v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?"
@@ -126,7 +126,7 @@ git_tag() {
     local tag="$1"
     local commit="$2"
 
-    git tag -a "$tag" -s -m "Version $tag" "$commit"
+    git tag -a "$tag" -m "Version $tag" "$commit"
 }
 
 previous_version() {


### PR DESCRIPTION
- Minor changes to `tag.sh` (see comments)
- Added `gojq`, needed by `verify_examples.sh`