### PR TITLE
Revised Monitoring example

### DIFF
--- a/exporter/metric/README.md
+++ b/exporter/metric/README.md
@@ -31,14 +31,7 @@ projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 opts := []mexporter.Option{
     mexporter.WithProjectID(projectID),
 }
-popts:= []push.Option{
-    push.WithResource(
-        resource.New(
-            label.String("author", "google"),
-            label.String("application", "example"),
-        ),
-    ),
-}
+popts:= []push.Option{}
 
 // Create exporter (collector embedded with the exporter).
 pusher, err := mexporter.InstallNewPipeline(opts, popts)

--- a/exporter/metric/README.md
+++ b/exporter/metric/README.md
@@ -27,10 +27,7 @@ import (
 )
 
 // Initialize exporter option.
-projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-opts := []mexporter.Option{
-    mexporter.WithProjectID(projectID),
-}
+opts := []mexporter.Option{}
 popts:= []push.Option{}
 
 // Create exporter (collector embedded with the exporter).
@@ -59,6 +56,15 @@ The Google Cloud Monitoring exporter depends upon [`google.FindDefaultCredential
 
 * A JSON file whose path is specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 * A JSON file in a location known to the gcloud command-line tool. On Windows, this is `%APPDATA%/gcloud/application_default_credentials.json`. On other systems, `$HOME/.config/gcloud/application_default_credentials.json`.
+
+When running code locally, you may need to specify a Google Project ID in addition to `GOOGLE_APPLICATION_CREDENTIALS`. This is best done using an environment variable (e.g. `GOOGLE_CLOUD_PROJECT`) and the `metric.WithProjectID` method, e.g.:
+
+```golang
+projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+opts := []mexporter.Option{
+    mexporter.WithProjectID(projectID),
+}
+```
 
 ## Useful links
 

--- a/exporter/metric/README.md
+++ b/exporter/metric/README.md
@@ -51,7 +51,7 @@ defer pusher.Stop()
 ctx := context.Background()
 meter := pusher.Provider().Meter("cloudmonitoring/example")
 
-counter := metric.Must(meter).NewInt64Counter("counter.foo")
+counter := metric.Must(meter).NewInt64Counter("counter-foo")
 labels := []label.KeyValue{
     label.Key("key").String("value"),
 }


### PR DESCRIPTION
The example in the Monitoring README is insufficient.

I believe this is a working example.

I removed the curious explanation of importing modules. In my experience (and editor), I can simply reference the imports in code and `go.mod` is revised automatically (or will be revised on `go run` or `go build`). So, I simplified this and made the imports exhaustive.

I was unable to use `popts == nil` and so have used the example `resource.New(...)` approach here too.

The Google Project ID is required if run off-cloud and so I've added it here. I noticed, after-the-fact, that the Trace README correctly specifies `WithProjectID(os.Getenv("GOOGLE_CLOUD_PROJECT"))` and so, both READMEs are now consistent. However, neither piece of documentation explains the requirement to `export GOOGLE_CLOUD_PROJECT="..."` and likely should.