### PR TITLE
Use %s to print duration

### DIFF
--- a/exporter/metric/cloudmonitoring.go
+++ b/exporter/metric/cloudmonitoring.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	errReportingIntervalTooLow = fmt.Errorf("reporting interval less than %d", minimumReportingDuration)
+	errReportingIntervalTooLow = fmt.Errorf("reporting interval less than %s", minimumReportingDuration)
 )
 
 // Exporter is the public interface of OpenTelemetry metric exporter for


### PR DESCRIPTION
%d shows duration in nanosecond which is hard to read, %s shows in human
readable way such as 1s.