### PR TITLE
Added a set function to set MonitoringClientOptions in option

### DIFF
--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -207,6 +207,13 @@ func WithTraceClientOptions(opts []option.ClientOption) func(o *options) {
 	}
 }
 
+// WithMonitoringClientOptions sets additionial client options for monitoring.
+func WithMonitoringClientOptions(opts []option.ClientOption) func(o *options) {
+	return func(o *options) {
+		o.MonitoringClientOptions = opts
+	}
+}
+
 // WithContext sets the context that trace exporter and metric exporter
 // relies on.
 func WithContext(ctx context.Context) func(o *options) {


### PR DESCRIPTION
Currently there is no need to set MonitoringClientOptions in trace exporter option.

If user wants to export to stackdriver monitoring, there is no way to pass credentials. 

So here we are!