### PR TITLE
add header-checker-lint config yaml

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,5 @@
+allowedLicenses:
+  - Apache-2.0
+sourceFileExtensions:
+  - go
+  - sh

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,17 @@
+// Copyright 2020, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build tools
 
 package tools


### PR DESCRIPTION
Check `.sh` and `.go` files. Added one missing header. There are still `Copyright 20xx, OpenTelemetry Authors` headers, which we will have to leave for now.

header-check app is now installed on this repo.