### PR TITLE
allow Google Inc copyright holder

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -3,3 +3,5 @@ allowedLicenses:
 sourceFileExtensions:
   - go
   - sh
+allowedCopyrightHolders:
+- "Google Inc"


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/141.  It doesn't doesn't seem to let me add Google Inc in the same PR as a new file, so adding a separate change here.