### PR TITLE
Remove bundler in favor of BatchSpanProcessor + to comply w/ Specification

### DIFF
--- a/example/trace/http/client/client.go
+++ b/example/trace/http/client/client.go
@@ -39,7 +39,7 @@ func initTracer() func() {
 
 	// Create Google Cloud Trace exporter to be able to retrieve
 	// the collected spans.
-	_, flush, err := texporter.InstallNewPipeline(
+	_, shutdown, err := texporter.InstallNewPipeline(
 		[]texporter.Option{texporter.WithProjectID(projectID)},
 		// For this example code we use sdktrace.AlwaysSample sampler to sample all traces.
 		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
@@ -48,12 +48,12 @@ func initTracer() func() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return flush
+	return shutdown
 }
 
 func main() {
-	flush := initTracer()
-	defer flush()
+	shutdown := initTracer()
+	defer shutdown()
 	tr := otel.Tracer("cloudtrace/example/client")
 
 	client := http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}

--- a/example/trace/http/server/server.go
+++ b/example/trace/http/server/server.go
@@ -33,7 +33,7 @@ func initTracer() func() {
 
 	// Create Google Cloud Trace exporter to be able to retrieve
 	// the collected spans.
-	_, flush, err := cloudtrace.InstallNewPipeline(
+	_, shutdown, err := cloudtrace.InstallNewPipeline(
 		[]cloudtrace.Option{cloudtrace.WithProjectID(projectID)},
 		// For this example code we use sdktrace.AlwaysSample sampler to sample all traces.
 		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
@@ -42,12 +42,12 @@ func initTracer() func() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return flush
+	return shutdown
 }
 
 func main() {
-	flush := initTracer()
-	defer flush()
+	shutdown := initTracer()
+	defer shutdown()
 
 	helloHandler := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -33,7 +33,7 @@ import (
 
 func main() {
     // Create exporter and trace provider pipeline, and register provider.
-    _, flush, err := texporter.InstallNewPipeline(
+    _, shutdown, err := texporter.InstallNewPipeline(
         []texporter.Option {
             // optional exporter options
         },
@@ -53,7 +53,7 @@ func main() {
         log.Fatalf("texporter.InstallNewPipeline: %v", err)
     }
     // before ending program, wait for all enqueued spans to be exported
-    defer flush()
+    defer shutdown()
 
     // Create custom span.
     tracer := otel.TraceProvider().Tracer("example.com/trace")
@@ -79,7 +79,7 @@ When running code locally, you may need to specify a Google Project ID in additi
 
 ```go
 projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-_, flush, err := texporter.InstallNewPipeline(
+_, shutdown, err := texporter.InstallNewPipeline(
     []texporter.Option {
         texporter.WithProjectID(projectID),
         // other optional exporter options

--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -187,7 +187,7 @@ func NewExportPipeline(opts []Option, topts ...sdktrace.TracerProviderOption) (t
 	for _, opt := range opts {
 		opt(&o)
 	}
-	exporter, err := NewExporterWithOptions(&o)
+	exporter, err := newExporterWithOptions(&o)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -205,13 +205,10 @@ func NewExporter(opts ...Option) (*Exporter, error) {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return NewExporterWithOptions(&o)
+	return newExporterWithOptions(&o)
 }
 
-// NewExporter creates a new Exporter thats implements trace.Exporter.
-// This version takes a single options struct.  This shouldn't be called
-// by user code, instead use `NewExportPipeline` or `NewExporter`.
-func NewExporterWithOptions(o *options) (*Exporter, error) {
+func newExporterWithOptions(o *options) (*Exporter, error) {
 	if o.ProjectID == "" {
 		creds, err := google.FindDefaultCredentials(o.Context, traceapi.DefaultAuthScopes()...)
 		if err != nil {

--- a/exporter/trace/cloudtrace_test.go
+++ b/exporter/trace/cloudtrace_test.go
@@ -17,11 +17,8 @@ package trace
 
 import (
 	"context"
-	"log"
 	"net"
-	"os"
 	"regexp"
-	"sync"
 	"testing"
 	"time"
 
@@ -51,8 +48,6 @@ func TestExporter_ExportSpan(t *testing.T) {
 		[]Option{
 			WithProjectID("PROJECT_ID_NOT_REAL"),
 			WithTraceClientOptions(clientOpt),
-			// handle bundle as soon as span is received
-			WithBundleCountThreshold(1),
 		},
 		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
@@ -90,7 +85,6 @@ func TestExporter_DisplayNameFormatter(t *testing.T) {
 		[]Option{
 			WithProjectID("PROJECT_ID_NOT_REAL"),
 			WithTraceClientOptions(clientOpt),
-			WithBundleCountThreshold(1),
 			WithDisplayNameFormatter(format),
 		},
 		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
@@ -116,13 +110,12 @@ func TestExporter_Timeout(t *testing.T) {
 	var exportErrors []error
 
 	// Create Google Cloud Trace Exporter
-	_, flush, err := InstallNewPipeline(
+	_, _, err := InstallNewPipeline(
 		[]Option{
 			WithProjectID("PROJECT_ID_NOT_REAL"),
 			WithTraceClientOptions(clientOpt),
 			WithTimeout(1 * time.Millisecond),
 			// handle bundle as soon as span is received
-			WithBundleCountThreshold(1),
 			WithOnError(func(err error) {
 				exportErrors = append(exportErrors, err)
 			}),
@@ -136,7 +129,6 @@ func TestExporter_Timeout(t *testing.T) {
 	assert.True(t, span.SpanContext().IsValid())
 
 	// wait for error to be handled
-	flush()
 	assert.EqualValues(t, 0, mock.GetNumSpans())
 	if got, want := len(exportErrors), 1; got != want {
 		t.Fatalf("len(exportErrors) = %q; want %q", got, want)
@@ -144,173 +136,6 @@ func TestExporter_Timeout(t *testing.T) {
 	got, want := exportErrors[0].Error(), "rpc error: code = (DeadlineExceeded|Unknown) desc = context deadline exceeded"
 	if match, _ := regexp.MatchString(want, got); !match {
 		t.Fatalf("err.Error() = %q; want %q", got, want)
-	}
-}
-
-func TestBundling(t *testing.T) {
-	mock := cloudmock.NewCloudMock()
-	defer mock.Shutdown()
-	clientOpt := []option.ClientOption{option.WithGRPCConn(mock.ClientConn())}
-
-	ch := make(chan []*tracepb.Span)
-	mock.SetOnUpload(func(ctx context.Context, spans []*tracepb.Span) {
-		ch <- spans
-	})
-
-	_, _, err := InstallNewPipeline(
-		[]Option{
-			WithProjectID("PROJECT_ID_NOT_REAL"),
-			WithTraceClientOptions(clientOpt),
-			WithBundleDelayThreshold(time.Second / 10),
-			WithBundleCountThreshold(10),
-		},
-		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-	)
-	assert.NoError(t, err)
-
-	for i := 0; i < 35; i++ {
-		_, span := otel.Tracer("test-tracer").Start(context.Background(), "test-span")
-		span.End()
-	}
-
-	// Read the first three bundles.
-	<-ch
-	<-ch
-	<-ch
-
-	// Test that the fourth bundle isn't sent early.
-	select {
-	case <-ch:
-		t.Errorf("bundle sent too early")
-	case <-time.After(time.Second / 20):
-		<-ch
-	}
-
-	// Test that there aren't extra bundles.
-	select {
-	case <-ch:
-		t.Errorf("too many bundles sent")
-	case <-time.After(time.Second / 5):
-	}
-}
-
-func TestBundling_ConcurrentExports(t *testing.T) {
-	mock := cloudmock.NewCloudMock()
-	defer mock.Shutdown()
-	clientOpt := []option.ClientOption{option.WithGRPCConn(mock.ClientConn())}
-
-	var exportMap sync.Map // maintain a collection of the spans exported
-	wg := sync.WaitGroup{}
-	mock.SetOnUpload(func(ctx context.Context, spans []*tracepb.Span) {
-		for _, s := range spans {
-			exportMap.Store(s.SpanId, true)
-		}
-		wg.Done()
-
-		// Don't complete the function until the WaitGroup is done.
-		// This ensures the semaphore limiting the concurrent uploads is not
-		// released by one goroutine completing before the other.
-		wg.Wait()
-	})
-
-	workers := 3
-	spansPerWorker := 50
-	delay := 2 * time.Second
-	_, flush, err := InstallNewPipeline(
-		[]Option{
-			WithProjectID("PROJECT_ID_NOT_REAL"),
-			WithTraceClientOptions(clientOpt),
-			WithBundleDelayThreshold(delay),
-			WithBundleCountThreshold(spansPerWorker),
-			WithMaxNumberOfWorkers(workers),
-		},
-		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-	)
-	assert.NoError(t, err)
-
-	waitCh := make(chan struct{})
-	wg.Add(workers)
-
-	totalSpans := workers * spansPerWorker
-	var expectedSpanIDs []string
-	go func() {
-		// Release enough spans to form two bundles
-		for i := 0; i < totalSpans; i++ {
-			_, span := otel.Tracer("test-tracer").Start(context.Background(), "test-span")
-			expectedSpanIDs = append(expectedSpanIDs, span.SpanContext().SpanID.String())
-			span.End()
-		}
-
-		// Wait for the desired concurrency before completing
-		wg.Wait()
-		close(waitCh)
-	}()
-
-	select {
-	case <-waitCh:
-	case <-time.After(delay / 2): // fail before a time-based flush is triggered
-		t.Fatal("timed out waiting for concurrent uploads")
-	}
-
-	// all the spans are accounted for
-	var exportedSpans []string
-	exportMap.Range(func(key, value interface{}) bool {
-		exportedSpans = append(exportedSpans, key.(string))
-		return true
-	})
-	if len(exportedSpans) != totalSpans {
-		t.Errorf("got %d spans, want %d", len(exportedSpans), totalSpans)
-	}
-	for _, id := range expectedSpanIDs {
-		if _, ok := exportMap.Load(id); !ok {
-			t.Errorf("want %s; missing from exported spans", id)
-		}
-	}
-
-	flush()
-}
-
-func TestBundling_Oversized(t *testing.T) {
-	mock := cloudmock.NewCloudMock()
-	defer mock.Shutdown()
-	clientOpt := []option.ClientOption{option.WithGRPCConn(mock.ClientConn())}
-
-	var uploaded bool
-	mock.SetOnUpload(func(ctx context.Context, spans []*tracepb.Span) { uploaded = true })
-
-	exp, err := NewExporter(
-		WithProjectID("PROJECT_ID_NOT_REAL"),
-		WithTraceClientOptions(clientOpt),
-		WithBundleByteLimit(1),
-	)
-	assert.NoError(t, err)
-	exp.traceExporter.overflowLogger.delayDur = 100 * time.Millisecond
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		sdktrace.WithSyncer(exp),
-	)
-	otel.SetTracerProvider(tp)
-
-	buf := &logBuffer{logInputChan: make(chan []byte, 100)}
-	log.SetOutput(buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	go func() {
-		for i := 0; i < 10; i++ {
-			_, span := otel.Tracer("test-tracer").Start(context.Background(), "test-span")
-			span.SetName("a")
-			span.End()
-		}
-	}()
-
-	if got, want := <-buf.logInputChan, regexp.MustCompile(`OpenTelemetry Cloud Trace exporter: failed to upload spans: oversized item: 10`); !want.Match([]byte(got)) {
-		t.Errorf("log: got %s, want %s", got, want)
-	}
-	if got, want := uploaded, false; got != want {
-		t.Errorf("uploaded: got %v, want %v", got, want)
 	}
 }
 
@@ -366,8 +191,6 @@ func TestExporter_ExportWithUserAgent(t *testing.T) {
 		[]Option{
 			WithProjectID("PROJECT_ID_NOT_REAL"),
 			WithTraceClientOptions(clientOpt),
-			// handle bundle as soon as span is received
-			WithBundleCountThreshold(1),
 		},
 		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -79,6 +79,11 @@ func (e *traceExporter) ConvertSpan(_ context.Context, sd *export.SpanSnapshot) 
 	return protoFromSpanSnapshot(sd, e.projectID, e.o.DisplayNameFormatter)
 }
 
+func (e *traceExporter) Shutdown(ctx context.Context) error {
+	// return e.client.Close()
+	return nil
+}
+
 // uploadSpans sends a set of spans to Stackdriver.
 func (e *traceExporter) uploadSpans(ctx context.Context, spans []*tracepb.Span) error {
 	req := tracepb.BatchWriteSpansRequest{

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -80,8 +80,7 @@ func (e *traceExporter) ConvertSpan(_ context.Context, sd *export.SpanSnapshot) 
 }
 
 func (e *traceExporter) Shutdown(ctx context.Context) error {
-	// return e.client.Close()
-	return nil
+	return e.client.Close()
 }
 
 // uploadSpans sends a set of spans to Stackdriver.

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/support/bundler"
 	tracepb "google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
-	"google.golang.org/protobuf/proto"
 )
 
 // traceExporter is an implementation of trace.Exporter and trace.BatchExporter
@@ -39,7 +38,7 @@ type traceExporter struct {
 	projectID string
 	bundler   *bundler.Bundler
 	// uploadFn defaults in uploadSpans; it can be replaced for tests.
-	uploadFn func(ctx context.Context, spans []*tracepb.Span)
+	uploadFn func(ctx context.Context, spans []*tracepb.Span) error
 	overflowLogger
 	client *traceclient.Client
 }
@@ -62,72 +61,26 @@ func newTraceExporter(o *options) (*traceExporter, error) {
 		o:              o,
 		overflowLogger: overflowLogger{delayDur: 5 * time.Second},
 	}
-	b := bundler.NewBundler((*tracepb.Span)(nil), func(bundle interface{}) {
-		e.uploadFn(context.Background(), bundle.([]*tracepb.Span))
-	})
-
-	if o.BundleDelayThreshold > 0 {
-		b.DelayThreshold = o.BundleDelayThreshold
-	} else {
-		b.DelayThreshold = defaultBundleDelayThreshold
-	}
-
-	if o.BundleCountThreshold > 0 {
-		b.BundleCountThreshold = o.BundleCountThreshold
-	} else {
-		b.BundleCountThreshold = defaultBundleCountThreshold
-	}
-
-	if o.BundleByteThreshold > 0 {
-		b.BundleByteThreshold = o.BundleByteThreshold
-	} else {
-		b.BundleByteThreshold = defaultBundleByteThreshold
-	}
-
-	if o.BundleByteLimit > 0 {
-		b.BundleByteLimit = o.BundleByteLimit
-	} else {
-		b.BundleByteLimit = defaultBundleByteLimit
-	}
-
-	if o.BufferMaxBytes > 0 {
-		b.BufferedByteLimit = o.BufferMaxBytes
-	} else {
-		b.BufferedByteLimit = defaultBufferedByteLimit
-	}
-
-	if o.MaxNumberOfWorkers > 0 {
-		b.HandlerLimit = o.MaxNumberOfWorkers
-	}
-
-	e.bundler = b
 	e.uploadFn = e.uploadSpans
 	return e, nil
 }
 
-func (e *traceExporter) checkBundlerError(err error) {
-	switch err {
-	case nil:
-		return
-	case bundler.ErrOversizedItem:
-		e.overflowLogger.log(true)
-	case bundler.ErrOverflow:
-		e.overflowLogger.log(false)
-	default:
-		e.o.handleError(err)
+func (e *traceExporter) ExportSpans(ctx context.Context, spanData []*export.SpanSnapshot) error {
+	// Ship the whole bundle o data.
+	results := make([]*tracepb.Span, len(spanData))
+	for i, sd := range spanData {
+		results[i] = e.ConvertSpan(ctx, sd)
 	}
+	return e.uploadFn(ctx, results)
 }
 
 // ExportSpan exports a SpanSnapshot to Stackdriver Trace.
-func (e *traceExporter) ExportSpan(_ context.Context, sd *export.SpanSnapshot) {
-	protoSpan := protoFromSpanSnapshot(sd, e.projectID, e.o.DisplayNameFormatter)
-	protoSize := proto.Size(protoSpan)
-	err := e.bundler.Add(protoSpan, protoSize)
-	e.checkBundlerError(err)
+func (e *traceExporter) ConvertSpan(_ context.Context, sd *export.SpanSnapshot) *tracepb.Span {
+	return protoFromSpanSnapshot(sd, e.projectID, e.o.DisplayNameFormatter)
 }
 
 // uploadSpans sends a set of spans to Stackdriver.
-func (e *traceExporter) uploadSpans(ctx context.Context, spans []*tracepb.Span) {
+func (e *traceExporter) uploadSpans(ctx context.Context, spans []*tracepb.Span) error {
 	req := tracepb.BatchWriteSpansRequest{
 		Name:  "projects/" + e.projectID,
 		Spans: spans,
@@ -154,10 +107,7 @@ func (e *traceExporter) uploadSpans(ctx context.Context, spans []*tracepb.Span) 
 		// span.SetStatus(codes.Unknown)
 		e.o.handleError(err)
 	}
-}
-
-func (e *traceExporter) Flush() {
-	e.bundler.Flush()
+	return err
 }
 
 // overflowLogger ensures that at most one overflow error log message is


### PR DESCRIPTION
Fixes #100 

- Remove bundler and associated config/tests
- Remove metrics-options from trace-exporter config
- Update returned `flush` method from "pipeline" generation for `shutdown` method (only exposed sdk method in 1.0 spec)
- Add configuration for batch processor to Exporter-Pipeline helper method
- Update examples to denote `flush`=>`shutdown` semantic change
