### PR TITLE
Prepare for releasing v0.17.0

### DIFF
--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric => ../../exporter/metric
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.16.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.17.0
 	go.opentelemetry.io/otel v0.16.0
 	go.opentelemetry.io/otel/sdk v0.16.0
 )

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace => ../../../exporter/trace
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.16.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.17.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.17.0
 	go.opentelemetry.io/otel v0.17.0

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.16.0"
+	return "0.17.0"
 }

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "0.16.0"
+	return "0.17.0"
 }


### PR DESCRIPTION
### Breaking changes
* Remove exporter-side bundling of traces and remove unused configuration parameters (#149, fixes #100)

### New features
* Set `User-Agent` header correctly on requests to GCP APIs (#148)

### Bugfixes
* Map OTel span status codes correctly to Google Cloud Trace API status codes (#150, fixes #143)

### Miscellaneous
* Better verification of example code stored outside this repo (#140)
* Better verification of copyright headers (#139)
