### PR TITLE
Prepare for releasing v0.19.0

### DIFF
--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric => ../../exporter/metric
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.18.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.19.0
 	go.opentelemetry.io/otel v0.19.0
 	go.opentelemetry.io/otel/metric v0.19.0
 	go.opentelemetry.io/otel/sdk v0.19.0

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace => ../../../exporter/trace
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.18.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.19.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.19.0
 	go.opentelemetry.io/otel v0.19.0

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.18.0"
+	return "0.19.0"
 }

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "0.18.0"
+	return "0.19.0"
 }


### PR DESCRIPTION
Fixes #157.

---

Draft release notes

### New features

* When exported to Google Cloud Trace, spans are named `<name>` instead of `Span.<kind>.<name>`, which aligns with exporters in other languages (#109, #151, #155)
* Compatible with version 0.19.0 of opentelemetry-go (#158)
