### PR TITLE
Add ability to set the default trace attributes

### DIFF
--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -263,7 +263,7 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 }
 
 func createKeyValueAttributes(attr map[string]interface{}) []attribute.KeyValue {
-	kv := make([]attribute.KeyValue, len(attr))
+	kv := make([]attribute.KeyValue, 0, len(attr))
 
 	for k, v := range attr {
 		switch val := v.(type) {

--- a/exporter/trace/cloudtrace_test.go
+++ b/exporter/trace/cloudtrace_test.go
@@ -48,6 +48,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		[]Option{
 			WithProjectID("PROJECT_ID_NOT_REAL"),
 			WithTraceClientOptions(clientOpt),
+			WithDefaultTraceAttributes(map[string]interface{}{"TEST_ATTRIBUTE": "TEST_VALUE"}),
 		},
 		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 	)
@@ -72,6 +73,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 	assert.EqualValues(t, "", mock.GetSpan(0).GetStatus().Message)
 	assert.EqualValues(t, codepb.Code_UNKNOWN, mock.GetSpan(1).GetStatus().Code)
 	assert.EqualValues(t, "Error Message", mock.GetSpan(1).GetStatus().Message)
+	assert.EqualValues(t, "TEST_VALUE", mock.GetSpan(0).Attributes.AttributeMap["TEST_ATTRIBUTE"].GetStringValue().Value)
 }
 
 func TestExporter_DisplayNameNoFormatter(t *testing.T) {


### PR DESCRIPTION
Fix [#156](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/156)

This adds the missing WithDefaultTraceAttributes option.