### PR TITLE
Don't export timeSeries if there are no records in cps

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -267,6 +267,10 @@ func (me *metricExporter) exportTimeSeries(ctx context.Context, cps export.Check
 		return nil
 	})
 
+	if len(tss) == 0 {
+		return nil
+	}
+
 	if aggError != nil {
 		if me.o.onError != nil {
 			me.o.onError(aggError)


### PR DESCRIPTION
Added a check to ensure there are records in the cps when exporting, otherwise return and don't export. 

Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/166 that caused the error `rpc error: code = InvalidArgument desc = Request was missing field timeSeries.` everytime metrics were exported but no values were added to the metricExporter.