### PR TITLE
 e2e-test-server to EXCLUDED_PACKAGES in tag.sh

### DIFF
--- a/example/metric/create_dashboard.sh
+++ b/example/metric/create_dashboard.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-# Copyright 2020, Google Inc.
+#!/usr/bin/env bash
+
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/get_main_pkgs.sh
+++ b/get_main_pkgs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020, Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2020, Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tag.sh
+++ b/tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020, Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 readonly PROGNAME=$(basename "$0")
 readonly PROGDIR=$(pwd)
 
-readonly EXCLUDE_PACKAGES="tools"
+readonly EXCLUDE_PACKAGES="tools|e2e-test-server"
 readonly SEMVER_REGEX="v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?"
 
 usage() {

--- a/verify_examples.sh
+++ b/verify_examples.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020, Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Don't bother making a tag for e2e-test-server as it's not intended to be used as a library.

Also fix the licenses that don't pass CI.