### PR TITLE
Add SpanContextFromRequest

### DIFF
--- a/propagator/propagator.go
+++ b/propagator/propagator.go
@@ -55,6 +55,7 @@ func (p CloudTraceFormatPropagator) getHeaderValue(carrier propagation.TextMapCa
 }
 
 // Inject injects a context to the carrier following Google Cloud Trace format.
+// In this method, SpanID is expected to be stored in big endian.
 func (p CloudTraceFormatPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
 	span := trace.SpanFromContext(ctx)
 	sc := span.SpanContext()
@@ -78,6 +79,7 @@ func (p CloudTraceFormatPropagator) Inject(ctx context.Context, carrier propagat
 }
 
 // Extract extacts a context from the carrier if the header contains Google Cloud Trace header format.
+// In this method, SpanID in carrier is decimal, and it is converted to trace.SpanID in big endian.
 func (p CloudTraceFormatPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
 	header := p.getHeaderValue(carrier)
 	if header == "" {


### PR DESCRIPTION
Fixes #116. Merge this after merging #203.

* Extrace spanContextFromHeader out of Extrace and use it as common logic for Extract and SpanContextFromReqeust
* Change return type of `New()` from `propagation.TextMapPropagator` to `CloudTraceFormatPropagator` so that the caller call `SpanContextFromRequest` without type casting
* Fixes a bug where TraceFlags is not properly set when `;o=TRACE_TRUE` part is not set.