### PR TITLE
Add support for non-string metric labels

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -498,7 +498,7 @@ func (me *metricExporter) recordToMpb(r *export.Record, library instrumentation.
 	iter := r.Labels().Iter()
 	for iter.Next() {
 		kv := iter.Label()
-		labels[normalizeLabelKey(string(kv.Key))] = kv.Value.AsString()
+		labels[normalizeLabelKey(string(kv.Key))] = kv.Value.Emit()
 	}
 
 	return &googlemetricpb.Metric{


### PR DESCRIPTION
This is a follow-up to #217 which added support for monitored resource labels. In this PR we add support for metric labels.

Context: #218 