### PR TITLE
Add ops-agent metric tests to integration tests for the exporter.

### DIFF
--- a/exporter/collector/internal/integrationtest/testcases.go
+++ b/exporter/collector/internal/integrationtest/testcases.go
@@ -26,5 +26,15 @@ var (
 			OTLPInputFixturePath: "testdata/fixtures/nonmonotonic_counter_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/nonmonotonic_counter_metrics_expect.json",
 		},
+		{
+			Name:                 "Ops Agent Self-Reported metrics",
+			OTLPInputFixturePath: "testdata/fixtures/ops_agent_self_metrics.json",
+			ExpectFixturePath:    "testdata/fixtures/ops_agent_self_metrics_expect.json",
+		},
+		{
+			Name:                 "Ops Agent Host Metrics",
+			OTLPInputFixturePath: "testdata/fixtures/ops_agent_host_metrics.json",
+			ExpectFixturePath:    "testdata/fixtures/ops_agent_host_metrics_expect.json",
+		},
 	}
 )

--- a/exporter/collector/testdata/fixtures/ops_agent_host_metrics.json
+++ b/exporter/collector/testdata/fixtures/ops_agent_host_metrics.json
@@ -1,0 +1,2808 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/swap/bytes_used",
+                            "description": "Swap (unix) or pagefile (windows) usage.",
+                            "unit": "By",
+                            "gauge": {}
+                        },
+                        {
+                            "name": "agent.googleapis.com/swap/io",
+                            "description": "The number of paging operations.",
+                            "unit": "{operations}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "in"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094996967601",
+                                        "asInt": "3652190208"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "out"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094996967601",
+                                        "asInt": "33672253440"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/processes/cpu_time",
+                            "description": "Total CPU seconds broken down by different states.",
+                            "unit": "s",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "systemd"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "/lib/systemd/systemd --user"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "578"
+                                                }
+                                            },
+                                            {
+                                                "key": "user_or_syst",
+                                                "value": {
+                                                    "stringValue": "user"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025763774",
+                                        "asInt": "40000"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "systemd"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "/lib/systemd/systemd --user"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "578"
+                                                }
+                                            },
+                                            {
+                                                "key": "user_or_syst",
+                                                "value": {
+                                                    "stringValue": "syst"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025763774",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "-bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "595"
+                                                }
+                                            },
+                                            {
+                                                "key": "user_or_syst",
+                                                "value": {
+                                                    "stringValue": "user"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025926785",
+                                        "asInt": "80000"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "-bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "595"
+                                                }
+                                            },
+                                            {
+                                                "key": "user_or_syst",
+                                                "value": {
+                                                    "stringValue": "syst"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025926785",
+                                        "asInt": "120000"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "google-cloud-metrics-agent"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "./bin/google-cloud-metrics-agent --config=otel-col.yml"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "2725"
+                                                }
+                                            },
+                                            {
+                                                "key": "user_or_syst",
+                                                "value": {
+                                                    "stringValue": "user"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026092573",
+                                        "asInt": "100000"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "google-cloud-metrics-agent"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "./bin/google-cloud-metrics-agent --config=otel-col.yml"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "2725"
+                                                }
+                                            },
+                                            {
+                                                "key": "user_or_syst",
+                                                "value": {
+                                                    "stringValue": "syst"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026092573",
+                                        "asInt": "30000"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/processes/rss_usage",
+                            "description": "The amount of physical memory in use.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "systemd"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "/lib/systemd/systemd --user"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "578"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095025763774",
+                                        "asDouble": 5431296
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "-bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "595"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095025926785",
+                                        "asDouble": 6938624
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "google-cloud-metrics-agent"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "./bin/google-cloud-metrics-agent --config=otel-col.yml"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "2725"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026092573",
+                                        "asDouble": 73625600
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/processes/vm_usage",
+                            "description": "Virtual memory size.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "systemd"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "/lib/systemd/systemd --user"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "578"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095025763774",
+                                        "asDouble": 21528576
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "-bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "595"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095025926785",
+                                        "asDouble": 30916608
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "google-cloud-metrics-agent"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "./bin/google-cloud-metrics-agent --config=otel-col.yml"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "2725"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026092573",
+                                        "asDouble": 1355685888
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/processes/disk/read_bytes_count",
+                            "description": "Disk bytes transferred.",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "systemd"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "/lib/systemd/systemd --user"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "578"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025763774",
+                                        "asInt": "1073152"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "-bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "595"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025926785",
+                                        "asInt": "766906368"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "google-cloud-metrics-agent"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "./bin/google-cloud-metrics-agent --config=otel-col.yml"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "2725"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026092573",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/processes/disk/write_bytes_count",
+                            "description": "Disk bytes transferred.",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "systemd"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "/lib/systemd/systemd --user"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "578"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025763774",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "-bash"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "595"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095025926785",
+                                        "asInt": "7915782144"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "command",
+                                                "value": {
+                                                    "stringValue": "google-cloud-metrics-agent"
+                                                }
+                                            },
+                                            {
+                                                "key": "command_line",
+                                                "value": {
+                                                    "stringValue": "./bin/google-cloud-metrics-agent --config=otel-col.yml"
+                                                }
+                                            },
+                                            {
+                                                "key": "owner",
+                                                "value": {
+                                                    "stringValue": "joshuasuereth_google_com"
+                                                }
+                                            },
+                                            {
+                                                "key": "pid",
+                                                "value": {
+                                                    "stringValue": "2725"
+                                                }
+                                            },
+                                            {
+                                                "key": "process",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026092573",
+                                        "asInt": "4096"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/swap/percent_used",
+                            "description": "Swap (unix) or pagefile (windows) usage.",
+                            "unit": "By",
+                            "gauge": {}
+                        },
+                        {
+                            "name": "agent.googleapis.com/pagefile/percent_used",
+                            "description": "Swap (unix) or pagefile (windows) usage.",
+                            "unit": "By",
+                            "gauge": {}
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/memory/bytes_used",
+                            "description": "Bytes of memory in use.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "slab"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 177328128
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "used"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 166518784
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "free"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 2614779904
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "buffered"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 148340736
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "cached"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 1208135680
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/memory/percent_used",
+                            "description": "Bytes of memory in use.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "slab"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 4.10947591438758
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "used"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 3.858975673284657
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "free"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 60.59599883055591
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "buffered"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 3.437710015833058
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "cached"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997138400",
+                                        "asDouble": 27.997839565938804
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/cpu/load_1m",
+                            "description": "Average CPU Load over 1 minute.",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": "1636147094997219538",
+                                        "asDouble": 0.01
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/cpu/load_5m",
+                            "description": "Average CPU Load over 5 minutes.",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": "1636147094997219538",
+                                        "asDouble": 0.07
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/cpu/load_15m",
+                            "description": "Average CPU Load over 15 minutes.",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": "1636147094997219538",
+                                        "asDouble": 0.21
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/disk/read_bytes_count",
+                            "description": "Disk bytes transferred.",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "913047552"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "886438912"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "163840"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "2281984"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/operation_count",
+                            "description": "Disk operations count.",
+                            "unit": "{operations}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "40"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "343"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "40273"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "116910"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "38979"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "92252"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/io_time",
+                            "description": "Time disk spent activated. On Windows, this is calculated as the inverse of disk idle time.",
+                            "unit": "s",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "6065204"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "164692"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "12"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "36"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/pending_operations",
+                            "description": "The queue size of pending I/O operations.",
+                            "unit": "{operations}",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asDouble": 0
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/weighted_io_time",
+                            "description": "Time disk spent activated multiplied by the queue length.",
+                            "unit": "s",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "4893248"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "12"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "1156"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "10807004"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/merged_operations",
+                            "description": "The number of disk reads merged into single physical disk access operations.",
+                            "unit": "{operations}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "276190"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "276174"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "read"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "write"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/write_bytes_count",
+                            "description": "Disk bytes transferred.",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "8594224640"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda1"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "8594138112"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda14"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "sda15"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147094997264291",
+                                        "asInt": "512"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/cpu/utilization",
+                            "description": "Total CPU seconds broken down by different states.",
+                            "unit": "s",
+                            "gauge": {}
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/interface/packets",
+                            "description": "The number of packets transferred.",
+                            "unit": "{packets}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "lo"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "tx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "37"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "lo"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "rx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "37"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "ens4"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "tx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "179493"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "ens4"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "rx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "329601"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/interface/errors",
+                            "description": "The number of errors encountered.",
+                            "unit": "{errors}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "lo"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "tx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "lo"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "rx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "ens4"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "tx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "ens4"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "rx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/interface/traffic",
+                            "description": "The number of bytes transmitted and received.",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "lo"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "tx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "5253"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "lo"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "rx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "5253"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "ens4"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "tx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "16550487"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "ens4"
+                                                }
+                                            },
+                                            {
+                                                "key": "direction",
+                                                "value": {
+                                                    "stringValue": "rx"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095026571005",
+                                        "asInt": "3075430661"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/network/tcp_connections",
+                            "description": "The number of connections.",
+                            "unit": "{connections}",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "SYN_RECV"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "CLOSE"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "FIN_WAIT_1"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "LAST_ACK"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "TIME_WAIT"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "CLOSE_WAIT"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "FIN_WAIT_2"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "LISTEN"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 3
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "SYN_SENT"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "CLOSING"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "DELETE"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "tcp_state",
+                                                "value": {
+                                                    "stringValue": "ESTABLISHED"
+                                                }
+                                            },
+                                            {
+                                                "key": "port",
+                                                "value": {
+                                                    "stringValue": "all"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095026726306",
+                                        "asDouble": 7
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/disk/bytes_used",
+                            "description": "Filesystem bytes used.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "used"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 8255782912
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "free"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 11705372672
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "reserved"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 976375808
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "used"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 5904384
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "free"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 123846656
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "reserved"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 0
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/disk/percent_used",
+                            "description": "Filesystem bytes used.",
+                            "unit": "By",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "used"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 4.5505484965669645
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "free"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 95.44945150343304
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda15"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "reserved"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 0
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "used"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 39.43054583385338
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "free"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 55.90617371669945
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "device",
+                                                "value": {
+                                                    "stringValue": "/dev/sda1"
+                                                }
+                                            },
+                                            {
+                                                "key": "state",
+                                                "value": {
+                                                    "stringValue": "reserved"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": "1636147095029224045",
+                                        "asDouble": 4.6632804494471705
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "josh-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884797"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/542671417255/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/processes/fork_count",
+                            "description": "Total number of created processes.",
+                            "unit": "{processes}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1636141022000000000",
+                                        "timeUnixNano": "1636147095029632456",
+                                        "asInt": "35156"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        }
+    ]
+}

--- a/exporter/collector/testdata/fixtures/ops_agent_host_metrics_expect.json
+++ b/exporter/collector/testdata/fixtures/ops_agent_host_metrics_expect.json
@@ -1,0 +1,3047 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "agent.googleapis.com/swap/io",
+            "labels": {
+              "direction": "in"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "3652190208"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/swap/io",
+            "labels": {
+              "direction": "out"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "33672253440"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/cpu_time",
+            "labels": {
+              "command": "systemd",
+              "command_line": "/lib/systemd/systemd --user",
+              "owner": "joshuasuereth_google_com",
+              "pid": "578",
+              "process": "all",
+              "user_or_syst": "user"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "40000"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/cpu_time",
+            "labels": {
+              "command": "systemd",
+              "command_line": "/lib/systemd/systemd --user",
+              "owner": "joshuasuereth_google_com",
+              "pid": "578",
+              "process": "all",
+              "user_or_syst": "syst"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/cpu_time",
+            "labels": {
+              "command": "bash",
+              "command_line": "-bash",
+              "owner": "joshuasuereth_google_com",
+              "pid": "595",
+              "process": "all",
+              "user_or_syst": "user"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "80000"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/cpu_time",
+            "labels": {
+              "command": "bash",
+              "command_line": "-bash",
+              "owner": "joshuasuereth_google_com",
+              "pid": "595",
+              "process": "all",
+              "user_or_syst": "syst"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "120000"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/cpu_time",
+            "labels": {
+              "command": "google-cloud-metrics-agent",
+              "command_line": "./bin/google-cloud-metrics-agent --config=otel-col.yml",
+              "owner": "joshuasuereth_google_com",
+              "pid": "2725",
+              "process": "all",
+              "user_or_syst": "user"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "100000"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/cpu_time",
+            "labels": {
+              "command": "google-cloud-metrics-agent",
+              "command_line": "./bin/google-cloud-metrics-agent --config=otel-col.yml",
+              "owner": "joshuasuereth_google_com",
+              "pid": "2725",
+              "process": "all",
+              "user_or_syst": "syst"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "30000"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/rss_usage",
+            "labels": {
+              "command": "systemd",
+              "command_line": "/lib/systemd/systemd --user",
+              "owner": "joshuasuereth_google_com",
+              "pid": "578",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 5431296
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/rss_usage",
+            "labels": {
+              "command": "bash",
+              "command_line": "-bash",
+              "owner": "joshuasuereth_google_com",
+              "pid": "595",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 6938624
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/rss_usage",
+            "labels": {
+              "command": "google-cloud-metrics-agent",
+              "command_line": "./bin/google-cloud-metrics-agent --config=otel-col.yml",
+              "owner": "joshuasuereth_google_com",
+              "pid": "2725",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 73625600
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/vm_usage",
+            "labels": {
+              "command": "systemd",
+              "command_line": "/lib/systemd/systemd --user",
+              "owner": "joshuasuereth_google_com",
+              "pid": "578",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 21528576
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/vm_usage",
+            "labels": {
+              "command": "bash",
+              "command_line": "-bash",
+              "owner": "joshuasuereth_google_com",
+              "pid": "595",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 30916608
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/vm_usage",
+            "labels": {
+              "command": "google-cloud-metrics-agent",
+              "command_line": "./bin/google-cloud-metrics-agent --config=otel-col.yml",
+              "owner": "joshuasuereth_google_com",
+              "pid": "2725",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1355685888
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/disk/read_bytes_count",
+            "labels": {
+              "command": "systemd",
+              "command_line": "/lib/systemd/systemd --user",
+              "owner": "joshuasuereth_google_com",
+              "pid": "578",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1073152"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/disk/read_bytes_count",
+            "labels": {
+              "command": "bash",
+              "command_line": "-bash",
+              "owner": "joshuasuereth_google_com",
+              "pid": "595",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "766906368"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/disk/read_bytes_count",
+            "labels": {
+              "command": "google-cloud-metrics-agent",
+              "command_line": "./bin/google-cloud-metrics-agent --config=otel-col.yml",
+              "owner": "joshuasuereth_google_com",
+              "pid": "2725",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/disk/write_bytes_count",
+            "labels": {
+              "command": "systemd",
+              "command_line": "/lib/systemd/systemd --user",
+              "owner": "joshuasuereth_google_com",
+              "pid": "578",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/disk/write_bytes_count",
+            "labels": {
+              "command": "bash",
+              "command_line": "-bash",
+              "owner": "joshuasuereth_google_com",
+              "pid": "595",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "7915782144"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/disk/write_bytes_count",
+            "labels": {
+              "command": "google-cloud-metrics-agent",
+              "command_line": "./bin/google-cloud-metrics-agent --config=otel-col.yml",
+              "owner": "joshuasuereth_google_com",
+              "pid": "2725",
+              "process": "all"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "4096"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/bytes_used",
+            "labels": {
+              "state": "slab"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 177328128
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/bytes_used",
+            "labels": {
+              "state": "used"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 166518784
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/bytes_used",
+            "labels": {
+              "state": "free"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 2614779904
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/bytes_used",
+            "labels": {
+              "state": "buffered"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 148340736
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/bytes_used",
+            "labels": {
+              "state": "cached"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1208135680
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/percent_used",
+            "labels": {
+              "state": "slab"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 4.10947591438758
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/percent_used",
+            "labels": {
+              "state": "used"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 3.858975673284657
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/percent_used",
+            "labels": {
+              "state": "free"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 60.59599883055591
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/percent_used",
+            "labels": {
+              "state": "buffered"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 3.437710015833058
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/memory/percent_used",
+            "labels": {
+              "state": "cached"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 27.997839565938804
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/cpu/load_1m"
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.01
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/cpu/load_5m"
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.07
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/cpu/load_15m"
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.21
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/read_bytes_count",
+            "labels": {
+              "device": "sda"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "913047552"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/read_bytes_count",
+            "labels": {
+              "device": "sda1"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "886438912"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/read_bytes_count",
+            "labels": {
+              "device": "sda14"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "163840"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/read_bytes_count",
+            "labels": {
+              "device": "sda15"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "2281984"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda14",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "40"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda14",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda15",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "343"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda15",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "40273"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "116910"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda1",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "38979"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/operation_count",
+            "labels": {
+              "device": "sda1",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "92252"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/io_time",
+            "labels": {
+              "device": "sda"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "6065204"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/io_time",
+            "labels": {
+              "device": "sda1"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "164692"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/io_time",
+            "labels": {
+              "device": "sda14"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "12"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/io_time",
+            "labels": {
+              "device": "sda15"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "36"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/pending_operations",
+            "labels": {
+              "device": "sda15"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/pending_operations",
+            "labels": {
+              "device": "sda"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/pending_operations",
+            "labels": {
+              "device": "sda1"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/pending_operations",
+            "labels": {
+              "device": "sda14"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/weighted_io_time",
+            "labels": {
+              "device": "sda1"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "4893248"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/weighted_io_time",
+            "labels": {
+              "device": "sda14"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "12"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/weighted_io_time",
+            "labels": {
+              "device": "sda15"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1156"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/weighted_io_time",
+            "labels": {
+              "device": "sda"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "10807004"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "276190"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda1",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda1",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "276174"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda14",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda14",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda15",
+              "direction": "read"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/merged_operations",
+            "labels": {
+              "device": "sda15",
+              "direction": "write"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/write_bytes_count",
+            "labels": {
+              "device": "sda"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "8594224640"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/write_bytes_count",
+            "labels": {
+              "device": "sda1"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "8594138112"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/write_bytes_count",
+            "labels": {
+              "device": "sda14"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/write_bytes_count",
+            "labels": {
+              "device": "sda15"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "512"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/packets",
+            "labels": {
+              "device": "lo",
+              "direction": "tx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "37"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/packets",
+            "labels": {
+              "device": "lo",
+              "direction": "rx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "37"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/packets",
+            "labels": {
+              "device": "ens4",
+              "direction": "tx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "179493"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/packets",
+            "labels": {
+              "device": "ens4",
+              "direction": "rx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "329601"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/errors",
+            "labels": {
+              "device": "lo",
+              "direction": "tx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/errors",
+            "labels": {
+              "device": "lo",
+              "direction": "rx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/errors",
+            "labels": {
+              "device": "ens4",
+              "direction": "tx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/errors",
+            "labels": {
+              "device": "ens4",
+              "direction": "rx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "0"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/traffic",
+            "labels": {
+              "device": "lo",
+              "direction": "tx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "5253"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/traffic",
+            "labels": {
+              "device": "lo",
+              "direction": "rx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "5253"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/traffic",
+            "labels": {
+              "device": "ens4",
+              "direction": "tx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "16550487"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/interface/traffic",
+            "labels": {
+              "device": "ens4",
+              "direction": "rx"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "3075430661"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "SYN_RECV"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "CLOSE"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "FIN_WAIT_1"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "LAST_ACK"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "TIME_WAIT"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "CLOSE_WAIT"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "FIN_WAIT_2"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "LISTEN"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 3
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "SYN_SENT"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "CLOSING"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "DELETE"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/network/tcp_connections",
+            "labels": {
+              "port": "all",
+              "tcp_state": "ESTABLISHED"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 7
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/bytes_used",
+            "labels": {
+              "device": "/dev/sda1",
+              "state": "used"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 8255782912
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/bytes_used",
+            "labels": {
+              "device": "/dev/sda1",
+              "state": "free"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 11705372672
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/bytes_used",
+            "labels": {
+              "device": "/dev/sda1",
+              "state": "reserved"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 976375808
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/bytes_used",
+            "labels": {
+              "device": "/dev/sda15",
+              "state": "used"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 5904384
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/bytes_used",
+            "labels": {
+              "device": "/dev/sda15",
+              "state": "free"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 123846656
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/bytes_used",
+            "labels": {
+              "device": "/dev/sda15",
+              "state": "reserved"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/percent_used",
+            "labels": {
+              "device": "/dev/sda15",
+              "state": "used"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 4.5505484965669645
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/percent_used",
+            "labels": {
+              "device": "/dev/sda15",
+              "state": "free"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 95.44945150343304
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/percent_used",
+            "labels": {
+              "device": "/dev/sda15",
+              "state": "reserved"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/percent_used",
+            "labels": {
+              "device": "/dev/sda1",
+              "state": "used"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 39.43054583385338
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/percent_used",
+            "labels": {
+              "device": "/dev/sda1",
+              "state": "free"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 55.90617371669945
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/disk/percent_used",
+            "labels": {
+              "device": "/dev/sda1",
+              "state": "reserved"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 4.6632804494471705
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/processes/fork_count"
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884797",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "35156"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/exporter/collector/testdata/fixtures/ops_agent_self_metrics.json
+++ b/exporter/collector/testdata/fixtures/ops_agent_self_metrics.json
@@ -1,0 +1,125 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "otel-collector"
+                        }
+                    },
+                    {
+                        "key": "host.name",
+                        "value": {
+                            "stringValue": "ops-agent-metrics.c.otel-opsagenttester.internal"
+                        }
+                    },
+                    {
+                        "key": "job",
+                        "value": {
+                            "stringValue": "otel-collector"
+                        }
+                    },
+                    {
+                        "key": "instance",
+                        "value": {
+                            "stringValue": "0.0.0.0:8888"
+                        }
+                    },
+                    {
+                        "key": "port",
+                        "value": {
+                            "stringValue": "8888"
+                        }
+                    },
+                    {
+                        "key": "scheme",
+                        "value": {
+                            "stringValue": "http"
+                        }
+                    },
+                    {
+                        "key": "cloud.provider",
+                        "value": {
+                            "stringValue": "gcp"
+                        }
+                    },
+                    {
+                        "key": "cloud.platform",
+                        "value": {
+                            "stringValue": "gcp_compute_engine"
+                        }
+                    },
+                    {
+                        "key": "cloud.account.id",
+                        "value": {
+                            "stringValue": "otel-opsagenttester"
+                        }
+                    },
+                    {
+                        "key": "cloud.availability_zone",
+                        "value": {
+                            "stringValue": "us-central1-a"
+                        }
+                    },
+                    {
+                        "key": "host.id",
+                        "value": {
+                            "stringValue": "1447596667076884700"
+                        }
+                    },
+                    {
+                        "key": "host.type",
+                        "value": {
+                            "stringValue": "projects/500000000000/machineTypes/e2-medium"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "agent.googleapis.com/agent/memory_usage",
+                            "description": "Total physical memory (resident set size)",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": "1636147063351000000",
+                                        "asDouble": 61992960
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "agent.googleapis.com/agent/uptime",
+                            "description": "Uptime of the process",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "version",
+                                                "value": {
+                                                    "stringValue": "google-cloud-ops-agent-metrics/latest-build_distro"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1636147063351000000",
+                                        "timeUnixNano": "1636147063351000000",
+                                        "asInt": "25"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ],
+            "schemaUrl": "https://opentelemetry.io/schemas/v1.5.0"
+        }
+    ]
+}

--- a/exporter/collector/testdata/fixtures/ops_agent_self_metrics_expect.json
+++ b/exporter/collector/testdata/fixtures/ops_agent_self_metrics_expect.json
@@ -1,0 +1,60 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "agent.googleapis.com/agent/memory_usage"
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884700",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 61992960
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "agent.googleapis.com/agent/uptime",
+            "labels": {
+              "version": "google-cloud-ops-agent-metrics/latest-build_distro"
+            }
+          },
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "1447596667076884700",
+              "zone": "us-central1-a"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "25"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Ensure existing behavior for ops-agent self + host metrics remains as-is during rewrite.

cc @lingshi, @aabmass 