### PR TITLE
Ignore project id in monitored resource

### DIFF
--- a/exporter/collector/internal/integrationtest/diff.go
+++ b/exporter/collector/internal/integrationtest/diff.go
@@ -17,29 +17,23 @@ package integrationtest
 import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	metricpb "google.golang.org/genproto/googleapis/api/metric"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var (
 	cmpOptions = []cmp.Option{
 		protocmp.Transform(),
-
-		// Ignore project IDs because fixtures may have been dumped from another project.
-		protocmp.IgnoreFields(&monitoringpb.CreateTimeSeriesRequest{}, "name"),
-		protocmp.IgnoreFields(&monitoringpb.CreateMetricDescriptorRequest{}, "name"),
-		protocmp.IgnoreFields(&metricpb.MetricDescriptor{}, "name"),
-
 		cmpopts.EquateEmpty(),
 	}
 )
 
 // Diff uses cmp.Diff(), protocmp, and some custom options to compare two protobuf messages.
-func DiffProtos(x interface{}, y interface{}) string {
-	return cmp.Diff(
-		x,
-		y,
-		cmpOptions...,
-	)
+func DiffProtos(x, y *MetricExpectFixture) string {
+	x = proto.Clone(x).(*MetricExpectFixture)
+	y = proto.Clone(y).(*MetricExpectFixture)
+	normalizeFixture(x)
+	normalizeFixture(y)
+
+	return cmp.Diff(x, y, cmpOptions...)
 }

--- a/exporter/collector/internal/integrationtest/testcase.go
+++ b/exporter/collector/internal/integrationtest/testcase.go
@@ -169,6 +169,9 @@ func normalizeFixture(fixture *MetricExpectFixture) {
 					p.GetInterval().EndTime = &timestamppb.Timestamp{}
 				}
 			}
+
+			// clear project ID from monitored resource
+			delete(ts.GetResource().GetLabels(), "project_id")
 		}
 	}
 

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -92,23 +92,16 @@ func TestMetrics(t *testing.T) {
 				endTime,
 			)
 			diff := integrationtest.DiffProtos(
-				actualCreateMetricDescriptorReq,
-				expectFixture.GetCreateMetricDescriptorRequests(),
+				&integrationtest.MetricExpectFixture{
+					CreateTimeSeriesRequests:       actualCreateTimeSeriesReq,
+					CreateMetricDescriptorRequests: actualCreateMetricDescriptorReq,
+				},
+				expectFixture,
 			)
 			require.Emptyf(
 				t,
 				diff,
-				"Expected CreateMetricDescriptor request and actual GCM request differ:\n%v",
-				diff,
-			)
-			diff = integrationtest.DiffProtos(
-				actualCreateTimeSeriesReq,
-				expectFixture.GetCreateTimeSeriesRequests(),
-			)
-			require.Emptyf(
-				t,
-				diff,
-				"Expected CreateTimeSeries request and actual GCM request differ:\n%v",
+				"Expected requests fixture and actual GCM requests differ:\n%v",
 				diff,
 			)
 		})


### PR DESCRIPTION
Ignore the `project_id` field in comparisons and strip it out when recording fixtures. To implement this, I've replaced the `protocmp.IgnoreFields()` options with normalizing the protos beforehand instead.