### PR TITLE
Fix defer gotchas

### DIFF
--- a/exporter/collector/internal/integrationtest/cmd/recordfixtures/main.go
+++ b/exporter/collector/internal/integrationtest/cmd/recordfixtures/main.go
@@ -57,7 +57,7 @@ func main() {
 	go testServer.Serve()
 	defer testServer.Shutdown()
 	testServerExporter := integrationtest.CreateMetricsTestServerExporter(ctx, t, testServer)
-	defer require.NoError(t, testServerExporter.Shutdown(ctx))
+	defer func() { require.NoError(t, testServerExporter.Shutdown(ctx)) }()
 
 	for _, test := range integrationtest.TestCases {
 		metrics := test.LoadOTLPMetricsInput(t, startTime, endTime)

--- a/exporter/collector/metrics_integration_test.go
+++ b/exporter/collector/metrics_integration_test.go
@@ -55,7 +55,7 @@ func TestIntegrationMetrics(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			metrics := test.LoadOTLPMetricsInput(t, startTime, endTime)
 			exporter := createMetricsExporter(ctx, t)
-			defer require.NoError(t, exporter.Shutdown(ctx))
+			defer func() { require.NoError(t, exporter.Shutdown(ctx)) }()
 
 			require.NoError(
 				t,

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -76,7 +76,7 @@ func TestMetrics(t *testing.T) {
 			go testServer.Serve()
 			defer testServer.Shutdown()
 			testServerExporter := createMetricsTestServerExporter(ctx, t, testServer)
-			defer require.NoError(t, testServerExporter.Shutdown(ctx))
+			defer func() { require.NoError(t, testServerExporter.Shutdown(ctx)) }()
 
 			require.NoError(
 				t,


### PR DESCRIPTION
In a few spots, I added code like `defer foo(bar())` where bar had a side effect.