### PR TITLE
[Metrics Rewrite] add outline with todos for fragmenting work

### DIFF
--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -24,6 +24,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/model/pdata"
+	"google.golang.org/genproto/googleapis/api/metric"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 )
 
 // metricsExporter is the GCM exporter that uses pdata directly
@@ -31,6 +34,8 @@ type metricsExporter struct {
 	cfg    *Config
 	client *monitoring.MetricClient
 }
+
+type labels map[string]string
 
 func (me *metricsExporter) Shutdown(context.Context) error {
 	return me.client.Close()
@@ -43,6 +48,8 @@ func newGoogleCloudMetricsExporter(
 ) (component.MetricsExporter, error) {
 	setVersionInUserAgent(cfg, set.BuildInfo.Version)
 
+	// TODO: map cfg options into metric service client configuration with
+	// generateClientOptions()
 	client, err := monitoring.NewMetricClient(ctx)
 	if err != nil {
 		return nil, err
@@ -65,10 +72,119 @@ func newGoogleCloudMetricsExporter(
 
 // pushMetrics calls pushes pdata metrics to GCM, creating metric descriptors if necessary
 func (me *metricsExporter) pushMetrics(ctx context.Context, m pdata.Metrics) error {
+	timeSeries := make([]*monitoringpb.TimeSeries, 0, m.DataPointCount())
+
+	rms := m.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		monitoredResource, extraResourceLabels := resourceMetricsToMonitoredResource(rm.Resource())
+		ilms := rm.InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ilm := ilms.At(j)
+
+			extraLabels := mergeLabels(instrumentationLibraryToLabels(ilm.InstrumentationLibrary()), extraResourceLabels)
+			mes := ilm.Metrics()
+			for k := 0; k < mes.Len(); k++ {
+				me := mes.At(k)
+				timeSeries = append(timeSeries, metricToTimeSeries(monitoredResource, extraLabels, ilm, me)...)
+			}
+		}
+	}
+
 	// TODO: self observability
-	points := 0
-	dropped := 0
-	var err error = nil
-	recordPointCount(ctx, points-dropped, dropped, err)
+	err := me.createTimeSeries(ctx, timeSeries)
+	recordPointCount(ctx, len(timeSeries), m.DataPointCount()-len(timeSeries), err)
+	return err
+}
+
+func (me *metricsExporter) createTimeSeries(ctx context.Context, ts []*monitoringpb.TimeSeries) error {
+	return me.client.CreateServiceTimeSeries(
+		ctx,
+		&monitoringpb.CreateTimeSeriesRequest{
+			TimeSeries: ts,
+			// TODO set Name field with project ID from config or ADC
+		},
+	)
+}
+
+// Transforms pdata Resource to a GCM Monitored Resource. Any resource attributes not accounted
+// for in the monitored resource which should be merged into metric labels are also returned.
+func resourceMetricsToMonitoredResource(
+	resource pdata.Resource,
+) (*monitoredrespb.MonitoredResource, labels) {
+	// TODO
+	return nil, nil
+}
+
+func instrumentationLibraryToLabels(il pdata.InstrumentationLibrary) labels {
+	// TODO
 	return nil
+}
+
+func metricToTimeSeries(
+	resource *monitoredrespb.MonitoredResource,
+	extraLabels labels,
+	ilm pdata.InstrumentationLibraryMetrics,
+	me pdata.Metric,
+) []*monitoringpb.TimeSeries {
+	timeSeries := []*monitoringpb.TimeSeries{}
+
+	switch me.DataType() {
+	case pdata.MetricDataTypeSum:
+		sum := me.Sum()
+		points := sum.DataPoints()
+		for i := 0; i < points.Len(); i++ {
+			ts := sumPointToTimeSeries(resource, extraLabels, ilm, me, sum, points.At(i))
+			timeSeries = append(timeSeries, ts)
+		}
+	// TODO: add cases for other metric data types
+	default:
+		// TODO: log unsupported metric
+	}
+
+	return timeSeries
+}
+
+func sumPointToTimeSeries(
+	resource *monitoredrespb.MonitoredResource,
+	extraLabels labels,
+	ilm pdata.InstrumentationLibraryMetrics,
+	me pdata.Metric,
+	sum pdata.Sum,
+	point pdata.NumberDataPoint,
+) *monitoringpb.TimeSeries {
+	// TODO
+	return &monitoringpb.TimeSeries{
+		Resource: resource,
+		Unit:     me.Unit(),
+		Metric: &metric.Metric{
+			Labels: mergeLabels(
+				attributesToLabels(point.Attributes()),
+				extraLabels,
+				// ... instrumentation library
+			),
+			// ...
+		},
+		// ...
+	}
+}
+
+func attributesToLabels(
+	attrs pdata.AttributeMap,
+) labels {
+	// TODO
+	return nil
+}
+
+func mergeLabels(mergeInto labels, others ...labels) labels {
+	if mergeInto == nil {
+		mergeInto = labels{}
+	}
+	for _, ls := range others {
+		for k, v := range ls {
+			mergeInto[k] = v
+		}
+	}
+
+	return mergeInto
 }

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+func TestMetricToTimeSeries(t *testing.T) {
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+	me := ilm.Metrics().AppendEmpty()
+	me.SetDataType(pdata.MetricDataTypeSum)
+	{
+		sum := me.Sum()
+		sum.SetIsMonotonic(true)
+		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+		point := sum.DataPoints().AppendEmpty()
+		point.SetDoubleVal(10)
+	}
+
+	mr := &monitoredrespb.MonitoredResource{}
+
+	ts := metricToTimeSeries(
+		mr,
+		labels{},
+		ilm,
+		me,
+	)
+
+	require.Len(t, ts, 1, "Should create one timeseries for sum")
+	require.Same(t, ts[0].Resource, mr, "Should assign the passed in monitored resource")
+}
+
+func TestMergeLabels(t *testing.T) {
+	assert.NotNil(t, mergeLabels(nil, labels{}), "Should create labels if mergeInto is nil")
+
+	assert.Equal(
+		t,
+		mergeLabels(labels{"foo": "foo"}, labels{"bar": "bar"}),
+		labels{"foo": "foo", "bar": "bar"},
+		"Should merge disjoint labels",
+	)
+
+	assert.Equal(
+		t,
+		mergeLabels(labels{"foo": "foo", "baz": "baz"}, labels{"foo": "bar"}),
+		labels{"foo": "bar", "baz": "baz"},
+		"Should merge intersecting labels, keeping the last value",
+	)
+}


### PR DESCRIPTION
Added the basic outline for metrics exporter with TODOs for pairing off work.

Each pdata point type will have a `xPointToTimeSeries()` function which takes parameters for a flat view for that point. See `sumPointToTimeSeries()` for a partial example.