### PR TITLE
[Metrics Rewrite] support for pdata Sum points

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -11,3 +11,10 @@ The new code does not:
 
 - truncate label keys longer than 100 characters.
 - prepend `key` when the first character is `_`.
+
+## OTLP Sum
+
+In the old exporter, delta sums were converted into GAUGE points ([see test
+fixture](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/9bc1f49ebe000b0b3b1aa5b7f201e7996effdcd8/exporter/collector/testdata/fixtures/delta_counter_metrics_expect.json#L15)).
+The new pdata exporter sends these as CUMULATIVE points with the same delta time window
+(reseting at each point) aka pseudo-cumulatives.

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -19,7 +19,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"unicode"
 
@@ -209,7 +208,7 @@ func (m *metricMapper) sumPointToTimeSeries(
 // metricNameToType maps OTLP metric name to GCM metric type (aka name)
 func (m *metricMapper) metricNameToType(name string) string {
 	// TODO
-	return fmt.Sprintf("workload.googleapis.com/%v", name)
+	return "workload.googleapis.com/" + name
 }
 
 func attributesToLabels(

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -19,20 +19,29 @@ package collector
 
 import (
 	"context"
+	"fmt"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/model/pdata"
-	"google.golang.org/genproto/googleapis/api/metric"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // metricsExporter is the GCM exporter that uses pdata directly
 type metricsExporter struct {
 	cfg    *Config
 	client *monitoring.MetricClient
+	mapper metricMapper
+}
+
+// metricMapper is the part that transforms metrics. Separate from metricsExporter since it has
+// all pure functions.
+type metricMapper struct {
+	cfg *Config
 }
 
 type labels map[string]string
@@ -58,6 +67,7 @@ func newGoogleCloudMetricsExporter(
 	mExp := &metricsExporter{
 		cfg:    cfg,
 		client: client,
+		mapper: metricMapper{cfg},
 	}
 
 	return exporterhelper.NewMetricsExporter(
@@ -77,7 +87,7 @@ func (me *metricsExporter) pushMetrics(ctx context.Context, m pdata.Metrics) err
 	rms := m.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
-		monitoredResource, extraResourceLabels := resourceMetricsToMonitoredResource(rm.Resource())
+		monitoredResource, extraResourceLabels := me.mapper.resourceMetricsToMonitoredResource(rm.Resource())
 		ilms := rm.InstrumentationLibraryMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			ilm := ilms.At(j)
@@ -85,8 +95,8 @@ func (me *metricsExporter) pushMetrics(ctx context.Context, m pdata.Metrics) err
 			extraLabels := mergeLabels(instrumentationLibraryToLabels(ilm.InstrumentationLibrary()), extraResourceLabels)
 			mes := ilm.Metrics()
 			for k := 0; k < mes.Len(); k++ {
-				me := mes.At(k)
-				timeSeries = append(timeSeries, metricToTimeSeries(monitoredResource, extraLabels, ilm, me)...)
+				metric := mes.At(k)
+				timeSeries = append(timeSeries, me.mapper.metricToTimeSeries(monitoredResource, extraLabels, metric)...)
 			}
 		}
 	}
@@ -109,7 +119,7 @@ func (me *metricsExporter) createTimeSeries(ctx context.Context, ts []*monitorin
 
 // Transforms pdata Resource to a GCM Monitored Resource. Any resource attributes not accounted
 // for in the monitored resource which should be merged into metric labels are also returned.
-func resourceMetricsToMonitoredResource(
+func (m *metricMapper) resourceMetricsToMonitoredResource(
 	resource pdata.Resource,
 ) (*monitoredrespb.MonitoredResource, labels) {
 	// TODO
@@ -121,20 +131,19 @@ func instrumentationLibraryToLabels(il pdata.InstrumentationLibrary) labels {
 	return nil
 }
 
-func metricToTimeSeries(
+func (m *metricMapper) metricToTimeSeries(
 	resource *monitoredrespb.MonitoredResource,
 	extraLabels labels,
-	ilm pdata.InstrumentationLibraryMetrics,
-	me pdata.Metric,
+	metric pdata.Metric,
 ) []*monitoringpb.TimeSeries {
 	timeSeries := []*monitoringpb.TimeSeries{}
 
-	switch me.DataType() {
+	switch metric.DataType() {
 	case pdata.MetricDataTypeSum:
-		sum := me.Sum()
+		sum := metric.Sum()
 		points := sum.DataPoints()
 		for i := 0; i < points.Len(); i++ {
-			ts := sumPointToTimeSeries(resource, extraLabels, ilm, me, sum, points.At(i))
+			ts := m.sumPointToTimeSeries(resource, extraLabels, metric, sum, points.At(i))
 			timeSeries = append(timeSeries, ts)
 		}
 	// TODO: add cases for other metric data types
@@ -145,28 +154,60 @@ func metricToTimeSeries(
 	return timeSeries
 }
 
-func sumPointToTimeSeries(
+func (m *metricMapper) sumPointToTimeSeries(
 	resource *monitoredrespb.MonitoredResource,
 	extraLabels labels,
-	ilm pdata.InstrumentationLibraryMetrics,
-	me pdata.Metric,
+	metric pdata.Metric,
 	sum pdata.Sum,
 	point pdata.NumberDataPoint,
 ) *monitoringpb.TimeSeries {
-	// TODO
+	metricKind := metricpb.MetricDescriptor_CUMULATIVE
+	startTime := timestamppb.New(point.StartTimestamp().AsTime())
+	if !sum.IsMonotonic() {
+		metricKind = metricpb.MetricDescriptor_GAUGE
+		startTime = nil
+	}
+
+	var valueType metricpb.MetricDescriptor_ValueType
+	var value *monitoringpb.TypedValue
+	if point.Type() == pdata.MetricValueTypeInt {
+		valueType = metricpb.MetricDescriptor_INT64
+		value = &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+			Int64Value: point.IntVal(),
+		}}
+	} else {
+		valueType = metricpb.MetricDescriptor_DOUBLE
+		value = &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+			DoubleValue: point.DoubleVal(),
+		}}
+	}
+
 	return &monitoringpb.TimeSeries{
-		Resource: resource,
-		Unit:     me.Unit(),
-		Metric: &metric.Metric{
+		Resource:   resource,
+		Unit:       metric.Unit(),
+		MetricKind: metricKind,
+		ValueType:  valueType,
+		Points: []*monitoringpb.Point{{
+			Interval: &monitoringpb.TimeInterval{
+				StartTime: startTime,
+				EndTime:   timestamppb.New(point.Timestamp().AsTime()),
+			},
+			Value: value,
+		}},
+		Metric: &metricpb.Metric{
+			Type: m.metricNameToType(metric.Name()),
 			Labels: mergeLabels(
 				attributesToLabels(point.Attributes()),
 				extraLabels,
-				// ... instrumentation library
 			),
-			// ...
 		},
-		// ...
 	}
+}
+
+// metricNameToType maps OTLP metric name to GCM metric type (aka name)
+func (m *metricMapper) metricNameToType(name string) string {
+	// TODO
+	return fmt.Sprintf("workload.googleapis.com/%v", name)
 }
 
 func attributesToLabels(

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -16,32 +16,36 @@ package collector
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	start = time.Unix(0, 0)
 )
 
 func TestMetricToTimeSeries(t *testing.T) {
-	ilm := pdata.NewInstrumentationLibraryMetrics()
-	me := ilm.Metrics().AppendEmpty()
-	me.SetDataType(pdata.MetricDataTypeSum)
-	{
-		sum := me.Sum()
-		sum.SetIsMonotonic(true)
-		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
-		point := sum.DataPoints().AppendEmpty()
-		point.SetDoubleVal(10)
-	}
-
+	mapper := metricMapper{cfg: &Config{}}
+	metric := pdata.NewMetric()
+	metric.SetDataType(pdata.MetricDataTypeSum)
+	sum := metric.Sum()
+	sum.SetIsMonotonic(true)
+	sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+	point := sum.DataPoints().AppendEmpty()
+	point.SetDoubleVal(10)
 	mr := &monitoredrespb.MonitoredResource{}
 
-	ts := metricToTimeSeries(
+	ts := mapper.metricToTimeSeries(
 		mr,
 		labels{},
-		ilm,
-		me,
+		metric,
 	)
 
 	require.Len(t, ts, 1, "Should create one timeseries for sum")
@@ -63,5 +67,118 @@ func TestMergeLabels(t *testing.T) {
 		mergeLabels(labels{"foo": "foo", "baz": "baz"}, labels{"foo": "bar"}),
 		labels{"foo": "bar", "baz": "baz"},
 		"Should merge intersecting labels, keeping the last value",
+	)
+}
+
+func TestSumPointToTimeSeries(t *testing.T) {
+	mapper := metricMapper{cfg: &Config{}}
+	mr := &monitoredrespb.MonitoredResource{}
+
+	newCase := func() (pdata.Metric, pdata.Sum, pdata.NumberDataPoint) {
+		metric := pdata.NewMetric()
+		metric.SetDataType(pdata.MetricDataTypeSum)
+		sum := metric.Sum()
+		point := sum.DataPoints().AppendEmpty()
+		return metric, sum, point
+	}
+
+	t.Run("cumulative monotonic", func(t *testing.T) {
+		metric, sum, point := newCase()
+		metric.SetName("mysum")
+		unit := "s"
+		metric.SetUnit(unit)
+		sum.SetIsMonotonic(true)
+		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+		var value int64 = 10
+		point.SetIntVal(value)
+		end := start.Add(time.Hour)
+		point.SetStartTimestamp(pdata.NewTimestampFromTime(start))
+		point.SetTimestamp(pdata.NewTimestampFromTime(end))
+
+		ts := mapper.sumPointToTimeSeries(mr, labels{}, metric, sum, point)
+		assert.Equal(t, ts.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+		assert.Equal(t, ts.ValueType, metricpb.MetricDescriptor_INT64)
+		assert.Equal(t, ts.Unit, unit)
+		assert.Same(t, ts.Resource, mr)
+
+		assert.Equal(t, ts.Metric.Type, "workload.googleapis.com/mysum")
+		assert.Equal(t, ts.Metric.Labels, map[string]string{})
+
+		assert.Nil(t, ts.Metadata)
+
+		assert.Len(t, ts.Points, 1)
+		assert.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+			StartTime: timestamppb.New(start),
+			EndTime:   timestamppb.New(end),
+		})
+		assert.Equal(t, ts.Points[0].Value.GetInt64Value(), value)
+
+		// Test double as well
+		point.SetDoubleVal(float64(value))
+		ts = mapper.sumPointToTimeSeries(mr, labels{}, metric, sum, point)
+		assert.Equal(t, ts.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+		assert.Equal(t, ts.ValueType, metricpb.MetricDescriptor_DOUBLE)
+		assert.Equal(t, ts.Points[0].Value.GetDoubleValue(), float64(value))
+	})
+
+	t.Run("delta monotonic", func(t *testing.T) {
+		metric, sum, point := newCase()
+		metric.SetName("mysum")
+		sum.SetIsMonotonic(true)
+		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityDelta)
+		point.SetIntVal(10)
+		end := start.Add(time.Hour)
+		point.SetStartTimestamp(pdata.NewTimestampFromTime(start))
+		point.SetTimestamp(pdata.NewTimestampFromTime(end))
+
+		// Should output a "pseudo-cumulative" with same interval as the delta
+		ts := mapper.sumPointToTimeSeries(mr, labels{}, metric, sum, point)
+		assert.Equal(t, ts.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+		assert.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+			StartTime: timestamppb.New(start),
+			EndTime:   timestamppb.New(end),
+		})
+	})
+
+	t.Run("non monotonic", func(t *testing.T) {
+		metric, sum, point := newCase()
+		metric.SetName("mysum")
+		sum.SetIsMonotonic(false)
+		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityDelta)
+		point.SetIntVal(10)
+		end := start.Add(time.Hour)
+		point.SetStartTimestamp(pdata.NewTimestampFromTime(start))
+		point.SetTimestamp(pdata.NewTimestampFromTime(end))
+
+		// Should output a gauge regardless of temporality, only setting end time
+		ts := mapper.sumPointToTimeSeries(mr, labels{}, metric, sum, point)
+		assert.Equal(t, ts.MetricKind, metricpb.MetricDescriptor_GAUGE)
+		assert.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+			EndTime: timestamppb.New(end),
+		})
+
+		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityDelta)
+		ts = mapper.sumPointToTimeSeries(mr, labels{}, metric, sum, point)
+		assert.Equal(t, ts.MetricKind, metricpb.MetricDescriptor_GAUGE)
+		assert.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+			EndTime: timestamppb.New(end),
+		})
+	})
+
+	t.Run("add extra labels", func(t *testing.T) {
+		metric, sum, point := newCase()
+		extraLabels := map[string]string{"foo": "bar"}
+		ts := mapper.sumPointToTimeSeries(mr, labels(extraLabels), metric, sum, point)
+		assert.Equal(t, ts.Metric.Labels, extraLabels)
+	})
+}
+
+func TestMetricNameToType(t *testing.T) {
+	mapper := metricMapper{cfg: &Config{}}
+	assert.Equal(
+		t,
+		mapper.metricNameToType("foo"),
+		"workload.googleapis.com/foo",
+		"Should use workload metric domain with default config",
 	)
 }


### PR DESCRIPTION
- Separated metric mapping portions into methods on struct `metricMapper`, which holds config and has all pure functions. This makes it easy to test without creating a GCM client
- Implement OTLP Sum point mapping in `sumPointToTimeSeries()`
- Tests

Note that in the OC based exporter, delta sums were converted into gauges ([test fixture](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/9bc1f49ebe000b0b3b1aa5b7f201e7996effdcd8/exporter/collector/testdata/fixtures/delta_counter_metrics_expect.json#L15)) while here we are making cumulatives with short time window. This will be a breaking change