### PR TITLE
[Metrics Rewrite] attribute to label mapping

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -1,0 +1,13 @@
+# Breaking changes vs old googlecloud exporter
+
+The new pdata based exporter has some breaking changes from the original OpenCensus stackdriver
+based `googlecloud` exporter:
+
+## Labels
+
+Original label key mapping code is
+[here](https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/42e7e58efdb937e8477f827d3fba022212335dbc/sanitize.go#L26).
+The new code does not:
+
+- truncate label keys longer than 100 characters.
+- prepend `key` when the first character is `_`.


### PR DESCRIPTION
Check out the test cases to see how special cases are handled. This uses pdata's [`AttributeValue.AsString()`](https://pkg.go.dev/go.opentelemetry.io/collector/model/pdata#AttributeValue.AsString) which appears to convert to string using JSON rules. Differences from [OC based exporter](https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/42e7e58efdb937e8477f827d3fba022212335dbc/sanitize.go#L26):

- This code does not truncate attrib keys longer than 100 characters
- This code does not prepend `key` to keys starting with `_`.