### PR TITLE
Add logic to translate metric descriptors and initial flow

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -3,6 +3,22 @@
 The new pdata based exporter has some breaking changes from the original OpenCensus stackdriver
 based `googlecloud` exporter:
 
+## Metric Names and Descriptors
+
+The previous collector exporter would default to sending metrics with the type:
+`custom.googleapis.com/OpenCensus/{metric_name}`.  This has been changed to
+`workload.googleapis.com/{metric_name}`.
+
+Additionally, the previous exporter had a hardcoded list of known metric domains
+where this "prefix" would not be used. The new exporter allows full configuration
+of this list via the `metric.known_domains` property.
+
+Additionally, the DisplayName for a metric used to be exactly the
+`{metric_name}`. Now, the metric name is chosen as the full-path after the
+domain name of the metric type.  E.g. if a metric called
+`workload.googleapis.com/nginx/latency` is created, the display name will
+be `nginx/latency` instead of `workload.googleapis.com/nginx/latency`.
+
 ## Labels
 
 Original label key mapping code is
@@ -18,3 +34,10 @@ In the old exporter, delta sums were converted into GAUGE points ([see test
 fixture](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/9bc1f49ebe000b0b3b1aa5b7f201e7996effdcd8/exporter/collector/testdata/fixtures/delta_counter_metrics_expect.json#L15)).
 The new pdata exporter sends these as CUMULATIVE points with the same delta time window
 (reseting at each point) aka pseudo-cumulatives.
+
+## OTLP Summary
+
+The old exporter relied on upstream conversion of OTLP Summary into Gauge and
+Cumulative points.  The new exporter performas this conversion itself, which
+means summary metric descriptors will include label description for `percentile`
+labels.

--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -38,6 +38,6 @@ The new pdata exporter sends these as CUMULATIVE points with the same delta time
 ## OTLP Summary
 
 The old exporter relied on upstream conversion of OTLP Summary into Gauge and
-Cumulative points.  The new exporter performas this conversion itself, which
+Cumulative points.  The new exporter performs this conversion itself, which
 means summary metric descriptors will include label description for `percentile`
 labels.

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -47,6 +47,8 @@ type Config struct {
 type MetricConfig struct {
 	Prefix                     string `mapstructure:"prefix"`
 	SkipCreateMetricDescriptor bool   `mapstructure:"skip_create_descriptor"`
+	// If a metric belongs to one of these domains it does not get a prefix.
+	KnownDomains []string `mapstructure:"known_domains"`
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Google Cloud).

--- a/exporter/collector/config_test.go
+++ b/exporter/collector/config_test.go
@@ -90,6 +90,9 @@ func TestLoadConfig(t *testing.T) {
 			MetricConfig: MetricConfig{
 				Prefix:                     "prefix",
 				SkipCreateMetricDescriptor: true,
+				KnownDomains: []string{
+					"googleapis.com", "kubernetes.io", "istio.io", "knative.dev",
+				},
 			},
 		})
 }

--- a/exporter/collector/factory.go
+++ b/exporter/collector/factory.go
@@ -42,20 +42,24 @@ func NewFactory() component.ExporterFactory {
 
 	return exporterhelper.NewFactory(
 		typeStr,
-		createDefaultConfig,
+		func() config.Exporter { return createDefaultConfig() },
 		exporterhelper.WithTraces(createTracesExporter),
 		exporterhelper.WithMetrics(createMetricsExporter),
 	)
 }
 
 // createDefaultConfig creates the default configuration for exporter.
-func createDefaultConfig() config.Exporter {
+func createDefaultConfig() *Config {
 	return &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
 		TimeoutSettings:  exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),
 		UserAgent:        "opentelemetry-collector-contrib {{version}}",
+		MetricConfig: MetricConfig{
+			KnownDomains: domains,
+			Prefix:       "workload.googleapis.com",
+		},
 	}
 }
 

--- a/exporter/collector/internal/integrationtest/testcases.go
+++ b/exporter/collector/internal/integrationtest/testcases.go
@@ -20,7 +20,7 @@ var (
 			Name:                 "Basic Counter",
 			OTLPInputFixturePath: "testdata/fixtures/basic_counter_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/basic_counter_metrics_expect.json",
-			Skip:                 false,
+			Skip:                 true,
 		},
 		{
 			Name:                 "Delta Counter",

--- a/exporter/collector/internal/integrationtest/testcases.go
+++ b/exporter/collector/internal/integrationtest/testcases.go
@@ -20,7 +20,7 @@ var (
 			Name:                 "Basic Counter",
 			OTLPInputFixturePath: "testdata/fixtures/basic_counter_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/basic_counter_metrics_expect.json",
-			Skip:                 true,
+			Skip:                 false,
 		},
 		{
 			Name:                 "Delta Counter",

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -163,7 +163,7 @@ func (me *metricsExporter) exportMetricDescriptorRunner() {
 	for md := range me.mds {
 		// Not yet sent, now we sent it.
 		if mdCache[md.Type] == nil {
-			err := me.exportMetricDescriptor(context.Background(), md)
+			err := me.exportMetricDescriptor(context.TODO(), md)
 			// TODO: Log-once on error, per metric descriptor?
 			// TODO: Re-use passed-in logger to exporter.
 			if err != nil {

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
 	"google.golang.org/genproto/googleapis/api/label"
-	"google.golang.org/genproto/googleapis/api/metric"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
@@ -370,7 +369,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					Name:        "custom.googleapis.com/test.metric",
 					DisplayName: "test.metric",
@@ -403,7 +402,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					Name:        "custom.googleapis.com/test.metric",
 					DisplayName: "test.metric",
@@ -436,7 +435,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					Name:        "test.metric",
 					DisplayName: "test.metric",
@@ -469,7 +468,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					Name:        "test.metric",
 					DisplayName: "test.metric",
@@ -500,7 +499,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					Name:        "test.metric",
 					DisplayName: "test.metric",
@@ -529,7 +528,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				histogram.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					Name:        "test.metric",
 					DisplayName: "test.metric",
@@ -555,7 +554,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				point.Attributes().InsertString("test_label", "value")
 				return metric
 			},
-			expected: []*metric.MetricDescriptor{
+			expected: []*metricpb.MetricDescriptor{
 				{
 					DisplayName: "test.metric_summary_sum",
 					Type:        "workload.googleapis.com/test.metric_summary_sum",

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
+	"google.golang.org/genproto/googleapis/api/label"
+	"google.golang.org/genproto/googleapis/api/metric"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
@@ -349,7 +351,7 @@ func TestNumberDataPointToValue(t *testing.T) {
 type metricDescriptorTest struct {
 	name          string
 	metricCreator func() pdata.Metric
-	expected      *metricpb.MetricDescriptor
+	expected      []*metricpb.MetricDescriptor
 }
 
 func TestMetricDescriptorMapping(t *testing.T) {
@@ -365,16 +367,24 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				gauge := metric.Gauge()
 				point := gauge.DataPoints().AppendEmpty()
 				point.SetDoubleVal(10)
+				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: &metricpb.MetricDescriptor{
-				Name:        "custom.googleapis.com/test.metric",
-				DisplayName: "test.metric",
-				Type:        "custom.googleapis.com/test.metric",
-				MetricKind:  metricpb.MetricDescriptor_GAUGE,
-				ValueType:   metricpb.MetricDescriptor_DOUBLE,
-				Unit:        "1",
-				Description: "Description",
+			expected: []*metric.MetricDescriptor{
+				{
+					Name:        "custom.googleapis.com/test.metric",
+					DisplayName: "test.metric",
+					Type:        "custom.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_GAUGE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -390,16 +400,24 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 				point := sum.DataPoints().AppendEmpty()
 				point.SetDoubleVal(10)
+				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: &metricpb.MetricDescriptor{
-				Name:        "custom.googleapis.com/test.metric",
-				DisplayName: "test.metric",
-				Type:        "custom.googleapis.com/test.metric",
-				MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-				ValueType:   metricpb.MetricDescriptor_DOUBLE,
-				Unit:        "1",
-				Description: "Description",
+			expected: []*metric.MetricDescriptor{
+				{
+					Name:        "custom.googleapis.com/test.metric",
+					DisplayName: "test.metric",
+					Type:        "custom.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -415,16 +433,24 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityDelta)
 				point := sum.DataPoints().AppendEmpty()
 				point.SetDoubleVal(10)
+				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: &metricpb.MetricDescriptor{
-				Name:        "test.metric",
-				DisplayName: "test.metric",
-				Type:        "workload.googleapis.com/test.metric",
-				MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-				ValueType:   metricpb.MetricDescriptor_DOUBLE,
-				Unit:        "1",
-				Description: "Description",
+			expected: []*metric.MetricDescriptor{
+				{
+					Name:        "test.metric",
+					DisplayName: "test.metric",
+					Type:        "workload.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -440,16 +466,24 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 				point := sum.DataPoints().AppendEmpty()
 				point.SetDoubleVal(10)
+				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: &metricpb.MetricDescriptor{
-				Name:        "test.metric",
-				DisplayName: "test.metric",
-				Type:        "workload.googleapis.com/test.metric",
-				MetricKind:  metricpb.MetricDescriptor_GAUGE,
-				ValueType:   metricpb.MetricDescriptor_DOUBLE,
-				Unit:        "1",
-				Description: "Description",
+			expected: []*metric.MetricDescriptor{
+				{
+					Name:        "test.metric",
+					DisplayName: "test.metric",
+					Type:        "workload.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_GAUGE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -462,16 +496,25 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				metric.SetUnit("1")
 				histogram := metric.Histogram()
 				histogram.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+				point := histogram.DataPoints().AppendEmpty()
+				point.Attributes().InsertString("test_label", "test_value")
 				return metric
 			},
-			expected: &metricpb.MetricDescriptor{
-				Name:        "test.metric",
-				DisplayName: "test.metric",
-				Type:        "workload.googleapis.com/test.metric",
-				MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-				ValueType:   metricpb.MetricDescriptor_DISTRIBUTION,
-				Unit:        "1",
-				Description: "Description",
+			expected: []*metric.MetricDescriptor{
+				{
+					Name:        "test.metric",
+					DisplayName: "test.metric",
+					Type:        "workload.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_DISTRIBUTION,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -486,14 +529,76 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				histogram.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 				return metric
 			},
-			expected: &metricpb.MetricDescriptor{
-				Name:        "test.metric",
-				DisplayName: "test.metric",
-				Type:        "workload.googleapis.com/test.metric",
-				MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-				ValueType:   metricpb.MetricDescriptor_DISTRIBUTION,
-				Unit:        "1",
-				Description: "Description",
+			expected: []*metric.MetricDescriptor{
+				{
+					Name:        "test.metric",
+					DisplayName: "test.metric",
+					Type:        "workload.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_DISTRIBUTION,
+					Unit:        "1",
+					Description: "Description",
+					Labels:      []*label.LabelDescriptor{},
+				},
+			},
+		},
+		{
+			name: "Summary",
+			metricCreator: func() pdata.Metric {
+				metric := pdata.NewMetric()
+				metric.SetDataType(pdata.MetricDataTypeSummary)
+				metric.SetName("test.metric")
+				metric.SetDescription("Description")
+				metric.SetUnit("1")
+				summary := metric.Summary()
+				point := summary.DataPoints().AppendEmpty()
+				point.Attributes().InsertString("test_label", "value")
+				return metric
+			},
+			expected: []*metric.MetricDescriptor{
+				{
+					DisplayName: "test.metric_summary_sum",
+					Type:        "workload.googleapis.com/test.metric_summary_sum",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
+				{
+					DisplayName: "test.metric_summary_count",
+					Type:        "workload.googleapis.com/test.metric_summary_count",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_INT64,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
+				{
+					Type:        "workload.googleapis.com/test.metric_summary_percentile",
+					DisplayName: "test.metric_summary_percentile",
+					MetricKind:  metricpb.MetricDescriptor_GAUGE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+						{
+							Key:         "percentile",
+							Description: "the value at a given percentile of a distribution",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -95,6 +95,7 @@ func TestMergeLabels(t *testing.T) {
 
 func TestSumPointToTimeSeries(t *testing.T) {
 	mapper := metricMapper{cfg: &Config{}}
+	mapper.SetMetricDefaults()
 	mr := &monitoredrespb.MonitoredResource{}
 
 	newCase := func() (pdata.Metric, pdata.Sum, pdata.NumberDataPoint) {
@@ -203,6 +204,7 @@ func TestSumPointToTimeSeries(t *testing.T) {
 
 func TestGaugePointToTimeSeries(t *testing.T) {
 	mapper := metricMapper{cfg: &Config{}}
+	mapper.SetMetricDefaults()
 	mr := &monitoredrespb.MonitoredResource{}
 
 	newCase := func() (pdata.Metric, pdata.Gauge, pdata.NumberDataPoint) {
@@ -259,6 +261,7 @@ func TestGaugePointToTimeSeries(t *testing.T) {
 
 func TestMetricNameToType(t *testing.T) {
 	mapper := metricMapper{cfg: &Config{}}
+	mapper.SetMetricDefaults()
 	assert.Equal(
 		t,
 		mapper.metricNameToType("foo"),

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -95,8 +95,7 @@ func TestMergeLabels(t *testing.T) {
 }
 
 func TestSumPointToTimeSeries(t *testing.T) {
-	mapper := metricMapper{cfg: &Config{}}
-	mapper.SetMetricDefaults()
+	mapper := metricMapper{cfg: createDefaultConfig()}
 	mr := &monitoredrespb.MonitoredResource{}
 
 	newCase := func() (pdata.Metric, pdata.Sum, pdata.NumberDataPoint) {
@@ -204,8 +203,7 @@ func TestSumPointToTimeSeries(t *testing.T) {
 }
 
 func TestGaugePointToTimeSeries(t *testing.T) {
-	mapper := metricMapper{cfg: &Config{}}
-	mapper.SetMetricDefaults()
+	mapper := metricMapper{cfg: createDefaultConfig()}
 	mr := &monitoredrespb.MonitoredResource{}
 
 	newCase := func() (pdata.Metric, pdata.Gauge, pdata.NumberDataPoint) {
@@ -261,8 +259,7 @@ func TestGaugePointToTimeSeries(t *testing.T) {
 }
 
 func TestMetricNameToType(t *testing.T) {
-	mapper := metricMapper{cfg: &Config{}}
-	mapper.SetMetricDefaults()
+	mapper := metricMapper{cfg: createDefaultConfig()}
 	assert.Equal(
 		t,
 		mapper.metricNameToType("foo"),
@@ -603,8 +600,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mapper := &metricMapper{}
-			mapper.SetMetricDefaults()
+			mapper := metricMapper{cfg: createDefaultConfig()}
 			metric := test.metricCreator()
 			md := mapper.metricDescriptor(metric)
 			assert.Equal(t, md, test.expected)

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -604,6 +605,58 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			metric := test.metricCreator()
 			md := mapper.metricDescriptor(metric)
 			assert.Equal(t, md, test.expected)
+		})
+	}
+}
+
+type knownDomainsTest struct {
+	name         string
+	metricType   string
+	knownDomains []string
+}
+
+func TestKnownDomains(t *testing.T) {
+	tests := []knownDomainsTest{
+		{
+			name:       "test",
+			metricType: "prefix/test",
+		},
+		{
+			name:       "googleapis.com/test",
+			metricType: "googleapis.com/test",
+		},
+		{
+			name:       "kubernetes.io/test",
+			metricType: "kubernetes.io/test",
+		},
+		{
+			name:       "istio.io/test",
+			metricType: "istio.io/test",
+		},
+		{
+			name:       "knative.dev/test",
+			metricType: "knative.dev/test",
+		},
+		{
+			name:         "knative.dev/test",
+			metricType:   "prefix/knative.dev/test",
+			knownDomains: []string{"example.com"},
+		},
+		{
+			name:         "example.com/test",
+			metricType:   "example.com/test",
+			knownDomains: []string{"example.com"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v to %v", test.name, test.metricType), func(t *testing.T) {
+			config := createDefaultConfig()
+			config.MetricConfig.Prefix = "prefix"
+			if len(test.knownDomains) > 0 {
+				config.MetricConfig.KnownDomains = test.knownDomains
+			}
+			mapper := metricMapper{cfg: config}
+			assert.Equal(t, test.metricType, mapper.metricNameToType(test.name))
 		})
 	}
 }


### PR DESCRIPTION
- If you enable any of the end-to-end integration tests, you'll see metric descriptors sent to the dummy service.
- Adds "known domains" configuration, so in the event we add new metric domain types (or system metrics define them), the metric name mapping logic can be configured.
- Adds "CreateDefaults" method to metric config structure.  This allows us to write method which use configuration without worrying about nil checking repeatedly.  Note: There's probably a better "go" way to do this, let me know.
- Updates createTimeSeries to call `CreateTimeSeries`.  We'll need to figure out `CreateServiceTimeSeries` later.
- Adds metric name/type/display name mappings (for updated version).
- Add simple label-mapping (no label-descriptions possible)
- Add constants for Summary mapping.

Not in this PR:
- Add "legacy" flag for metric naming conventions that:
  - uses external.googleapis.com/OpenCensus/
  - sets display name to original metric name (or last part of the path).