### PR TITLE
Wip suereth/summary timeseries

### DIFF
--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -250,12 +250,108 @@ func (m *metricMapper) metricToTimeSeries(
 			ts := m.gaugePointToTimeSeries(resource, extraLabels, metric, gauge, points.At(i))
 			timeSeries = append(timeSeries, ts)
 		}
+	case pdata.MetricDataTypeSummary:
+		summary := metric.Summary()
+		points := summary.DataPoints()
+		for i := 0; i < points.Len(); i++ {
+			ts := m.summaryPointToTimeSeries(resource, extraLabels, metric, summary, points.At(i))
+			timeSeries = append(timeSeries, ts...)
+		}
 	// TODO: add cases for other metric data types
 	default:
 		// TODO: log unsupported metric
 	}
 
 	return timeSeries
+}
+
+func (m *metricMapper) summaryPointToTimeSeries(
+	resource *monitoredrespb.MonitoredResource,
+	extraLabels labels,
+	metric pdata.Metric,
+	sum pdata.Summary,
+	point pdata.SummaryDataPoint,
+) []*monitoringpb.TimeSeries {
+	sumName, countName, percentileName := summaryMetricNames(metric.Name())
+	startTime := timestamppb.New(point.StartTimestamp().AsTime())
+	endTime := timestamppb.New(point.Timestamp().AsTime())
+	result := []*monitoringpb.TimeSeries{
+		{
+			Resource:   resource,
+			Unit:       metric.Unit(),
+			MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
+			ValueType:  metricpb.MetricDescriptor_DOUBLE,
+			Points: []*monitoringpb.Point{{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: startTime,
+					EndTime:   endTime,
+				},
+				Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+					DoubleValue: point.Sum(),
+				}},
+			}},
+			Metric: &metricpb.Metric{
+				Type: m.metricNameToType(sumName),
+				Labels: mergeLabels(
+					attributesToLabels(point.Attributes()),
+					extraLabels,
+				),
+			},
+		},
+		{
+			Resource:   resource,
+			Unit:       metric.Unit(),
+			MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
+			ValueType:  metricpb.MetricDescriptor_INT64,
+			Points: []*monitoringpb.Point{{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: startTime,
+					EndTime:   endTime,
+				},
+				Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+					Int64Value: int64(point.Count()),
+				}},
+			}},
+			Metric: &metricpb.Metric{
+				Type: m.metricNameToType(countName),
+				Labels: mergeLabels(
+					attributesToLabels(point.Attributes()),
+					extraLabels,
+				),
+			},
+		},
+	}
+	quantiles := point.QuantileValues()
+	for i := 0; i < quantiles.Len(); i++ {
+		quantile := quantiles.At(i)
+		pLabel := labels{
+			"percentile": fmt.Sprintf("%v", quantile.Quantile()),
+		}
+		result = append(result, &monitoringpb.TimeSeries{
+			Resource:   resource,
+			Unit:       metric.Unit(),
+			MetricKind: metricpb.MetricDescriptor_GAUGE,
+			ValueType:  metricpb.MetricDescriptor_DOUBLE,
+			Points: []*monitoringpb.Point{{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: startTime,
+					EndTime:   endTime,
+				},
+				Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+					DoubleValue: quantile.Value(),
+				}},
+			}},
+			Metric: &metricpb.Metric{
+				Type: m.metricNameToType(percentileName),
+				Labels: mergeLabels(
+					attributesToLabels(point.Attributes()),
+					extraLabels,
+					pLabel,
+				),
+			},
+		})
+	}
+	return result
 }
 
 func (m *metricMapper) sumPointToTimeSeries(
@@ -457,10 +553,16 @@ func (m *metricMapper) labelDescriptors(pm pdata.Metric) []*label.LabelDescripto
 	return result
 }
 
+// Returns (sum, count, percentile) metric names for a summary metric.
+func summaryMetricNames(name string) (string, string, string) {
+	sumName := fmt.Sprintf("%s%s", name, SummarySumSuffix)
+	countName := fmt.Sprintf("%s%s", name, SummaryCountPrefix)
+	percentileName := fmt.Sprintf("%s%s", name, SummaryPercentileSuffix)
+	return sumName, countName, percentileName
+}
+
 func (m *metricMapper) summaryMetricDescriptors(pm pdata.Metric) []*metricpb.MetricDescriptor {
-	sumName := fmt.Sprintf("%s%s", pm.Name(), SummarySumSuffix)
-	countName := fmt.Sprintf("%s%s", pm.Name(), SummaryCountPrefix)
-	percentileName := fmt.Sprintf("%s%s", pm.Name(), SummaryPercentileSuffix)
+	sumName, countName, percentileName := summaryMetricNames(pm.Name())
 	labels := m.labelDescriptors(pm)
 	return []*metricpb.MetricDescriptor{
 		{

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -259,6 +259,79 @@ func TestGaugePointToTimeSeries(t *testing.T) {
 	assert.Equal(t, ts.Metric.Labels, map[string]string{"foo": "bar", "baz": "bar"})
 }
 
+func TestSummaryPointToTimeSeries(t *testing.T) {
+	mapper := metricMapper{cfg: createDefaultConfig()}
+	mr := &monitoredrespb.MonitoredResource{}
+
+	metric := pdata.NewMetric()
+	metric.SetDataType(pdata.MetricDataTypeSummary)
+	summary := metric.Summary()
+	point := summary.DataPoints().AppendEmpty()
+
+	metric.SetName("mysummary")
+	unit := "1"
+	metric.SetUnit(unit)
+	var count uint64 = 10
+	var sum float64 = 100.0
+	point.SetCount(count)
+	point.SetSum(sum)
+	quantile := point.QuantileValues().AppendEmpty()
+	quantile.SetQuantile(0.0)
+	quantile.SetValue(1.0)
+	end := start.Add(time.Hour)
+	point.SetTimestamp(pdata.NewTimestampFromTime(end))
+	ts := mapper.metricToTimeSeries(mr, labels{}, metric)
+	assert.Len(t, ts, 3)
+	sumResult := ts[0]
+	countResult := ts[1]
+	quantileResult := ts[2]
+
+	// Test sum mapping
+	assert.Equal(t, sumResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+	assert.Equal(t, sumResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, sumResult.Unit, unit)
+	assert.Same(t, sumResult.Resource, mr)
+	assert.Equal(t, sumResult.Metric.Type, "workload.googleapis.com/mysummary_summary_sum")
+	assert.Equal(t, sumResult.Metric.Labels, map[string]string{})
+	assert.Nil(t, sumResult.Metadata)
+	assert.Len(t, sumResult.Points, 1)
+	assert.Equal(t, sumResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	})
+	assert.Equal(t, sumResult.Points[0].Value.GetDoubleValue(), sum)
+	// Test count mapping
+	assert.Equal(t, countResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+	assert.Equal(t, countResult.ValueType, metricpb.MetricDescriptor_INT64)
+	assert.Equal(t, countResult.Unit, unit)
+	assert.Same(t, countResult.Resource, mr)
+	assert.Equal(t, countResult.Metric.Type, "workload.googleapis.com/mysummary_summary_count")
+	assert.Equal(t, countResult.Metric.Labels, map[string]string{})
+	assert.Nil(t, countResult.Metadata)
+	assert.Len(t, countResult.Points, 1)
+	assert.Equal(t, countResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	})
+	assert.Equal(t, countResult.Points[0].Value.GetInt64Value(), int64(count))
+	// Test quantile mapping
+	assert.Equal(t, quantileResult.MetricKind, metricpb.MetricDescriptor_GAUGE)
+	assert.Equal(t, quantileResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, quantileResult.Unit, unit)
+	assert.Same(t, quantileResult.Resource, mr)
+	assert.Equal(t, quantileResult.Metric.Type, "workload.googleapis.com/mysummary_summary_percentile")
+	assert.Equal(t, quantileResult.Metric.Labels, map[string]string{
+		"percentile": "0",
+	})
+	assert.Nil(t, quantileResult.Metadata)
+	assert.Len(t, quantileResult.Points, 1)
+	assert.Equal(t, quantileResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	})
+	assert.Equal(t, quantileResult.Points[0].Value.GetDoubleValue(), 1.0)
+}
+
 func TestMetricNameToType(t *testing.T) {
 	mapper := metricMapper{cfg: createDefaultConfig()}
 	assert.Equal(


### PR DESCRIPTION
- Add `Summary` as supported type for TimeSeries conversion.
- Creates N Timeseries (2+QuantileValue.size) per-Summary
- Uses similar logic/shared infra with `Summary` metric descriptor code.