### PR TITLE
Update integration test cases to allow modifying config

### DIFF
--- a/exporter/collector/internal/integrationtest/testcases.go
+++ b/exporter/collector/internal/integrationtest/testcases.go
@@ -14,12 +14,30 @@
 
 package integrationtest
 
+import "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+
 var (
 	TestCases = []MetricsTestCase{
 		{
 			Name:                 "Basic Counter",
 			OTLPInputFixturePath: "testdata/fixtures/basic_counter_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/basic_counter_metrics_expect.json",
+		},
+		{
+			Name:                 "Modified prefix unknown domain",
+			OTLPInputFixturePath: "testdata/fixtures/basic_counter_metrics.json",
+			ExpectFixturePath:    "testdata/fixtures/unknown_domain_metrics_expect.json",
+			Configure: func(cfg *collector.Config) {
+				cfg.MetricConfig.Prefix = "foobar.org"
+			},
+		},
+		{
+			Name:                 "Modified prefix workload.googleapis.com",
+			OTLPInputFixturePath: "testdata/fixtures/basic_counter_metrics.json",
+			ExpectFixturePath:    "testdata/fixtures/workloadgoogleapis_prefix_metrics_expect.json",
+			Configure: func(cfg *collector.Config) {
+				cfg.MetricConfig.Prefix = "workload.googleapis.com"
+			},
 		},
 		{
 			Name:                 "Delta Counter",

--- a/exporter/collector/metrics_integration_test.go
+++ b/exporter/collector/metrics_integration_test.go
@@ -30,13 +30,17 @@ import (
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/integrationtest"
 )
 
-func createMetricsExporter(ctx context.Context, t *testing.T) component.MetricsExporter {
+func createMetricsExporter(
+	ctx context.Context,
+	t *testing.T,
+	test *integrationtest.MetricsTestCase,
+) component.MetricsExporter {
 	factory := collector.NewFactory()
 
 	exporter, err := factory.CreateMetricsExporter(
 		ctx,
 		componenttest.NewNopExporterCreateSettings(),
-		integrationtest.CreateConfig(factory),
+		test.CreateConfig(),
 	)
 	require.NoError(t, err)
 	require.NoError(t, exporter.Start(ctx, componenttest.NewNopHost()))
@@ -54,7 +58,7 @@ func TestIntegrationMetrics(t *testing.T) {
 
 		t.Run(test.Name, func(t *testing.T) {
 			metrics := test.LoadOTLPMetricsInput(t, startTime, endTime)
-			exporter := createMetricsExporter(ctx, t)
+			exporter := createMetricsExporter(ctx, t, &test)
 			defer func() { require.NoError(t, exporter.Shutdown(ctx)) }()
 
 			require.NoError(

--- a/exporter/collector/testdata/fixtures/unknown_domain_metrics_expect.json
+++ b/exporter/collector/testdata/fixtures/unknown_domain_metrics_expect.json
@@ -1,0 +1,49 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "custom.googleapis.com/opencensus/foobar.org/testcounter",
+            "labels": {
+              "foo": "bar"
+            }
+          },
+          "resource": {
+            "type": "global"
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "createMetricDescriptorRequests": [
+    {
+      "metricDescriptor": {
+        "type": "custom.googleapis.com/opencensus/foobar.org/testcounter",
+        "labels": [
+          {
+            "key": "foo"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "INT64",
+        "unit": "1",
+        "description": "This is a test counter",
+        "displayName": "OpenCensus/testcounter"
+      }
+    }
+  ]
+}

--- a/exporter/collector/testdata/fixtures/workloadgoogleapis_prefix_metrics_expect.json
+++ b/exporter/collector/testdata/fixtures/workloadgoogleapis_prefix_metrics_expect.json
@@ -1,0 +1,32 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/testcounter",
+            "labels": {
+              "foo": "bar"
+            }
+          },
+          "resource": {
+            "type": "global"
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Update integration test case struct with `Configure` func member which allows modifying the default config
- Refactored code to use the same mechanism to create exporters everywhere
- Added two test cases demonstrating `Configure` option
  - Modify prefix to some unknown
  - Modify prefix to `workload.googleapis.com` which shouldn't create metric descriptors.