### PR TITLE
Enable ops agent host metric integration test.

### DIFF
--- a/exporter/collector/internal/integrationtest/testcases.go
+++ b/exporter/collector/internal/integrationtest/testcases.go
@@ -64,7 +64,6 @@ var (
 			Name:                 "Ops Agent Self-Reported metrics",
 			OTLPInputFixturePath: "testdata/fixtures/ops_agent_self_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/ops_agent_self_metrics_expect.json",
-			Skip:                 false,
 			Configure: func(cfg *collector.Config) {
 				// Previous exporter did NOT export metric descriptors.
 				// TODO: Add a new test that also checks metric descriptors.
@@ -75,7 +74,11 @@ var (
 			Name:                 "Ops Agent Host Metrics",
 			OTLPInputFixturePath: "testdata/fixtures/ops_agent_host_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/ops_agent_host_metrics_expect.json",
-			Skip:                 true,
+			Configure: func(cfg *collector.Config) {
+				// Previous exporter did NOT export metric descriptors.
+				// TODO: Add a new test that also checks metric descriptors.
+				cfg.MetricConfig.SkipCreateMetricDescriptor = true
+			},
 		},
 		{
 			Name:                 "GKE Workload Metrics",

--- a/exporter/collector/testdata/fixtures/ops_agent_host_metrics_expect.json
+++ b/exporter/collector/testdata/fixtures/ops_agent_host_metrics_expect.json
@@ -17,6 +17,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -45,6 +46,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -78,6 +80,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -111,6 +114,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -144,6 +148,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -178,6 +183,7 @@
           },
           "metricKind": "CUMULATIVE",
           "valueType": "INT64",
+          "unit": "s",
           "points": [
             {
               "interval": {
@@ -210,6 +216,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -243,6 +250,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -275,6 +283,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -306,6 +315,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -337,6 +347,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -368,6 +379,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -399,6 +411,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -430,6 +443,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -461,6 +475,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -493,6 +508,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -525,6 +541,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -557,6 +574,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -589,6 +607,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -621,6 +640,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -649,6 +669,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -676,6 +697,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -703,6 +725,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -730,6 +753,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -757,6 +781,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -784,6 +809,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -811,6 +837,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -838,6 +865,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -865,6 +893,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -892,6 +921,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -916,6 +946,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "1",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -940,6 +971,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "1",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -964,6 +996,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "1",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -991,6 +1024,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1019,6 +1053,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1047,6 +1082,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1075,6 +1111,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1104,6 +1141,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1133,6 +1171,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1162,6 +1201,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1191,6 +1231,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1220,6 +1261,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1249,6 +1291,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1278,6 +1321,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1307,6 +1351,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1335,6 +1380,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1363,6 +1409,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1391,6 +1438,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1419,6 +1467,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1447,6 +1496,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{operations}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -1474,6 +1524,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{operations}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -1501,6 +1552,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{operations}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -1528,6 +1580,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{operations}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -1556,6 +1609,7 @@
           },
           "metricKind": "CUMULATIVE",
           "valueType": "INT64",
+          "unit": "s",
           "points": [
             {
               "interval": {
@@ -1583,6 +1637,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1611,6 +1666,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1639,6 +1695,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "s",
           "valueType": "INT64",
           "points": [
             {
@@ -1668,6 +1725,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1697,6 +1755,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1726,6 +1785,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1755,6 +1815,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1784,6 +1845,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1813,6 +1875,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1842,6 +1905,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1871,6 +1935,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{operations}",
           "valueType": "INT64",
           "points": [
             {
@@ -1899,6 +1964,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1927,6 +1993,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1955,6 +2022,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -1983,6 +2051,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -2012,6 +2081,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{packets}",
           "valueType": "INT64",
           "points": [
             {
@@ -2041,6 +2111,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{packets}",
           "valueType": "INT64",
           "points": [
             {
@@ -2070,6 +2141,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{packets}",
           "valueType": "INT64",
           "points": [
             {
@@ -2099,6 +2171,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{packets}",
           "valueType": "INT64",
           "points": [
             {
@@ -2128,6 +2201,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{errors}",
           "valueType": "INT64",
           "points": [
             {
@@ -2157,6 +2231,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{errors}",
           "valueType": "INT64",
           "points": [
             {
@@ -2186,6 +2261,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{errors}",
           "valueType": "INT64",
           "points": [
             {
@@ -2215,6 +2291,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{errors}",
           "valueType": "INT64",
           "points": [
             {
@@ -2244,6 +2321,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -2273,6 +2351,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -2302,6 +2381,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -2331,6 +2411,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "By",
           "valueType": "INT64",
           "points": [
             {
@@ -2360,6 +2441,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2388,6 +2470,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2416,6 +2499,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2444,6 +2528,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2472,6 +2557,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2500,6 +2586,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2528,6 +2615,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2556,6 +2644,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2584,6 +2673,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2612,6 +2702,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2640,6 +2731,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2668,6 +2760,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "{connections}",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2696,6 +2789,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2724,6 +2818,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2752,6 +2847,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2780,6 +2876,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2808,6 +2905,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2836,6 +2934,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2864,6 +2963,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2892,6 +2992,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2920,6 +3021,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2948,6 +3050,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -2976,6 +3079,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -3004,6 +3108,7 @@
             }
           },
           "metricKind": "GAUGE",
+          "unit": "By",
           "valueType": "DOUBLE",
           "points": [
             {
@@ -3028,6 +3133,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
+          "unit": "{processes}",
           "valueType": "INT64",
           "points": [
             {


### PR DESCRIPTION
- There is a bug in upstream agent-metric-processor that sets incorrect units on usage metrics (https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/issues/72)
- We update the expectations for inculsion of units in CreateTimeSeries
- We disable metric descriptors (for now).  Given the bug in agent-metric-processor, liekly ops-agent will need upstream fix for this first.