### PR TITLE
Add a feature gate, which defaults to false, for using the re-written exporter

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -201,6 +201,13 @@ and [memory limiter](https://github.com/open-telemetry/opentelemetry-collector/t
 optimal network usage and avoiding memory overruns.  You may also want to run an additional
 [sampler](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/probabilisticsamplerprocessor), depending on your needs.
 
+## Features and Feature-Gates
+
+See the [Collector feature gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/featuregate/README.md#collector-feature-gates) for an overview of feature gates in the collector.
+
+**ALPHA**: `exporter.googlecloud.OTLPDirect`
+
+When enabled via `--feature-gates=exporter.googlecloud.OTLPDirect`, the googlecloud exporter translates pdata directly to google cloud monitoring's types, rather than first translating to opencensus.
 
 ## Deprecatations
 

--- a/exporter/collector/config_test.go
+++ b/exporter/collector/config_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	factories, err := componenttest.NopFactories()
 	assert.Nil(t, err)
 

--- a/exporter/collector/factory_test.go
+++ b/exporter/collector/factory_test.go
@@ -22,7 +22,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/service/featuregate"
 )
+
+// SetPdataFeatureGateForTest changes the pdata feature gate during a test.
+// usage: defer SetPdataFeatureGateForTest(true)()
+func SetPdataFeatureGateForTest(enabled bool) func() {
+	originalValue := featuregate.IsEnabled(pdataExporterFeatureGate)
+	featuregate.Apply(map[string]bool{pdataExporterFeatureGate: enabled})
+	return func() {
+		featuregate.Apply(map[string]bool{pdataExporterFeatureGate: originalValue})
+	}
+}
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()

--- a/exporter/collector/legacymetricsexporter.go
+++ b/exporter/collector/legacymetricsexporter.go
@@ -1,0 +1,170 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the rewritten googlecloud metrics exporter which no longer takes
+// dependency on the OpenCensus stackdriver exporter.
+
+package collector
+
+import (
+	"context"
+	"fmt"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
+)
+
+// legacyMetricsExporter is a wrapper struct of OC stackdriver exporter
+type legacyMetricsExporter struct {
+	mexporter *stackdriver.Exporter
+}
+
+func (me *legacyMetricsExporter) Shutdown(context.Context) error {
+	me.mexporter.Flush()
+	me.mexporter.StopMetricsExporter()
+	return me.mexporter.Close()
+}
+
+func newLegacyGoogleCloudMetricsExporter(
+	ctx context.Context,
+	cfg *Config,
+	set component.ExporterCreateSettings,
+) (component.MetricsExporter, error) {
+	setVersionInUserAgent(cfg, set.BuildInfo.Version)
+
+	// TODO:  For each ProjectID, create a different exporter
+	// or at least a unique Google Cloud client per ProjectID.
+	options := stackdriver.Options{
+		// If the project ID is an empty string, it will be set by default based on
+		// the project this is running on in GCP.
+		ProjectID: cfg.ProjectID,
+
+		MetricPrefix: cfg.MetricConfig.Prefix,
+
+		// Set DefaultMonitoringLabels to an empty map to avoid getting the "opencensus_task" label
+		DefaultMonitoringLabels: &stackdriver.Labels{},
+
+		Timeout: cfg.Timeout,
+	}
+
+	// note options.UserAgent overrides the option.WithUserAgent client option in the Metric exporter
+	if cfg.UserAgent != "" {
+		options.UserAgent = cfg.UserAgent
+	}
+
+	copts, err := generateClientOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+	options.TraceClientOptions = copts
+	options.MonitoringClientOptions = copts
+
+	if cfg.MetricConfig.SkipCreateMetricDescriptor {
+		options.SkipCMD = true
+	}
+	if len(cfg.ResourceMappings) > 0 {
+		rm := resourceMapper{
+			mappings: cfg.ResourceMappings,
+		}
+		options.MapResource = rm.mapResource
+	}
+
+	sde, serr := stackdriver.NewExporter(options)
+	if serr != nil {
+		return nil, fmt.Errorf("cannot configure Google Cloud metric exporter: %w", serr)
+	}
+	mExp := &legacyMetricsExporter{mexporter: sde}
+
+	return exporterhelper.NewMetricsExporter(
+		cfg,
+		set,
+		mExp.pushMetrics,
+		exporterhelper.WithShutdown(mExp.Shutdown),
+		// Disable exporterhelper Timeout, since we are using a custom mechanism
+		// within exporter itself
+		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithRetry(cfg.RetrySettings))
+}
+
+// pushMetrics calls StackdriverExporter.PushMetricsProto on each element of the given metrics
+func (me *legacyMetricsExporter) pushMetrics(ctx context.Context, m pdata.Metrics) error {
+	rms := m.ResourceMetrics()
+	mds := make([]*agentmetricspb.ExportMetricsServiceRequest, 0, rms.Len())
+	for i := 0; i < rms.Len(); i++ {
+		emsr := &agentmetricspb.ExportMetricsServiceRequest{}
+		emsr.Node, emsr.Resource, emsr.Metrics = internaldata.ResourceMetricsToOC(rms.At(i))
+		mds = append(mds, emsr)
+	}
+	// PushMetricsProto doesn't bundle subsequent calls, so we need to
+	// combine the data here to avoid generating too many RPC calls.
+	mds = exportAdditionalLabels(mds)
+
+	count := 0
+	for _, md := range mds {
+		count += len(md.Metrics)
+	}
+	metrics := make([]*metricspb.Metric, 0, count)
+	for _, md := range mds {
+		if md.Resource == nil {
+			metrics = append(metrics, md.Metrics...)
+			continue
+		}
+		for _, metric := range md.Metrics {
+			if metric.Resource == nil {
+				metric.Resource = md.Resource
+			}
+			metrics = append(metrics, metric)
+		}
+	}
+	points := numPoints(metrics)
+	// The two nil args here are: node (which is ignored) and resource
+	// (which we just moved to individual metrics).
+	dropped, err := me.mexporter.PushMetricsProto(ctx, nil, nil, metrics)
+	recordPointCount(ctx, points-dropped, dropped, err)
+	return err
+}
+
+func exportAdditionalLabels(mds []*agentmetricspb.ExportMetricsServiceRequest) []*agentmetricspb.ExportMetricsServiceRequest {
+	for _, md := range mds {
+		if md.Resource == nil ||
+			md.Resource.Labels == nil ||
+			md.Node == nil ||
+			md.Node.Identifier == nil ||
+			len(md.Node.Identifier.HostName) == 0 {
+			continue
+		}
+		// MetricsToOC removes `host.name` label and writes it to node indentifier, here we reintroduce it.
+		md.Resource.Labels[conventions.AttributeHostName] = md.Node.Identifier.HostName
+	}
+	return mds
+}
+
+func numPoints(metrics []*metricspb.Metric) int {
+	numPoints := 0
+	for _, metric := range metrics {
+		tss := metric.GetTimeseries()
+		for _, ts := range tss {
+			numPoints += len(ts.GetPoints())
+		}
+	}
+	return numPoints
+}

--- a/exporter/collector/legacymetricsexporter_test.go
+++ b/exporter/collector/legacymetricsexporter_test.go
@@ -1,0 +1,228 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the rewritten googlecloud metrics exporter which no longer takes
+// dependency on the OpenCensus stackdriver exporter.
+
+package collector
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"google.golang.org/api/option"
+	cloudmonitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/grpc"
+
+	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/metricstestutil"
+)
+
+func TestLegacyGoogleCloudMetricExport(t *testing.T) {
+	srv := grpc.NewServer()
+
+	descriptorReqCh := make(chan *requestWithMetadata)
+	timeSeriesReqCh := make(chan *requestWithMetadata)
+
+	mockServer := &mockMetricServer{descriptorReqCh: descriptorReqCh, timeSeriesReqCh: timeSeriesReqCh}
+	cloudmonitoringpb.RegisterMetricServiceServer(srv, mockServer)
+
+	lis, err := net.Listen("tcp", "localhost:8080")
+	require.NoError(t, err)
+	defer lis.Close()
+
+	go srv.Serve(lis)
+
+	// Example with overridden client options
+	clientOptions := []option.ClientOption{
+		option.WithoutAuthentication(),
+		option.WithTelemetryDisabled(),
+	}
+
+	creationParams := componenttest.NewNopExporterCreateSettings()
+	creationParams.BuildInfo = component.BuildInfo{
+		Version: "v0.0.1",
+	}
+
+	sde, err := newLegacyGoogleCloudMetricsExporter(context.Background(), &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		ProjectID:        "idk",
+		Endpoint:         "127.0.0.1:8080",
+		UserAgent:        "MyAgent {{version}}",
+		UseInsecure:      true,
+		GetClientOptions: func() []option.ClientOption {
+			return clientOptions
+		},
+	}, creationParams)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sde.Shutdown(context.Background())) }()
+
+	md := agentmetricspb.ExportMetricsServiceRequest{
+		Resource: &resourcepb.Resource{
+			Type: "host",
+			Labels: map[string]string{
+				"cloud.availability_zone": "us-central1",
+				"host.name":               "foo",
+				"k8s.cluster.name":        "test",
+				"contrib.opencensus.io/exporter/stackdriver/project_id": "1234567",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			metricstestutil.Gauge(
+				"test_gauge1",
+				[]string{"k0"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v0"},
+					metricstestutil.Double(time.Now(), 1))),
+			metricstestutil.Gauge(
+				"test_gauge2",
+				[]string{"k0", "k1"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v0", "v1"},
+					metricstestutil.Double(time.Now(), 12))),
+			metricstestutil.Gauge(
+				"test_gauge3",
+				[]string{"k0", "k1", "k2"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v0", "v1", "v2"},
+					metricstestutil.Double(time.Now(), 123))),
+			metricstestutil.Gauge(
+				"test_gauge4",
+				[]string{"k0", "k1", "k2", "k3"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v0", "v1", "v2", "v3"},
+					metricstestutil.Double(time.Now(), 1234))),
+			metricstestutil.Gauge(
+				"test_gauge5",
+				[]string{"k4", "k5"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v4", "v5"},
+					metricstestutil.Double(time.Now(), 34))),
+		},
+	}
+	md.Metrics[2].Resource = &resourcepb.Resource{
+		Type: "host",
+		Labels: map[string]string{
+			"cloud.availability_zone": "us-central1",
+			"host.name":               "bar",
+			"k8s.cluster.name":        "test",
+			"contrib.opencensus.io/exporter/stackdriver/project_id": "1234567",
+		},
+	}
+	md.Metrics[3].Resource = &resourcepb.Resource{
+		Type: "host",
+		Labels: map[string]string{
+			"contrib.opencensus.io/exporter/stackdriver/project_id": "1234567",
+		},
+	}
+	md.Metrics[4].Resource = &resourcepb.Resource{
+		Type: "test",
+	}
+
+	assert.NoError(t, sde.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(md.Node, md.Resource, md.Metrics)), err)
+
+	expectedNames := map[string]struct{}{
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge1": {},
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge2": {},
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge3": {},
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge4": {},
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge5": {},
+	}
+	for i := 0; i < 5; i++ {
+		drm := <-descriptorReqCh
+		assert.Regexp(t, "MyAgent v0\\.0\\.1", drm.metadata["user-agent"])
+		dr := drm.req.(*cloudmonitoringpb.CreateMetricDescriptorRequest)
+		assert.Contains(t, expectedNames, dr.MetricDescriptor.Name)
+		delete(expectedNames, dr.MetricDescriptor.Name)
+	}
+
+	trm := <-timeSeriesReqCh
+	assert.Regexp(t, "MyAgent v0\\.0\\.1", trm.metadata["user-agent"])
+	tr := trm.req.(*cloudmonitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, tr.TimeSeries, 5)
+
+	resourceFoo := map[string]string{
+		"node_name":    "foo",
+		"cluster_name": "test",
+		"location":     "us-central1",
+		"project_id":   "1234567",
+	}
+
+	resourceBar := map[string]string{
+		"node_name":    "bar",
+		"cluster_name": "test",
+		"location":     "us-central1",
+		"project_id":   "1234567",
+	}
+
+	resourceProjectID := map[string]string{
+		"project_id": "1234567",
+	}
+
+	expectedTimeSeries := map[string]struct {
+		value          float64
+		labels         map[string]string
+		resourceLabels map[string]string
+	}{
+		"custom.googleapis.com/opencensus/test_gauge1": {
+			value:          float64(1),
+			labels:         map[string]string{"k0": "v0"},
+			resourceLabels: resourceFoo,
+		},
+		"custom.googleapis.com/opencensus/test_gauge2": {
+			value:          float64(12),
+			labels:         map[string]string{"k0": "v0", "k1": "v1"},
+			resourceLabels: resourceFoo,
+		},
+		"custom.googleapis.com/opencensus/test_gauge3": {
+			value:          float64(123),
+			labels:         map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"},
+			resourceLabels: resourceBar,
+		},
+		"custom.googleapis.com/opencensus/test_gauge4": {
+			value:          float64(1234),
+			labels:         map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"},
+			resourceLabels: resourceProjectID,
+		},
+		"custom.googleapis.com/opencensus/test_gauge5": {
+			value:          float64(34),
+			labels:         map[string]string{"k4": "v4", "k5": "v5"},
+			resourceLabels: nil,
+		},
+	}
+	for i := 0; i < 5; i++ {
+		require.Contains(t, expectedTimeSeries, tr.TimeSeries[i].Metric.Type)
+		ts := expectedTimeSeries[tr.TimeSeries[i].Metric.Type]
+		assert.Equal(t, ts.labels, tr.TimeSeries[i].Metric.Labels)
+		require.Len(t, tr.TimeSeries[i].Points, 1)
+		assert.Equal(t, ts.value, tr.TimeSeries[i].Points[0].Value.GetDoubleValue())
+		assert.Equal(t, ts.resourceLabels, tr.TimeSeries[i].Resource.Labels)
+	}
+}

--- a/exporter/collector/metrics_integration_test.go
+++ b/exporter/collector/metrics_integration_test.go
@@ -49,6 +49,7 @@ func createMetricsExporter(
 }
 
 func TestIntegrationMetrics(t *testing.T) {
+	defer collector.SetPdataFeatureGateForTest(true)()
 	ctx := context.Background()
 	endTime := time.Now()
 	startTime := endTime.Add(-time.Second)

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -21,10 +21,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/integrationtest"
 )
 
 func TestMetrics(t *testing.T) {
+	defer collector.SetPdataFeatureGateForTest(true)()
 	ctx := context.Background()
 	endTime := time.Now()
 	startTime := endTime.Add(-time.Second)

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -96,6 +96,7 @@ func TestMergeLabels(t *testing.T) {
 }
 
 func TestHistogramPointToTimeSeries(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	cfg := createDefaultConfig()
 	cfg.ProjectID = "myproject"
 	mapper := metricMapper{cfg: cfg}
@@ -160,6 +161,7 @@ func TestHistogramPointToTimeSeries(t *testing.T) {
 }
 
 func TestExponentialHistogramPointToTimeSeries(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	cfg := createDefaultConfig()
 	cfg.ProjectID = "myproject"
 	mapper := metricMapper{cfg: cfg}
@@ -283,6 +285,7 @@ func TestExemplarOnlyTraceId(t *testing.T) {
 }
 
 func TestSumPointToTimeSeries(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	mapper := metricMapper{cfg: createDefaultConfig()}
 	mr := &monitoredrespb.MonitoredResource{}
 
@@ -391,6 +394,7 @@ func TestSumPointToTimeSeries(t *testing.T) {
 }
 
 func TestGaugePointToTimeSeries(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	mapper := metricMapper{cfg: createDefaultConfig()}
 	mr := &monitoredrespb.MonitoredResource{}
 
@@ -447,6 +451,7 @@ func TestGaugePointToTimeSeries(t *testing.T) {
 }
 
 func TestSummaryPointToTimeSeries(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	mapper := metricMapper{cfg: createDefaultConfig()}
 	mr := &monitoredrespb.MonitoredResource{}
 
@@ -520,6 +525,7 @@ func TestSummaryPointToTimeSeries(t *testing.T) {
 }
 
 func TestMetricNameToType(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	mapper := metricMapper{cfg: createDefaultConfig()}
 	assert.Equal(
 		t,
@@ -612,6 +618,7 @@ type metricDescriptorTest struct {
 }
 
 func TestMetricDescriptorMapping(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	tests := []metricDescriptorTest{
 		{
 			name: "Gauge",
@@ -876,6 +883,7 @@ type knownDomainsTest struct {
 }
 
 func TestKnownDomains(t *testing.T) {
+	defer SetPdataFeatureGateForTest(true)()
 	tests := []knownDomainsTest{
 		{
 			name:       "test",


### PR DESCRIPTION
This allows the new pdata-based exporter to be enabled on the collector with `--feature-gates=exporter.googlecloud.OTLPDirect` when running the collector.

Code in exporter/collector/legacymetricsexporter.go (and the corresponding `_test.go` file) is taken from the [current upstream implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6a1c2471092b7f62ad1a37f62cbb7b0179676d01/exporter/googlecloudexporter/googlecloud.go#L126), which wraps the [opencensus stackdriver exporter](https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver).

This means that changing the upstream implementation to use the rewritten implementation will be a no-op.