### PR TITLE
Skip already seen attribute keys when creating LabelDescriptors

### DIFF
--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -740,11 +740,17 @@ func (m *metricMapper) metricTypeToDisplayName(mURL string) string {
 func (m *metricMapper) labelDescriptors(pm pdata.Metric) []*label.LabelDescriptor {
 	// TODO - allow customization of label descriptions.
 	result := []*label.LabelDescriptor{}
+	seenKeys := map[string]struct{}{}
 	addAttributes := func(attr pdata.AttributeMap) {
 		attr.Range(func(key string, _ pdata.AttributeValue) bool {
+			// Skip keys that have already been set
+			if _, ok := seenKeys[key]; ok {
+				return true
+			}
 			result = append(result, &label.LabelDescriptor{
 				Key: key,
 			})
+			seenKeys[key] = struct{}{}
 			return true
 		})
 	}

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -864,6 +864,40 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Multiple points",
+			metricCreator: func() pdata.Metric {
+				metric := pdata.NewMetric()
+				metric.SetDataType(pdata.MetricDataTypeGauge)
+				metric.SetName("custom.googleapis.com/test.metric")
+				metric.SetDescription("Description")
+				metric.SetUnit("1")
+				gauge := metric.Gauge()
+
+				for i := 0; i < 5; i++ {
+					point := gauge.DataPoints().AppendEmpty()
+					point.SetDoubleVal(10)
+					point.Attributes().InsertString("test_label", "test_value")
+				}
+				return metric
+			},
+			expected: []*metricpb.MetricDescriptor{
+				{
+					Name:        "custom.googleapis.com/test.metric",
+					DisplayName: "test.metric",
+					Type:        "custom.googleapis.com/test.metric",
+					MetricKind:  metricpb.MetricDescriptor_GAUGE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Unit:        "1",
+					Description: "Description",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key: "test_label",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Otherwise we are sending duplicate label descriptors for each point in a given pdata `Metric`.