### PR TITLE
Move logging to use zap-logger and set up self-observability to match…

### DIFF
--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -24,6 +24,7 @@ require (
 	cloud.google.com/go/monitoring v1.1.0
 	github.com/aws/aws-sdk-go v1.42.14 // indirect
 	github.com/google/go-cmp v0.5.6
+	go.uber.org/zap v1.19.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )
 


### PR DESCRIPTION
… collector expectations.


- Adds hook for us to create Meters/Instruments/Tracers from the passed-in collector TelemetrySettings
- Stores the zap logger for structured logging in the exporter.

Side question:  Why are we using OpenCensus for self-observability metrics instead of MeterProvider in TelemetrySettings?