### PR TITLE
Add ocgrpc metrics to exporter's self-obs metrics

### DIFF
--- a/exporter/collector/integrationtests.md
+++ b/exporter/collector/integrationtests.md
@@ -86,7 +86,8 @@ To add a new test:
     that the exporter makes to GCP services:
 
     ```sh
-    go run internal/integrationtest/cmd/recordfixtures/main.go
+    cd internal/integrationtest
+    go run cmd/recordfixtures/main.go
     ```
 
     The generated file is a JSON encoded

--- a/exporter/collector/internal/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/internal/integrationtest/inmemoryocexporter.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/metric/metricexport"
+	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
@@ -78,6 +79,7 @@ func (i *InMemoryOCExporter) Proto() []*SelfObservabilityMetric {
 // Shutdown unregisters the global OpenCensus views to reset state for the next test
 func (i *InMemoryOCExporter) Shutdown(ctx context.Context) error {
 	view.Unregister(collector.MetricViews()...)
+	view.Unregister(ocgrpc.DefaultClientViews...)
 	return nil
 }
 
@@ -87,6 +89,8 @@ func NewInMemoryOCViewExporter() (*InMemoryOCExporter, error) {
 	// Reset our views in case any tests ran before this
 	view.Unregister(collector.MetricViews()...)
 	view.Register(collector.MetricViews()...)
+	view.Unregister(ocgrpc.DefaultClientViews...)
+	// TODO: Register ocgrpc.DefaultClientViews to test them
 
 	return &InMemoryOCExporter{
 			c:      make(chan []*metricdata.Metric, 1),

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -29,6 +29,7 @@ import (
 	"unicode"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
@@ -93,6 +94,7 @@ func NewGoogleCloudMetricsExporter(
 	timeout time.Duration,
 ) (*MetricsExporter, error) {
 	view.Register(MetricViews()...)
+	view.Register(ocgrpc.DefaultClientViews...)
 	setVersionInUserAgent(&cfg, version)
 
 	// TODO - Share this lookup somewhere


### PR DESCRIPTION
This ensures we continue to get metrics added in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6945 when users switch to the new exporter.  I'm adding the ocgrpc metrics here (rather than upstream) so that we can integration test them.

Install the views in both the trace and metric exporters, since duplicate registration will just be a no-op.  That ensures users of either the trace or metrics exporter get opencensus grpc metrics.

Also, fix instructions for generating fixtures, which should have been updated when the testdata folder was moved.