### PR TITLE
Convert OTel Resource into metric labels

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -59,6 +59,13 @@ The new code does not:
 - truncate label keys longer than 100 characters.
 - prepend `key` when the first character is `_`.
 
+In addition, the exporter will now copy OTel Resource attributes `service.name`,
+`service.namespace` and `service.instance.id` into metric labels `service_name`,
+`service_namespace`, and `service_instance_id` respectively. This avoids duplicate timeseries
+when multiple instances of a service are running on a single monitored resource, for example
+running multiple service processes on a single GCE VM.  This can be turned off with the
+`metric.include_service_resource_attributes` config option.
+
 ## OTLP Sum
 
 In the old exporter, delta sums were converted into GAUGE points ([see test

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -66,9 +66,13 @@ type MetricConfig struct {
 	// resource. Default is true.
 	IncludeServiceResourceAttributes bool `mapstructure:"include_service_resource_attributes"`
 
-	// If provided, resources attributes with keys matching this regex will be copied into
-	// metric labels.
-	ResourceFilter string `mapstructure:"resource_filter"`
+	// If provided, resources attributes matching any filter will be included in metric labels.
+	ResourceFilters []ResourceFilter `mapstructure:"resource_filter"`
+}
+
+type ResourceFilter struct {
+	// Match resource keys by prefix
+	Prefix string `mapstructure:"prefix"`
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Google Cloud).

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -59,6 +59,16 @@ type MetricConfig struct {
 	// Buffer size for the channel which asynchronously calls CreateMetricDescriptor. Default
 	// is 10.
 	CreateMetricDescriptorBufferSize int `mapstructure:"create_metric_descriptor_buffer_size"`
+
+	// If true, the exporter will copy OTel's service.name, service.namespace, and
+	// service.instance.id resource attributes into the GCM timeseries metric labels. This
+	// option is recommended to avoid writing duplicate timeseries against the same monitored
+	// resource. Default is true.
+	IncludeServiceResourceAttributes bool `mapstructure:"include_service_resource_attributes"`
+
+	// If provided, resources attributes with keys matching this regex will be copied into
+	// metric labels.
+	ResourceFilter string `mapstructure:"resource_filter"`
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Google Cloud).
@@ -89,6 +99,7 @@ func DefaultConfig() Config {
 			Prefix:                           "workload.googleapis.com",
 			CreateMetricDescriptorBufferSize: 10,
 			InstrumentationLibraryLabels:     true,
+			IncludeServiceResourceAttributes: true,
 		},
 	}
 }

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -22,6 +22,7 @@ require (
 require (
 	cloud.google.com/go/monitoring v1.1.0
 	github.com/aws/aws-sdk-go v1.42.14 // indirect
+	github.com/google/go-cmp v0.5.6
 	go.uber.org/zap v1.19.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -88,6 +88,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					InstrumentationLibraryLabels:     true,
 					CreateMetricDescriptorBufferSize: 10,
+					IncludeServiceResourceAttributes: true,
 				},
 			},
 		})

--- a/exporter/collector/integrationtest/testcase.go
+++ b/exporter/collector/integrationtest/testcase.go
@@ -220,9 +220,10 @@ func normalizeMetricDescriptorReqs(t testing.TB, reqs ...*monitoringpb.CreateMet
 		if req.MetricDescriptor == nil {
 			continue
 		}
-		req.MetricDescriptor.Name = ""
-		sort.Slice(req.MetricDescriptor.Labels, func(i, j int) bool {
-			return req.MetricDescriptor.Labels[i].Key < req.MetricDescriptor.Labels[j].Key
+		md := req.MetricDescriptor
+		md.Name = ""
+		sort.Slice(md.Labels, func(i, j int) bool {
+			return md.Labels[i].Key < md.Labels[j].Key
 		})
 	}
 }

--- a/exporter/collector/integrationtest/testcase.go
+++ b/exporter/collector/integrationtest/testcase.go
@@ -217,9 +217,13 @@ func normalizeTimeSeriesReqs(t testing.TB, reqs ...*monitoringpb.CreateTimeSerie
 func normalizeMetricDescriptorReqs(t testing.TB, reqs ...*monitoringpb.CreateMetricDescriptorRequest) {
 	for _, req := range reqs {
 		req.Name = ""
-		if req.MetricDescriptor != nil {
-			req.MetricDescriptor.Name = ""
+		if req.MetricDescriptor == nil {
+			continue
 		}
+		req.MetricDescriptor.Name = ""
+		sort.Slice(req.MetricDescriptor.Labels, func(i, j int) bool {
+			return req.MetricDescriptor.Labels[i].Key < req.MetricDescriptor.Labels[j].Key
+		})
 	}
 }
 

--- a/exporter/collector/integrationtest/testcases.go
+++ b/exporter/collector/integrationtest/testcases.go
@@ -62,6 +62,7 @@ var (
 				// Previous exporter did NOT export metric descriptors.
 				// TODO: Add a new test that also checks metric descriptors.
 				cfg.MetricConfig.SkipCreateMetricDescriptor = true
+				cfg.MetricConfig.IncludeServiceResourceAttributes = false
 			},
 		},
 		{
@@ -97,6 +98,7 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/gke_control_plane_metrics_agent_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+				cfg.MetricConfig.IncludeServiceResourceAttributes = false
 			},
 		},
 		{
@@ -110,6 +112,14 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/create_service_timeseries_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+			},
+		},
+		{
+			Name:                 "WithResourceFilter",
+			OTLPInputFixturePath: "testdata/fixtures/with_resource_filter_metrics.json",
+			ExpectFixturePath:    "testdata/fixtures/with_resource_filter_metrics_expect.json",
+			Configure: func(cfg *collector.Config) {
+				cfg.MetricConfig.ResourceFilter = `telemetry\.sdk\..*`
 			},
 		},
 	}

--- a/exporter/collector/integrationtest/testcases.go
+++ b/exporter/collector/integrationtest/testcases.go
@@ -119,7 +119,9 @@ var (
 			OTLPInputFixturePath: "testdata/fixtures/with_resource_filter_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/with_resource_filter_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
-				cfg.MetricConfig.ResourceFilter = `telemetry\.sdk\..*`
+				cfg.MetricConfig.ResourceFilters = []collector.ResourceFilter{
+					{Prefix: "telemetry.sdk."},
+				}
 			},
 		},
 	}

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics.json
@@ -1,0 +1,77 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "foo-service"
+            }
+          },
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "foo"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "abc123"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "java"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.1.1"
+            }
+          },
+          {
+            "key": "something.uninteresting",
+            "value": {
+              "stringValue": "baz"
+            }
+          }
+        ]
+      },
+      "instrumentationLibraryMetrics": [
+        {
+          "instrumentationLibrary": {},
+          "metrics": [
+            {
+              "name": "testresourcefilter",
+              "description": "This is a test counter",
+              "unit": "1",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "foo",
+                        "value": {
+                          "stringValue": "bar"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1634322229906722370",
+                    "timeUnixNano": "1634322234906722370",
+                    "asInt": "253"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                "isMonotonic": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
@@ -1,0 +1,685 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/testresourcefilter",
+            "labels": {
+              "foo": "bar",
+              "service_instance_id": "abc123",
+              "service_name": "foo-service",
+              "service_namespace": "foo",
+              "telemetry_sdk_language": "java",
+              "telemetry_sdk_version": "1.1.1"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "foo-service",
+              "location": "global",
+              "namespace": "foo",
+              "task_id": "abc123"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ],
+          "unit": "1"
+        }
+      ]
+    }
+  ],
+  "createMetricDescriptorRequests": [
+    {
+      "metricDescriptor": {
+        "type": "workload.googleapis.com/testresourcefilter",
+        "labels": [
+          {
+            "key": "foo"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "INT64",
+        "unit": "1",
+        "description": "This is a test counter",
+        "displayName": "testresourcefilter"
+      }
+    }
+  ],
+  "selfObservabilityMetrics": {
+    "createTimeSeriesRequests": [
+      {
+        "timeSeries": [
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+              "labels": {
+                "status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "createMetricDescriptorRequests": [
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+          "labels": [
+            {
+              "key": "status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of metric points written to Cloud Monitoring.",
+          "displayName": "OpenCensus/googlecloudmonitoring/point_count"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            },
+            {
+              "key": "grpc_client_status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of RPCs by method and status.",
+          "displayName": "OpenCensus/grpc.io/client/completed_rpcs"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes received per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/received_bytes_per_rpc"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "ms",
+          "description": "Distribution of round-trip latency, by method.",
+          "displayName": "OpenCensus/grpc.io/client/roundtrip_latency"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes sent per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/sent_bytes_per_rpc"
+        }
+      }
+    ]
+  }
+}

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
@@ -47,22 +47,22 @@
         "type": "workload.googleapis.com/testresourcefilter",
         "labels": [
           {
-            "key": "service_namespace"
+            "key": "foo"
           },
           {
             "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          },
+          {
+            "key": "service_namespace"
           },
           {
             "key": "telemetry_sdk_language"
           },
           {
             "key": "telemetry_sdk_version"
-          },
-          {
-            "key": "service_name"
-          },
-          {
-            "key": "foo"
           }
         ],
         "metricKind": "CUMULATIVE",

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
@@ -47,6 +47,21 @@
         "type": "workload.googleapis.com/testresourcefilter",
         "labels": [
           {
+            "key": "service_namespace"
+          },
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "telemetry_sdk_language"
+          },
+          {
+            "key": "telemetry_sdk_version"
+          },
+          {
+            "key": "service_name"
+          },
+          {
             "key": "foo"
           }
         ],

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"net/url"
 	"path"
-	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -65,8 +64,7 @@ type MetricsExporter struct {
 // metricMapper is the part that transforms metrics. Separate from MetricsExporter since it has
 // all pure functions.
 type metricMapper struct {
-	cfg            Config
-	resourceFilter *regexp.Regexp
+	cfg Config
 }
 
 // Constants we use when translating summary metrics into GCP.
@@ -122,19 +120,11 @@ func NewGoogleCloudMetricsExporter(
 		return nil, err
 	}
 
-	resourceFilter, err := regexp.Compile(cfg.MetricConfig.ResourceFilter)
-	if err != nil {
-		return nil, err
-	}
-
 	mExp := &MetricsExporter{
 		cfg:    cfg,
 		client: client,
 		obs:    selfObservability{log: log},
-		mapper: metricMapper{
-			cfg:            cfg,
-			resourceFilter: resourceFilter,
-		},
+		mapper: metricMapper{cfg: cfg},
 		// We create a buffered channel for metric descriptors.
 		// MetricDescritpors are asycnhronously sent and optimistic.
 		// We only get Unit/Description/Display name from them, so it's ok

--- a/exporter/collector/monitoredresource_test.go
+++ b/exporter/collector/monitoredresource_test.go
@@ -15,7 +15,6 @@
 package collector
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +85,7 @@ func TestResourceMetricsToMonitoredResource(t *testing.T) {
 		{
 			name: "GCE with resource filter config",
 			updateMapper: func(mapper *metricMapper) {
-				mapper.resourceFilter = regexp.MustCompile(`cloud\..*`)
+				mapper.cfg.MetricConfig.ResourceFilters = []ResourceFilter{{Prefix: "cloud."}}
 			},
 			resourceLabels: map[string]string{
 				"cloud.platform":          "gcp_compute_engine",
@@ -370,7 +369,7 @@ func TestResourceMetricsToMonitoredResource(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mapper := metricMapper{cfg: DefaultConfig(), resourceFilter: emptyRe}
+			mapper := metricMapper{cfg: DefaultConfig()}
 			if test.updateMapper != nil {
 				test.updateMapper(&mapper)
 			}


### PR DESCRIPTION
Copy OTel Resource attributes `service.name`, `service.namespace` and `service.instance.id` into metric labels by default. This avoids duplicate timeseries when multiple instances of a service are running on a single monitored resource, for example running multiple service processes on a single GCE VM. Added a config option `metric.include_service_resource_attributes` to control this.

Also added a `metric.resource_filters` config option which which allows copying certain resource attributes onto metrics. This has been asked for in our trace exporters (https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/347, https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/145, https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/221 maybe). It may be necessary for users to configure this also when the `service.name,service.namespace,service.instance.id` triplet is not present to distinguish duplicate time series.