### PR TITLE
Retract exporter/metric@v1.0.0-RC1

### DIFF
--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -21,3 +21,5 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
+
+retract v1.0.0-RC1


### PR DESCRIPTION
exporter/metric was incorrectly tagged at v1.0.0-RC1.

Issue: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/291