### PR TITLE
Drop data points with start and end time too close together

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -52,9 +52,9 @@ behavior, please open an issue.
 
 ## Time staggering
 
-The [OTel datamodel specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#resets-and-gaps) an equal start and end time on a cumulative metric indicate a reset timeseries:
+According to the [OTel datamodel specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#resets-and-gaps), an equal start and end time on a cumulative metric indicate a reset timeseries:
 
-```When StartTimeUnixNano equals TimeUnixNano, a new unbroken sequence of observations begins with a reset at an unknown start time. The initial observed value is recorded to indicate that an unbroken sequence of observations resumes. These points have zero duration, and indicate that nothing is known about previously-reported points and that data may have been lost.```
+> When StartTimeUnixNano equals TimeUnixNano, a new unbroken sequence of observations begins with a reset at an unknown start time. The initial observed value is recorded to indicate that an unbroken sequence of observations resumes. These points have zero duration, and indicate that nothing is known about previously-reported points and that data may have been lost.
 
 The OpenCensus-based exporter took points with identical start and end times, and added a millisecond to the end time: https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/287.  However, the resulting point makes little sense: It has a very small time period, and a normal cumulative value for an interval.  The result is that graphs display a very large rate over that millisecond, which is misleading.
 

--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -50,6 +50,16 @@ For now, it is not possible to customizate the mapping algorithm, beyond using t
 in the collector pipeline before the exporter. If you have a use case for customizing the
 behavior, please open an issue.
 
+## Time staggering
+
+The [OTel datamodel specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#resets-and-gaps) an equal start and end time on a cumulative metric indicate a reset timeseries:
+
+```When StartTimeUnixNano equals TimeUnixNano, a new unbroken sequence of observations begins with a reset at an unknown start time. The initial observed value is recorded to indicate that an unbroken sequence of observations resumes. These points have zero duration, and indicate that nothing is known about previously-reported points and that data may have been lost.```
+
+The OpenCensus-based exporter took points with identical start and end times, and added a millisecond to the end time: https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/287.  However, the resulting point makes little sense: It has a very small time period, and a normal cumulative value for an interval.  The result is that graphs display a very large rate over that millisecond, which is misleading.
+
+This exporter instead drops points with identical start and end times.  Resets are already indicated by a change in the start timestamp for the subsequent point.
+
 ## Labels
 
 Original label key mapping code is

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -43,10 +43,21 @@ func TestMetricToTimeSeries(t *testing.T) {
 		sum := metric.Sum()
 		sum.SetIsMonotonic(true)
 		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+		startTs := pdata.NewTimestampFromTime(start)
+		endTs := pdata.NewTimestampFromTime(start.Add(time.Hour))
 		// Add three points
-		sum.DataPoints().AppendEmpty().SetDoubleVal(10)
-		sum.DataPoints().AppendEmpty().SetDoubleVal(15)
-		sum.DataPoints().AppendEmpty().SetDoubleVal(16)
+		point := sum.DataPoints().AppendEmpty()
+		point.SetDoubleVal(10)
+		point.SetStartTimestamp(startTs)
+		point.SetTimestamp(endTs)
+		point = sum.DataPoints().AppendEmpty()
+		point.SetDoubleVal(15)
+		point.SetStartTimestamp(startTs)
+		point.SetTimestamp(endTs)
+		point = sum.DataPoints().AppendEmpty()
+		point.SetDoubleVal(16)
+		point.SetStartTimestamp(startTs)
+		point.SetTimestamp(endTs)
 
 		ts := mapper.metricToTimeSeries(
 			mr,
@@ -467,6 +478,7 @@ func TestSummaryPointToTimeSeries(t *testing.T) {
 	quantile.SetValue(1.0)
 	end := start.Add(time.Hour)
 	point.SetTimestamp(pdata.NewTimestampFromTime(end))
+	point.SetStartTimestamp(pdata.NewTimestampFromTime(start))
 	ts := mapper.metricToTimeSeries(mr, labels{}, metric)
 	assert.Len(t, ts, 3)
 	sumResult := ts[0]


### PR DESCRIPTION
See breaking-changes.md for the rationale for this change.