### PR TITLE
Reenable disabled metrics test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(UNAME_S),Darwin)
 	endif
 endif
 
-GOTEST_MIN = go test -v -timeout 60s
+GOTEST_MIN = go test -v -timeout 70s
 GOTEST = $(GOTEST_MIN) -race
 GOTEST_WITH_COVERAGE = $(GOTEST) -coverprofile=coverage.txt -covermode=atomic
 


### PR DESCRIPTION
This fixes a TODO.

There is one change in behavior that I want to double-check is intentional:  The MetricDescriptor.Name used to be the format:  `projects/<project>/metricDescriptors/<prefix>/<metric name>`.  Now, the MetricDescriptor.Name appears to be just <metric name>.