### PR TITLE
Remove Known Domains

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -43,10 +43,11 @@ type Config struct {
 }
 
 type MetricConfig struct {
+	// Prefix is attached to all metrics sent by this exporter.
+	// Disable prefixes by setting it to "".
+	// Defaults to "workload.googleapis.com".
 	Prefix                     string `mapstructure:"prefix"`
 	SkipCreateMetricDescriptor bool   `mapstructure:"skip_create_descriptor"`
-	// If a metric belongs to one of these domains it does not get a prefix.
-	KnownDomains []string `mapstructure:"known_domains"`
 
 	// If true, set the instrumentation_source and instrumentation_version
 	// labels. Defaults to true.
@@ -77,15 +78,11 @@ type LabelMapping struct {
 	Optional bool `mapstructure:"optional"`
 }
 
-// Known metric domains. Note: This is now configurable for advanced usages.
-var domains = []string{"googleapis.com", "kubernetes.io", "istio.io", "knative.dev"}
-
 // DefaultConfig creates the default configuration for exporter.
 func DefaultConfig() Config {
 	return Config{
 		UserAgent: "opentelemetry-collector-contrib {{version}}",
 		MetricConfig: MetricConfig{
-			KnownDomains:                     domains,
 			Prefix:                           "workload.googleapis.com",
 			CreateMetricDescriptorBufferSize: 10,
 			InstrumentationLibraryLabels:     true,

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -81,11 +81,8 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				MetricConfig: collector.MetricConfig{
-					Prefix:                     "prefix",
-					SkipCreateMetricDescriptor: true,
-					KnownDomains: []string{
-						"googleapis.com", "kubernetes.io", "istio.io", "knative.dev",
-					},
+					Prefix:                           "prefix",
+					SkipCreateMetricDescriptor:       true,
 					InstrumentationLibraryLabels:     true,
 					CreateMetricDescriptorBufferSize: 10,
 				},

--- a/exporter/collector/integrationtest/testcases.go
+++ b/exporter/collector/integrationtest/testcases.go
@@ -67,6 +67,7 @@ var (
 				// Previous exporter did NOT export metric descriptors.
 				// TODO: Add a new test that also checks metric descriptors.
 				cfg.MetricConfig.SkipCreateMetricDescriptor = true
+				cfg.MetricConfig.Prefix = ""
 			},
 		},
 		{
@@ -77,6 +78,7 @@ var (
 				// Previous exporter did NOT export metric descriptors.
 				// TODO: Add a new test that also checks metric descriptors.
 				cfg.MetricConfig.SkipCreateMetricDescriptor = true
+				cfg.MetricConfig.Prefix = ""
 			},
 		},
 		{
@@ -84,7 +86,6 @@ var (
 			OTLPInputFixturePath: "testdata/fixtures/workload_metrics.json",
 			ExpectFixturePath:    "testdata/fixtures/workload_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
-				cfg.MetricConfig.Prefix = "workload.googleapis.com/"
 				cfg.MetricConfig.SkipCreateMetricDescriptor = true
 			},
 		},
@@ -94,6 +95,7 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/gke_metrics_agent_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+				cfg.MetricConfig.Prefix = ""
 			},
 		},
 		{
@@ -102,6 +104,7 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/gke_control_plane_metrics_agent_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+				cfg.MetricConfig.Prefix = ""
 			},
 		},
 		{
@@ -115,6 +118,7 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/create_service_timeseries_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+				cfg.MetricConfig.Prefix = ""
 			},
 		},
 	}

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -740,19 +740,9 @@ func (m *metricMapper) gaugePointToTimeSeries(
 	}
 }
 
-// Returns any configured prefix to add to unknown metric name.
-func (m *metricMapper) getMetricNamePrefix(name string) string {
-	for _, domain := range m.cfg.MetricConfig.KnownDomains {
-		if strings.Contains(name, domain) {
-			return ""
-		}
-	}
-	return m.cfg.MetricConfig.Prefix
-}
-
 // metricNameToType maps OTLP metric name to GCM metric type (aka name)
 func (m *metricMapper) metricNameToType(name string) string {
-	return path.Join(m.getMetricNamePrefix(name), name)
+	return path.Join(m.cfg.MetricConfig.Prefix, name)
 }
 
 func numberDataPointToValue(

--- a/exporter/collector/metricsexporter_test.go
+++ b/exporter/collector/metricsexporter_test.go
@@ -15,7 +15,6 @@
 package collector
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -617,7 +616,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			metricCreator: func() pdata.Metric {
 				metric := pdata.NewMetric()
 				metric.SetDataType(pdata.MetricDataTypeGauge)
-				metric.SetName("custom.googleapis.com/test.metric")
+				metric.SetName("test.metric")
 				metric.SetDescription("Description")
 				metric.SetUnit("1")
 				gauge := metric.Gauge()
@@ -628,9 +627,9 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			},
 			expected: []*metricpb.MetricDescriptor{
 				{
-					Name:        "custom.googleapis.com/test.metric",
+					Name:        "test.metric",
 					DisplayName: "test.metric",
-					Type:        "custom.googleapis.com/test.metric",
+					Type:        "workload.googleapis.com/test.metric",
 					MetricKind:  metricpb.MetricDescriptor_GAUGE,
 					ValueType:   metricpb.MetricDescriptor_DOUBLE,
 					Unit:        "1",
@@ -648,7 +647,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			metricCreator: func() pdata.Metric {
 				metric := pdata.NewMetric()
 				metric.SetDataType(pdata.MetricDataTypeSum)
-				metric.SetName("custom.googleapis.com/test.metric")
+				metric.SetName("test.metric")
 				metric.SetDescription("Description")
 				metric.SetUnit("1")
 				sum := metric.Sum()
@@ -661,9 +660,9 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			},
 			expected: []*metricpb.MetricDescriptor{
 				{
-					Name:        "custom.googleapis.com/test.metric",
+					Name:        "test.metric",
 					DisplayName: "test.metric",
-					Type:        "custom.googleapis.com/test.metric",
+					Type:        "workload.googleapis.com/test.metric",
 					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
 					ValueType:   metricpb.MetricDescriptor_DOUBLE,
 					Unit:        "1",
@@ -862,7 +861,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			metricCreator: func() pdata.Metric {
 				metric := pdata.NewMetric()
 				metric.SetDataType(pdata.MetricDataTypeGauge)
-				metric.SetName("custom.googleapis.com/test.metric")
+				metric.SetName("test.metric")
 				metric.SetDescription("Description")
 				metric.SetUnit("1")
 				gauge := metric.Gauge()
@@ -876,9 +875,9 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			},
 			expected: []*metricpb.MetricDescriptor{
 				{
-					Name:        "custom.googleapis.com/test.metric",
+					Name:        "test.metric",
 					DisplayName: "test.metric",
-					Type:        "custom.googleapis.com/test.metric",
+					Type:        "workload.googleapis.com/test.metric",
 					MetricKind:  metricpb.MetricDescriptor_GAUGE,
 					ValueType:   metricpb.MetricDescriptor_DOUBLE,
 					Unit:        "1",
@@ -897,59 +896,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 			mapper := metricMapper{cfg: DefaultConfig()}
 			metric := test.metricCreator()
 			md := mapper.metricDescriptor(metric)
-			assert.Equal(t, md, test.expected)
-		})
-	}
-}
-
-type knownDomainsTest struct {
-	name         string
-	metricType   string
-	knownDomains []string
-}
-
-func TestKnownDomains(t *testing.T) {
-	tests := []knownDomainsTest{
-		{
-			name:       "test",
-			metricType: "prefix/test",
-		},
-		{
-			name:       "googleapis.com/test",
-			metricType: "googleapis.com/test",
-		},
-		{
-			name:       "kubernetes.io/test",
-			metricType: "kubernetes.io/test",
-		},
-		{
-			name:       "istio.io/test",
-			metricType: "istio.io/test",
-		},
-		{
-			name:       "knative.dev/test",
-			metricType: "knative.dev/test",
-		},
-		{
-			name:         "knative.dev/test",
-			metricType:   "prefix/knative.dev/test",
-			knownDomains: []string{"example.com"},
-		},
-		{
-			name:         "example.com/test",
-			metricType:   "example.com/test",
-			knownDomains: []string{"example.com"},
-		},
-	}
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%v to %v", test.name, test.metricType), func(t *testing.T) {
-			config := DefaultConfig()
-			config.MetricConfig.Prefix = "prefix"
-			if len(test.knownDomains) > 0 {
-				config.MetricConfig.KnownDomains = test.knownDomains
-			}
-			mapper := metricMapper{cfg: config}
-			assert.Equal(t, test.metricType, mapper.metricNameToType(test.name))
+			assert.Equal(t, test.expected, md)
 		})
 	}
 }


### PR DESCRIPTION
`known_domains` was originally added in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/247 because we wanted to support attaching a prefix only to some metrics.  However, on other topics (create service timeseries, create metric descriptor, etc), we decided to make behavior explicitly configurable instead of implicit based on metric domain.

I think we should consider making metric prefixing also an explicitly-configurable behavior, which would mean there is no domain-specific behavior in the collector exporter.  Prefix = "" would disable attaching prefixes.

The only question I have is: Are there any use-cases we know of where we need to be able to mix metrics with/without a domain?

Marking as draft until we have had a chance to discuss.