### PR TITLE
Split client configuration per-endpoint

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -3,6 +3,29 @@
 The new pdata based exporter has some breaking changes from the original OpenCensus (OC)
 stackdriver based `googlecloud` exporter:
 
+## Configuration
+
+Client-specific configuration, including `endpoint` and `use_insecure` are now separated per-signal.  `resource_mappings` is now nested under `metric`.  For example,
+
+```yaml
+googlecloud:
+  endpoint: test-endpoint
+  use_insecure: true
+  resource_mappings:
+```
+Is now:
+
+```yaml
+googlecloud:
+  trace:
+    endpoint: test-trace-endpoint
+    use_insecure: true
+  metric:
+    endpoint: test-metric-endpoint
+    use_insecure: true
+    resource_mappings:
+```
+
 ## Metric Names and Descriptors
 
 The previous collector exporter would default to sending metrics with the type:

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -28,23 +28,33 @@ const (
 type Config struct {
 	ProjectID string `mapstructure:"project"`
 	UserAgent string `mapstructure:"user_agent"`
-	Endpoint  string `mapstructure:"endpoint"`
+
+	TraceConfig TraceConfig `mapstructure:"trace"`
+
+	MetricConfig MetricConfig `mapstructure:"metric"`
+}
+
+type ClientConfig struct {
+	Endpoint string `mapstructure:"endpoint"`
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
 
-	ResourceMappings []ResourceMapping `mapstructure:"resource_mappings"`
 	// GetClientOptions returns additional options to be passed
 	// to the underlying Google Cloud API client.
 	// Must be set programmatically (no support via declarative config).
 	// Optional.
 	GetClientOptions func() []option.ClientOption
+}
 
-	MetricConfig MetricConfig `mapstructure:"metric"`
+type TraceConfig struct {
+	ClientConfig ClientConfig `mapstructure:",squash"`
 }
 
 type MetricConfig struct {
-	Prefix                     string `mapstructure:"prefix"`
-	SkipCreateMetricDescriptor bool   `mapstructure:"skip_create_descriptor"`
+	ClientConfig               ClientConfig      `mapstructure:",squash"`
+	Prefix                     string            `mapstructure:"prefix"`
+	ResourceMappings           []ResourceMapping `mapstructure:"resource_mappings"`
+	SkipCreateMetricDescriptor bool              `mapstructure:"skip_create_descriptor"`
 	// If a metric belongs to one of these domains it does not get a prefix.
 	KnownDomains []string `mapstructure:"known_domains"`
 

--- a/exporter/collector/googlecloud.go
+++ b/exporter/collector/googlecloud.go
@@ -45,11 +45,11 @@ func setVersionInUserAgent(cfg *Config, version string) {
 	cfg.UserAgent = strings.ReplaceAll(cfg.UserAgent, "{{version}}", version)
 }
 
-func generateClientOptions(cfg *Config) ([]option.ClientOption, error) {
+func generateClientOptions(cfg *ClientConfig, userAgent string) ([]option.ClientOption, error) {
 	var copts []option.ClientOption
 	// option.WithUserAgent is used by the Trace exporter, but not the Metric exporter (see comment below)
-	if cfg.UserAgent != "" {
-		copts = append(copts, option.WithUserAgent(cfg.UserAgent))
+	if userAgent != "" {
+		copts = append(copts, option.WithUserAgent(userAgent))
 	}
 	if cfg.Endpoint != "" {
 		if cfg.UseInsecure {
@@ -59,8 +59,8 @@ func generateClientOptions(cfg *Config) ([]option.ClientOption, error) {
 				grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
 				grpc.WithInsecure(),
 			}
-			if cfg.UserAgent != "" {
-				dialOpts = append(dialOpts, grpc.WithUserAgent(cfg.UserAgent))
+			if userAgent != "" {
+				dialOpts = append(dialOpts, grpc.WithUserAgent(userAgent))
 			}
 			conn, err := grpc.Dial(cfg.Endpoint, dialOpts...)
 			if err != nil {
@@ -86,7 +86,7 @@ func NewGoogleCloudTracesExporter(cfg Config, version string, timeout time.Durat
 		cloudtrace.WithTimeout(timeout),
 	}
 
-	copts, err := generateClientOptions(&cfg)
+	copts, err := generateClientOptions(&cfg.TraceConfig.ClientConfig, cfg.UserAgent)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/collector/googlecloud_test.go
+++ b/exporter/collector/googlecloud_test.go
@@ -65,9 +65,13 @@ func TestGoogleCloudTraceExport(t *testing.T) {
 		{
 			name: "Standard",
 			cfg: Config{
-				ProjectID:   "idk",
-				Endpoint:    "127.0.0.1:8080",
-				UseInsecure: true,
+				ProjectID: "idk",
+				TraceConfig: TraceConfig{
+					ClientConfig: ClientConfig{
+						Endpoint:    "127.0.0.1:8080",
+						UseInsecure: true,
+					},
+				},
 			},
 		},
 	}
@@ -164,11 +168,11 @@ func TestGoogleCloudMetricExport(t *testing.T) {
 
 	config := DefaultConfig()
 	config.ProjectID = "idk"
-	config.Endpoint = "127.0.0.1:8080"
+	config.MetricConfig.ClientConfig.Endpoint = "127.0.0.1:8080"
 	config.UserAgent = "MyAgent {{version}}"
-	config.UseInsecure = true
+	config.MetricConfig.ClientConfig.UseInsecure = true
 	config.MetricConfig.InstrumentationLibraryLabels = false
-	config.GetClientOptions = func() []option.ClientOption {
+	config.MetricConfig.ClientConfig.GetClientOptions = func() []option.ClientOption {
 		// Example with overridden client options
 		return []option.ClientOption{
 			option.WithoutAuthentication(),

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -54,33 +54,19 @@ func TestLoadConfig(t *testing.T) {
 		&testExporterConfig{
 			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "customname")),
 			Config: collector.Config{
-				ProjectID:   "my-project",
-				UserAgent:   "opentelemetry-collector-contrib {{version}}",
-				Endpoint:    "test-endpoint",
-				UseInsecure: true,
-				ResourceMappings: []collector.ResourceMapping{
-					{
-						SourceType: "source.resource1",
-						TargetType: "target-resource1",
-						LabelMappings: []collector.LabelMapping{
-							{
-								SourceKey: "contrib.opencensus.io/exporter/googlecloud/project_id",
-								TargetKey: "project_id",
-								Optional:  true,
-							},
-							{
-								SourceKey: "source.label1",
-								TargetKey: "target_label_1",
-								Optional:  false,
-							},
-						},
-					},
-					{
-						SourceType: "source.resource2",
-						TargetType: "target-resource2",
+				ProjectID: "my-project",
+				UserAgent: "opentelemetry-collector-contrib {{version}}",
+				TraceConfig: collector.TraceConfig{
+					ClientConfig: collector.ClientConfig{
+						Endpoint:    "test-trace-endpoint",
+						UseInsecure: true,
 					},
 				},
 				MetricConfig: collector.MetricConfig{
+					ClientConfig: collector.ClientConfig{
+						Endpoint:    "test-metric-endpoint",
+						UseInsecure: true,
+					},
 					Prefix:                     "prefix",
 					SkipCreateMetricDescriptor: true,
 					KnownDomains: []string{
@@ -88,6 +74,28 @@ func TestLoadConfig(t *testing.T) {
 					},
 					InstrumentationLibraryLabels:     true,
 					CreateMetricDescriptorBufferSize: 10,
+					ResourceMappings: []collector.ResourceMapping{
+						{
+							SourceType: "source.resource1",
+							TargetType: "target-resource1",
+							LabelMappings: []collector.LabelMapping{
+								{
+									SourceKey: "contrib.opencensus.io/exporter/googlecloud/project_id",
+									TargetKey: "project_id",
+									Optional:  true,
+								},
+								{
+									SourceKey: "source.label1",
+									TargetKey: "target_label_1",
+									Optional:  false,
+								},
+							},
+						},
+						{
+							SourceType: "source.resource2",
+							TargetType: "target-resource2",
+						},
+					},
 				},
 			},
 		})

--- a/exporter/collector/integrationtest/metric_test_server.go
+++ b/exporter/collector/integrationtest/metric_test_server.go
@@ -151,8 +151,8 @@ func (m *MetricsTestServer) NewExporter(
 	t testing.TB,
 	cfg collector.Config,
 ) *collector.MetricsExporter {
-	cfg.Endpoint = m.Endpoint
-	cfg.UseInsecure = true
+	cfg.MetricConfig.ClientConfig.Endpoint = m.Endpoint
+	cfg.MetricConfig.ClientConfig.UseInsecure = true
 	cfg.ProjectID = "fakeprojectid"
 
 	exporter, err := collector.NewGoogleCloudMetricsExporter(
@@ -163,6 +163,6 @@ func (m *MetricsTestServer) NewExporter(
 		collector.DefaultTimeout,
 	)
 	require.NoError(t, err)
-	t.Logf("Collector MetricsTestServer exporter started, pointing at %v", cfg.Endpoint)
+	t.Logf("Collector MetricsTestServer exporter started, pointing at %v", cfg.MetricConfig.ClientConfig.Endpoint)
 	return exporter
 }

--- a/exporter/collector/integrationtest/testdata/config.yaml
+++ b/exporter/collector/integrationtest/testdata/config.yaml
@@ -8,21 +8,24 @@ exporters:
   googlecloud:
   googlecloud/customname:
     project: my-project
-    endpoint: test-endpoint
     user_agent: opentelemetry-collector-contrib {{version}}
-    use_insecure: true
-    resource_mappings:
-      - source_type: source.resource1
-        target_type: target-resource1
-        label_mappings:
-          - source_key: contrib.opencensus.io/exporter/googlecloud/project_id
-            target_key: project_id
-            optional: true
-          - source_key: source.label1
-            target_key: target_label_1
-      - source_type: source.resource2
-        target_type: target-resource2
+    trace:
+      endpoint: test-trace-endpoint
+      use_insecure: true
     metric:
+      endpoint: test-metric-endpoint
+      use_insecure: true
+      resource_mappings:
+        - source_type: source.resource1
+          target_type: target-resource1
+          label_mappings:
+            - source_key: contrib.opencensus.io/exporter/googlecloud/project_id
+              target_key: project_id
+              optional: true
+            - source_key: source.label1
+              target_key: target_label_1
+        - source_type: source.resource2
+          target_type: target-resource2
       prefix: prefix
       skip_create_descriptor: true
 

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -142,7 +142,7 @@ func NewGoogleCloudMetricsExporter(
 		cfg.ProjectID = creds.ProjectID
 	}
 
-	clientOpts, err := generateClientOptions(&cfg)
+	clientOpts, err := generateClientOptions(&cfg.MetricConfig.ClientConfig, cfg.UserAgent)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Second attempt at https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/298