### PR TITLE
Update collector docs to remove recommendation of using the batch pro…

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -44,7 +44,6 @@ These instructions are to get you up and running quickly with the GCP exporter i
     processors:
       memory_limiter:
       batch:
-        # Google Cloud Monitoring limits batches to 200 metric points.
         send_batch_max_size: 200
         send_batch_size: 200
     service:
@@ -55,7 +54,7 @@ These instructions are to get you up and running quickly with the GCP exporter i
           exporters: [googlecloud, logging]
         metrics:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter]
           exporters: [googlecloud, logging]
     ```
 


### PR DESCRIPTION
Update collector docs to remove recommendation of using the batch processor

BUG=216620312

This is a reopening of https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/303. Reusing that PR is not possible as the base repo was deleted.