### PR TITLE
Convert OTel Resource into metric labels

### DIFF
--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -71,7 +71,7 @@ In addition, the exporter will now copy OTel Resource attributes `service.name`,
 `service_namespace`, and `service_instance_id` respectively. This avoids duplicate timeseries
 when multiple instances of a service are running on a single monitored resource, for example
 running multiple service processes on a single GCE VM.  This can be turned off with the
-`metric.include_service_resource_attributes` config option.
+`metric.service_resource_labels` config option.
 
 ## OTLP Sum
 

--- a/exporter/collector/breaking-changes.md
+++ b/exporter/collector/breaking-changes.md
@@ -66,6 +66,13 @@ The new code does not:
 - truncate label keys longer than 100 characters.
 - prepend `key` when the first character is `_`.
 
+In addition, the exporter will now copy OTel Resource attributes `service.name`,
+`service.namespace` and `service.instance.id` into metric labels `service_name`,
+`service_namespace`, and `service_instance_id` respectively. This avoids duplicate timeseries
+when multiple instances of a service are running on a single monitored resource, for example
+running multiple service processes on a single GCE VM.  This can be turned off with the
+`metric.include_service_resource_attributes` config option.
+
 ## OTLP Sum
 
 In the old exporter, delta sums were converted into GAUGE points ([see test

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -63,7 +63,8 @@ type MetricConfig struct {
 	// If true, the exporter will copy OTel's service.name, service.namespace, and
 	// service.instance.id resource attributes into the GCM timeseries metric labels. This
 	// option is recommended to avoid writing duplicate timeseries against the same monitored
-	// resource. Default is true.
+	// resource. Disabling this option does not prevent resource_filters from adding those
+	// labels. Default is true.
 	ServiceResourceLabels bool `mapstructure:"service_resource_labels"`
 
 	// If provided, resource attributes matching any filter will be included in metric labels.

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -59,6 +59,22 @@ type MetricConfig struct {
 	// Buffer size for the channel which asynchronously calls CreateMetricDescriptor. Default
 	// is 10.
 	CreateMetricDescriptorBufferSize int `mapstructure:"create_metric_descriptor_buffer_size"`
+
+	// If true, the exporter will copy OTel's service.name, service.namespace, and
+	// service.instance.id resource attributes into the GCM timeseries metric labels. This
+	// option is recommended to avoid writing duplicate timeseries against the same monitored
+	// resource. Default is true.
+	ServiceResourceLabels bool `mapstructure:"service_resource_labels"`
+
+	// If provided, resource attributes matching any filter will be included in metric labels.
+	// Defaults to empty, which won't include any additional resource labels. Note that the
+	// service_resource_labels option operates independently from resource_filters.
+	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
+}
+
+type ResourceFilter struct {
+	// Match resource keys by prefix
+	Prefix string `mapstructure:"prefix"`
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Google Cloud).
@@ -89,6 +105,7 @@ func DefaultConfig() Config {
 			Prefix:                           "workload.googleapis.com",
 			CreateMetricDescriptorBufferSize: 10,
 			InstrumentationLibraryLabels:     true,
+			ServiceResourceLabels:            true,
 		},
 	}
 }

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -22,6 +22,7 @@ require (
 require (
 	cloud.google.com/go/monitoring v1.1.0
 	github.com/aws/aws-sdk-go v1.42.14 // indirect
+	github.com/google/go-cmp v0.5.6
 	go.uber.org/zap v1.19.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -88,6 +88,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					InstrumentationLibraryLabels:     true,
 					CreateMetricDescriptorBufferSize: 10,
+					ServiceResourceLabels:            true,
 				},
 			},
 		})

--- a/exporter/collector/integrationtest/testcase.go
+++ b/exporter/collector/integrationtest/testcase.go
@@ -217,9 +217,14 @@ func normalizeTimeSeriesReqs(t testing.TB, reqs ...*monitoringpb.CreateTimeSerie
 func normalizeMetricDescriptorReqs(t testing.TB, reqs ...*monitoringpb.CreateMetricDescriptorRequest) {
 	for _, req := range reqs {
 		req.Name = ""
-		if req.MetricDescriptor != nil {
-			req.MetricDescriptor.Name = ""
+		if req.MetricDescriptor == nil {
+			continue
 		}
+		md := req.MetricDescriptor
+		md.Name = ""
+		sort.Slice(md.Labels, func(i, j int) bool {
+			return md.Labels[i].Key < md.Labels[j].Key
+		})
 	}
 }
 

--- a/exporter/collector/integrationtest/testcases.go
+++ b/exporter/collector/integrationtest/testcases.go
@@ -67,6 +67,7 @@ var (
 				// Previous exporter did NOT export metric descriptors.
 				// TODO: Add a new test that also checks metric descriptors.
 				cfg.MetricConfig.SkipCreateMetricDescriptor = true
+				cfg.MetricConfig.ServiceResourceLabels = false
 			},
 		},
 		{
@@ -102,6 +103,7 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/gke_control_plane_metrics_agent_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+				cfg.MetricConfig.ServiceResourceLabels = false
 			},
 		},
 		{
@@ -115,6 +117,16 @@ var (
 			ExpectFixturePath:    "testdata/fixtures/create_service_timeseries_metrics_expect.json",
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.CreateServiceTimeSeries = true
+			},
+		},
+		{
+			Name:                 "WithResourceFilter",
+			OTLPInputFixturePath: "testdata/fixtures/with_resource_filter_metrics.json",
+			ExpectFixturePath:    "testdata/fixtures/with_resource_filter_metrics_expect.json",
+			Configure: func(cfg *collector.Config) {
+				cfg.MetricConfig.ResourceFilters = []collector.ResourceFilter{
+					{Prefix: "telemetry.sdk."},
+				}
 			},
 		},
 	}

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics.json
@@ -1,0 +1,77 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "foo-service"
+            }
+          },
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "foo"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "abc123"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "java"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.1.1"
+            }
+          },
+          {
+            "key": "something.uninteresting",
+            "value": {
+              "stringValue": "baz"
+            }
+          }
+        ]
+      },
+      "instrumentationLibraryMetrics": [
+        {
+          "instrumentationLibrary": {},
+          "metrics": [
+            {
+              "name": "testresourcefilter",
+              "description": "This is a test counter",
+              "unit": "1",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "foo",
+                        "value": {
+                          "stringValue": "bar"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1634322229906722370",
+                    "timeUnixNano": "1634322234906722370",
+                    "asInt": "253"
+                  }
+                ],
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                "isMonotonic": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
@@ -1,0 +1,700 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/testresourcefilter",
+            "labels": {
+              "foo": "bar",
+              "service_instance_id": "abc123",
+              "service_name": "foo-service",
+              "service_namespace": "foo",
+              "telemetry_sdk_language": "java",
+              "telemetry_sdk_version": "1.1.1"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "foo-service",
+              "location": "global",
+              "namespace": "foo",
+              "task_id": "abc123"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ],
+          "unit": "1"
+        }
+      ]
+    }
+  ],
+  "createMetricDescriptorRequests": [
+    {
+      "metricDescriptor": {
+        "type": "workload.googleapis.com/testresourcefilter",
+        "labels": [
+          {
+            "key": "foo"
+          },
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          },
+          {
+            "key": "service_namespace"
+          },
+          {
+            "key": "telemetry_sdk_language"
+          },
+          {
+            "key": "telemetry_sdk_version"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "INT64",
+        "unit": "1",
+        "description": "This is a test counter",
+        "displayName": "testresourcefilter"
+      }
+    }
+  ],
+  "selfObservabilityMetrics": {
+    "createTimeSeriesRequests": [
+      {
+        "timeSeries": [
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+              "labels": {
+                "status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "createMetricDescriptorRequests": [
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+          "labels": [
+            {
+              "key": "status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of metric points written to Cloud Monitoring.",
+          "displayName": "OpenCensus/googlecloudmonitoring/point_count"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            },
+            {
+              "key": "grpc_client_status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of RPCs by method and status.",
+          "displayName": "OpenCensus/grpc.io/client/completed_rpcs"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes received per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/received_bytes_per_rpc"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "ms",
+          "description": "Distribution of round-trip latency, by method.",
+          "displayName": "OpenCensus/grpc.io/client/roundtrip_latency"
+        }
+      },
+      {
+        "metricDescriptor": {
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes sent per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/sent_bytes_per_rpc"
+        }
+      }
+    ]
+  }
+}

--- a/exporter/collector/metricsexporter.go
+++ b/exporter/collector/metricsexporter.go
@@ -156,7 +156,7 @@ func NewGoogleCloudMetricsExporter(
 		cfg:    cfg,
 		client: client,
 		obs:    selfObservability{log: log},
-		mapper: metricMapper{cfg: cfg},
+		mapper: metricMapper{cfg},
 		// We create a buffered channel for metric descriptors.
 		// MetricDescritpors are asychronously sent and optimistic.
 		// We only get Unit/Description/Display name from them, so it's ok

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -15,6 +15,8 @@
 package collector
 
 import (
+	"strings"
+
 	"go.opentelemetry.io/collector/model/pdata"
 	semconv "go.opentelemetry.io/collector/model/semconv/v1.8.0"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
@@ -113,50 +115,51 @@ var (
 	}
 )
 
-// Transforms pdata Resource to a GCM Monitored Resource. Any resource attributes not accounted
-// for in the monitored resource which should be merged into metric labels are also returned.
-func (m *metricMapper) resourceMetricsToMonitoredResource(
+// Transforms pdata Resource to a GCM Monitored Resource. Any additional metric labels from the
+// resource are also returned.
+func (m *metricMapper) resourceToMonitoredResource(
 	resource pdata.Resource,
 ) (*monitoredrespb.MonitoredResource, labels) {
 	attrs := resource.Attributes()
 	cloudPlatform := getStringOrEmpty(attrs, semconv.AttributeCloudPlatform)
 
+	var mr *monitoredrespb.MonitoredResource
 	switch cloudPlatform {
 	case semconv.AttributeCloudPlatformGCPComputeEngine:
-		return createMonitoredResource(gceInstance, attrs)
+		mr = createMonitoredResource(gceInstance, attrs)
 	case semconv.AttributeCloudPlatformGCPKubernetesEngine:
 		// Try for most to least specific k8s_container, k8s_pod, etc
 		if _, ok := attrs.Get(semconv.AttributeK8SContainerName); ok {
-			return createMonitoredResource(k8sContainer, attrs)
+			mr = createMonitoredResource(k8sContainer, attrs)
 		} else if _, ok := attrs.Get(semconv.AttributeK8SPodName); ok {
-			return createMonitoredResource(k8sPod, attrs)
+			mr = createMonitoredResource(k8sPod, attrs)
 		} else if _, ok := attrs.Get(semconv.AttributeK8SNodeName); ok {
-			return createMonitoredResource(k8sNode, attrs)
+			mr = createMonitoredResource(k8sNode, attrs)
+		} else {
+			mr = createMonitoredResource(k8sCluster, attrs)
 		}
-		return createMonitoredResource(k8sCluster, attrs)
 	case semconv.AttributeCloudPlatformAWSEC2:
-		return createMonitoredResource(awsEc2Instance, attrs)
+		mr = createMonitoredResource(awsEc2Instance, attrs)
 	default:
 		// Fallback to generic_task
 		_, hasServiceName := attrs.Get(semconv.AttributeServiceName)
 		_, hasServiceInstanceID := attrs.Get(semconv.AttributeServiceInstanceID)
 		if hasServiceName && hasServiceInstanceID {
-			return createMonitoredResource(genericTask, attrs)
+			mr = createMonitoredResource(genericTask, attrs)
+		} else {
+			// If not possible, fallback to generic_node
+			mr = createMonitoredResource(genericNode, attrs)
 		}
-
-		// If not possible, fallback to generic_node
-		return createMonitoredResource(genericNode, attrs)
 	}
+	return mr, m.resourceToMetricLabels(resource)
 }
 
 func createMonitoredResource(
 	monitoredResourceType string,
 	resourceAttrs pdata.AttributeMap,
-) (*monitoredrespb.MonitoredResource, labels) {
+) *monitoredrespb.MonitoredResource {
 	mappings := monitoredResourceMappings[monitoredResourceType]
 	mrLabels := make(map[string]string, len(mappings))
-	// TODO handle extra labels
-	extraLabels := labels{}
 
 	for mrKey, mappingConfig := range mappings {
 		mrValue := ""
@@ -173,10 +176,37 @@ func createMonitoredResource(
 		mrLabels[mrKey] = mrValue
 	}
 	return &monitoredrespb.MonitoredResource{
-			Type:   monitoredResourceType,
-			Labels: mrLabels,
-		},
-		extraLabels
+		Type:   monitoredResourceType,
+		Labels: mrLabels,
+	}
+}
+
+// resourceToMetricLabels converts the Resource into metric labels needed to uniquely identify
+// the timeseries.
+func (m *metricMapper) resourceToMetricLabels(
+	resource pdata.Resource,
+) labels {
+	attrs := pdata.NewAttributeMap()
+	resource.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+		// Is a service attribute and should be included
+		match := m.cfg.MetricConfig.ServiceResourceLabels &&
+			(k == semconv.AttributeServiceName ||
+				k == semconv.AttributeServiceNamespace ||
+				k == semconv.AttributeServiceInstanceID)
+		// Matches one of the resource filters
+		for _, resourceFilter := range m.cfg.MetricConfig.ResourceFilters {
+			if match {
+				break
+			}
+			match = strings.HasPrefix(k, resourceFilter.Prefix)
+		}
+
+		if match {
+			attrs.Insert(k, v)
+		}
+		return true
+	})
+	return attributesToLabels(attrs)
 }
 
 func getStringOrEmpty(attributes pdata.AttributeMap, key string) string {

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -189,20 +189,19 @@ func (m *metricMapper) resourceToMetricLabels(
 	attrs := pdata.NewAttributeMap()
 	resource.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
 		// Is a service attribute and should be included
-		match := m.cfg.MetricConfig.ServiceResourceLabels &&
+		if m.cfg.MetricConfig.ServiceResourceLabels &&
 			(k == semconv.AttributeServiceName ||
 				k == semconv.AttributeServiceNamespace ||
-				k == semconv.AttributeServiceInstanceID)
+				k == semconv.AttributeServiceInstanceID) {
+			attrs.Insert(k, v)
+			return true
+		}
 		// Matches one of the resource filters
 		for _, resourceFilter := range m.cfg.MetricConfig.ResourceFilters {
-			if match {
-				break
+			if strings.HasPrefix(k, resourceFilter.Prefix) {
+				attrs.Insert(k, v)
+				return true
 			}
-			match = strings.HasPrefix(k, resourceFilter.Prefix)
-		}
-
-		if match {
-			attrs.Insert(k, v)
 		}
 		return true
 	})


### PR DESCRIPTION
Remake of #287 against main branch

Copy OTel Resource attributes `service.name`, `service.namespace` and `service.instance.id` into metric labels by default. This avoids duplicate timeseries when multiple instances of a service are running on a single monitored resource, for example running multiple service processes on a single GCE VM. Added a config option `metric.service_resource_labels` to control this.

Also added a `metric.resource_filters` config option which which allows copying certain resource attributes onto metrics. This has been asked for in our trace exporters (https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/347, https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/145, https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/221 maybe). It may be necessary for users to configure this also when the `service.name,service.namespace,service.instance.id` triplet is not present to distinguish duplicate time series.