### PR TITLE
Update release.go for latest release

### DIFF
--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -13,3 +13,5 @@ require (
 )
 
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace => ../exporter/trace
+
+retract v1.0.0-RC1

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -12,3 +12,9 @@ require (
 	go.opentelemetry.io/otel/sdk v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
 )
+
+retract (
+	v1.0.0
+	v1.0.0-RC2
+	v1.0.0-RC1
+)

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,17 +29,19 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.0.0"
-	unstable = "0.24.0"
+	stable   = "1.3.0"
+	unstable = "0.26.0"
 )
 
 var versions = map[string]string{
 	"":                    stable,
 	"exporter/trace/":     stable,
-	"example/trace/http/": stable,
+	"example/trace/http/": unstable,
 
 	"exporter/metric/": unstable,
 	"example/metric/":  unstable,
+
+	"exporter/collector/": unstable,
 }
 
 type module string


### PR DESCRIPTION
Also, retract stable releases for unstable components.  The trace example still has an unstable dependency, so mark it unstable.