### PR TITLE
Allow users to override useragent

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -35,6 +35,7 @@ import (
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"google.golang.org/api/option"
+	apioption "google.golang.org/api/option"
 	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
@@ -127,7 +128,7 @@ func newMetricExporter(o *options) (*metricExporter, error) {
 		return nil, errBlankProjectID
 	}
 
-	clientOpts := append(o.MonitoringClientOptions, option.WithUserAgent(userAgent))
+	clientOpts := append([]apioption.ClientOption{option.WithUserAgent(userAgent)}, o.MonitoringClientOptions...)
 	ctx := o.Context
 	if ctx == nil {
 		ctx = context.Background()


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/289

Options at the end of the list override options earlier in the list of options, so we need to prepend the user agent.