### PR TITLE
Normalize sums prior to exporting them

### DIFF
--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datapointstorage
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+const gcInterval = 20 * time.Minute
+
+type Cache map[string]usedPoint
+
+type usedPoint struct {
+	point *pdata.NumberDataPoint
+	used  bool
+}
+
+// New instantiates a cache and starts background processes
+func NewCache(shutdown <-chan struct{}) Cache {
+	c := make(Cache)
+	go func() {
+		ticker := time.NewTicker(gcInterval)
+		for c.gc(shutdown, ticker.C) {
+		}
+	}()
+	return c
+}
+
+// Get retrieves the point associated with the identifier, and whether
+// or not it was found
+func (c Cache) Get(identifier string) (*pdata.NumberDataPoint, bool) {
+	point, found := c[identifier]
+	if found {
+		point.used = true
+		c[identifier] = point
+	}
+	return point.point, found
+}
+
+// Set assigns the point to the identifier in the cache
+func (c Cache) Set(identifier string, point *pdata.NumberDataPoint) {
+	c[identifier] = usedPoint{point, true}
+}
+
+// gc garbage collects the cache after the ticker ticks
+func (c Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
+	select {
+	case <-shutdown:
+		return false
+	case <-tickerCh:
+		// garbage collect the cache
+		for id, point := range c {
+			if point.used {
+				// for points that have been used, mark them as unused
+				point.used = false
+				c[id] = point
+			} else {
+				// for points that have not been used, delete points
+				delete(c, id)
+			}
+		}
+	}
+	return true
+}
+
+// Identifier returns the unique string identifier for a metric
+func Identifier(resource *monitoredrespb.MonitoredResource, metric pdata.Metric, labels pdata.AttributeMap) string {
+	var b strings.Builder
+
+	// Resource identifiers
+	fmt.Fprintf(&b, "%v", resource.GetLabels())
+
+	// Metric identifiers
+	fmt.Fprintf(&b, " - %s", metric.Name())
+	labels.Sort().Range(func(k string, v pdata.AttributeValue) bool {
+		fmt.Fprintf(&b, " %s=%s", k, v.AsString())
+		return true
+	})
+	return b.String()
+}

--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -81,14 +81,19 @@ func (c Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
 }
 
 // Identifier returns the unique string identifier for a metric
-func Identifier(resource *monitoredrespb.MonitoredResource, metric pdata.Metric, labels pdata.AttributeMap) string {
+func Identifier(resource *monitoredrespb.MonitoredResource, extraLabels map[string]string, metric pdata.Metric, labels pdata.AttributeMap) string {
 	var b strings.Builder
 
 	// Resource identifiers
-	fmt.Fprintf(&b, "%v", resource.GetLabels())
+	if resource != nil {
+		fmt.Fprintf(&b, "%v", resource.GetLabels())
+	}
+
+	// Instrumentation library labels and additional resource labels
+	fmt.Fprintf(&b, " - %v", extraLabels)
 
 	// Metric identifiers
-	fmt.Fprintf(&b, " - %s", metric.Name())
+	fmt.Fprintf(&b, " - %s -", metric.Name())
 	labels.Sort().Range(func(k string, v pdata.AttributeValue) bool {
 		fmt.Fprintf(&b, " %s=%s", k, v.AsString())
 		return true

--- a/exporter/collector/internal/datapointstorage/datapointcache_test.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache_test.go
@@ -1,0 +1,115 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datapointstorage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestSetAndGet(t *testing.T) {
+	c := make(Cache)
+	c.Set("foo", nil)
+	point, found := c.Get("foo")
+	assert.Nil(t, point)
+	assert.True(t, found)
+
+	point, found = c.Get("bar")
+	assert.Nil(t, point)
+	assert.False(t, found)
+
+	setPoint := pdata.NewNumberDataPoint()
+	c.Set("bar", &setPoint)
+
+	point, found = c.Get("bar")
+	assert.Equal(t, point, &setPoint)
+	assert.True(t, found)
+}
+
+func TestShutdown(t *testing.T) {
+	shutdown := make(chan struct{})
+	c := make(Cache)
+	close(shutdown)
+	// gc should return after shutdown is closed
+	cont := c.gc(shutdown, make(chan time.Time))
+	assert.False(t, cont)
+}
+
+func TestGC(t *testing.T) {
+	shutdown := make(chan struct{})
+	c := make(Cache)
+	fakeTicker := make(chan time.Time)
+
+	c.Set("bar", nil)
+
+	// bar exists since we just set it
+	usedPoint, found := c["bar"]
+	assert.True(t, usedPoint.used)
+	assert.True(t, found)
+
+	// first gc tick marks bar stale
+	go func() {
+		fakeTicker <- time.Now()
+	}()
+	cont := c.gc(shutdown, fakeTicker)
+	assert.True(t, cont)
+	usedPoint, found = c["bar"]
+	assert.False(t, usedPoint.used)
+	assert.True(t, found)
+
+	// second gc tick removes bar
+	go func() {
+		fakeTicker <- time.Now()
+	}()
+	cont = c.gc(shutdown, fakeTicker)
+	assert.True(t, cont)
+	_, found = c["bar"]
+	assert.False(t, found)
+}
+
+func TestGetPreventsGC(t *testing.T) {
+	shutdown := make(chan struct{})
+	c := make(Cache)
+	fakeTicker := make(chan time.Time)
+
+	setPoint := pdata.NewNumberDataPoint()
+	c.Set("bar", &setPoint)
+
+	// bar exists since we just set it
+	_, found := c["bar"]
+	assert.True(t, found)
+
+	// first gc tick marks bar stale
+	go func() {
+		fakeTicker <- time.Now()
+	}()
+	cont := c.gc(shutdown, fakeTicker)
+	assert.True(t, cont)
+	// calling Get() marks it fresh again.
+	_, found = c.Get("bar")
+	assert.True(t, found)
+
+	// second gc tick does not remove bar
+	go func() {
+		fakeTicker <- time.Now()
+	}()
+	cont = c.gc(shutdown, fakeTicker)
+	assert.True(t, cont)
+	_, found = c["bar"]
+	assert.True(t, found)
+}

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -672,7 +672,7 @@ func (m *metricMapper) sumPointToTimeSeries(
 	startTime := timestamppb.New(point.StartTimestamp().AsTime())
 	var normalizationPoint *pdata.NumberDataPoint
 	if sum.IsMonotonic() {
-		metricIdentifier := datapointstorage.Identifier(resource, metric, point.Attributes())
+		metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
 		var keep bool
 		normalizationPoint, keep = m.normalizeMetric(point, metricIdentifier)
 		if !keep {

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -114,6 +114,7 @@ func TestMetricToTimeSeries(t *testing.T) {
 		require.Len(t, ts, 2, "Should create one timeseries for each sum point")
 		require.Same(t, ts[0].Resource, mr, "Should assign the passed in monitored resource")
 		require.Equal(t, ts[0].Points[0].Value.GetDoubleValue(), 5.0, "Should normalize the resulting sum")
+		require.Equal(t, ts[0].Points[0].Interval.StartTime, timestamppb.New(start), "Should use the first timestamp as the start time for the rest of the points")
 	})
 
 	t.Run("Sum with reset timestamp", func(t *testing.T) {

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -715,16 +715,14 @@ func TestNumberDataPointToValue(t *testing.T) {
 	point := pdata.NewNumberDataPoint()
 
 	point.SetIntVal(12)
-	value, valueType := numberDataPointToValue(point, nil)
+	value, valueType := numberDataPointToValue(point)
 	assert.Equal(t, valueType, metricpb.MetricDescriptor_INT64)
 	assert.EqualValues(t, value.GetInt64Value(), 12)
 
 	point.SetDoubleVal(12.3)
-	normalizationPoint := pdata.NewNumberDataPoint()
-	normalizationPoint.SetDoubleVal(1)
-	value, valueType = numberDataPointToValue(point, &normalizationPoint)
+	value, valueType = numberDataPointToValue(point)
 	assert.Equal(t, valueType, metricpb.MetricDescriptor_DOUBLE)
-	assert.EqualValues(t, value.GetDoubleValue(), 11.3)
+	assert.EqualValues(t, value.GetDoubleValue(), 12.3)
 }
 
 type metricDescriptorTest struct {


### PR DESCRIPTION
This is based on the [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/tree/master/processor/normalizesumsprocessor), but has a few differences:

* Timeseries are garbage-collected if they are not used after 20 minutes to prevent it from leaking memory
* It converts non-monotonic sums to gauges instead of keeping track of the latest and inserting resets when the value decreases.
* It handles explicit reset points (where start time is after end time).

To implement garbage collection, i've extracted the cache out into its own package.