### PR TITLE
Do not use IsZero on timestamps obtained from pdata

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -737,7 +737,7 @@ func (m *metricMapper) normalizeNumberDataPoint(point pdata.NumberDataPoint, ide
 		}
 		normalizedPoint = &newPoint
 	}
-	if (!ok && point.StartTimestamp().AsTime().IsZero()) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// This is the first time we've seen this metric, or we received
 		// an explicit reset point as described in
 		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	start = time.Unix(0, 0)
+	start = time.Unix(1000, 1000)
 )
 
 func newTestMetricMapper() (metricMapper, func()) {
@@ -586,6 +586,7 @@ func TestSummaryPointToTimeSeries(t *testing.T) {
 	quantile.SetQuantile(1.0)
 	quantile.SetValue(1.0)
 	end := start.Add(time.Hour)
+	point.SetStartTimestamp(pdata.NewTimestampFromTime(start))
 	point.SetTimestamp(pdata.NewTimestampFromTime(end))
 	ts := mapper.metricToTimeSeries(mr, labels{}, metric)
 	assert.Len(t, ts, 3)


### PR DESCRIPTION
Context: https://github.com/open-telemetry/opentelemetry-collector/issues/5102.  It isn't possible to round-trip timestamps before 1970 in the pdata timestamp package.  An unset timestamp would be Timestamp(0), which returns false for AsTime().IsZero()