### PR TITLE
Send summary counts as doubles instead of integers

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/batching_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/batching_metrics_expect.json
@@ -48,7 +48,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -56,7 +56,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -198,7 +198,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -206,7 +206,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -348,7 +348,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -356,7 +356,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -498,7 +498,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -506,7 +506,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -648,7 +648,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -656,7 +656,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -798,7 +798,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -806,7 +806,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -948,7 +948,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -956,7 +956,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1098,7 +1098,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -1106,7 +1106,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1248,7 +1248,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -1256,7 +1256,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1398,7 +1398,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -1406,7 +1406,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1548,7 +1548,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -1556,7 +1556,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1698,7 +1698,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -1706,7 +1706,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1848,7 +1848,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -1856,7 +1856,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -1998,7 +1998,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2006,7 +2006,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -2148,7 +2148,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2156,7 +2156,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -2298,7 +2298,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2306,7 +2306,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -2448,7 +2448,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2456,7 +2456,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -2598,7 +2598,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2606,7 +2606,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -2748,7 +2748,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2756,7 +2756,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -2898,7 +2898,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -2906,7 +2906,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3048,7 +3048,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3056,7 +3056,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3198,7 +3198,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3206,7 +3206,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3348,7 +3348,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3356,7 +3356,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3498,7 +3498,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3506,7 +3506,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3648,7 +3648,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3656,7 +3656,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3798,7 +3798,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3806,7 +3806,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3948,7 +3948,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3956,7 +3956,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4098,7 +4098,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -4106,7 +4106,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4248,7 +4248,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -4256,7 +4256,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4398,7 +4398,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -4406,7 +4406,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4548,7 +4548,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -4556,7 +4556,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4698,7 +4698,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -4706,7 +4706,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4848,7 +4848,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -4856,7 +4856,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -4998,7 +4998,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5006,7 +5006,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -5148,7 +5148,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5156,7 +5156,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -5298,7 +5298,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5306,7 +5306,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -5448,7 +5448,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5456,7 +5456,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -5598,7 +5598,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5606,7 +5606,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -5748,7 +5748,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5756,7 +5756,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -5898,7 +5898,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -5906,7 +5906,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -6052,7 +6052,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -6060,7 +6060,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -6184,7 +6184,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 1_count"
@@ -6233,7 +6233,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 2_count"
@@ -6282,7 +6282,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 3_count"
@@ -6331,7 +6331,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 4_count"
@@ -6380,7 +6380,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 5_count"
@@ -6429,7 +6429,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 6_count"
@@ -6478,7 +6478,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 7_count"
@@ -6527,7 +6527,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 8_count"
@@ -6576,7 +6576,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 9_count"
@@ -6625,7 +6625,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 10_count"
@@ -6674,7 +6674,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 11_count"
@@ -6723,7 +6723,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 12_count"
@@ -6772,7 +6772,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 13_count"
@@ -6821,7 +6821,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 14_count"
@@ -6870,7 +6870,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 15_count"
@@ -6919,7 +6919,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 16_count"
@@ -6968,7 +6968,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 17_count"
@@ -7017,7 +7017,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 18_count"
@@ -7066,7 +7066,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 19_count"
@@ -7115,7 +7115,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 20_count"
@@ -7164,7 +7164,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 21_count"
@@ -7213,7 +7213,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 22_count"
@@ -7262,7 +7262,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 23_count"
@@ -7311,7 +7311,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 24_count"
@@ -7360,7 +7360,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 25_count"
@@ -7409,7 +7409,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 26_count"
@@ -7458,7 +7458,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 27_count"
@@ -7507,7 +7507,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 28_count"
@@ -7556,7 +7556,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 29_count"
@@ -7605,7 +7605,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 30_count"
@@ -7654,7 +7654,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 31_count"
@@ -7703,7 +7703,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 32_count"
@@ -7752,7 +7752,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 33_count"
@@ -7801,7 +7801,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 34_count"
@@ -7850,7 +7850,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 35_count"
@@ -7899,7 +7899,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 36_count"
@@ -7948,7 +7948,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 37_count"
@@ -7997,7 +7997,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 38_count"
@@ -8046,7 +8046,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 39_count"
@@ -8095,7 +8095,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 40_count"
@@ -8144,7 +8144,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary 41_count"

--- a/exporter/collector/integrationtest/testdata/fixtures/summary_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/summary_metrics_expect.json
@@ -48,7 +48,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -56,7 +56,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -180,7 +180,7 @@
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
+        "valueType": "DOUBLE",
         "unit": "1",
         "description": "This is a test summary",
         "displayName": "testsummary_count"

--- a/exporter/collector/integrationtest/testdata/fixtures/workload_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/workload_metrics_expect.json
@@ -3499,7 +3499,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3507,7 +3507,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3567,7 +3567,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3575,7 +3575,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],
@@ -3635,7 +3635,7 @@
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DOUBLE",
           "points": [
             {
               "interval": {
@@ -3643,7 +3643,7 @@
                 "startTime": "1970-01-01T00:00:00Z"
               },
               "value": {
-                "int64Value": "10"
+                "doubleValue": 10
               }
             }
           ],

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -416,14 +416,14 @@ func (m *metricMapper) summaryPointToTimeSeries(
 			Resource:   resource,
 			Unit:       metric.Unit(),
 			MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
-			ValueType:  metricpb.MetricDescriptor_INT64,
+			ValueType:  metricpb.MetricDescriptor_DOUBLE,
 			Points: []*monitoringpb.Point{{
 				Interval: &monitoringpb.TimeInterval{
 					StartTime: startTime,
 					EndTime:   endTime,
 				},
-				Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-					Int64Value: int64(point.Count()),
+				Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+					DoubleValue: float64(point.Count()),
 				}},
 			}},
 			Metric: &metricpb.Metric{
@@ -951,7 +951,7 @@ func (m *metricMapper) summaryMetricDescriptors(
 			Type:        m.metricNameToType(countName),
 			Labels:      labels,
 			MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-			ValueType:   metricpb.MetricDescriptor_INT64,
+			ValueType:   metricpb.MetricDescriptor_DOUBLE,
 			Unit:        pm.Unit(),
 			Description: pm.Description(),
 			DisplayName: countName,

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -614,7 +614,7 @@ func TestSummaryPointToTimeSeries(t *testing.T) {
 	assert.Equal(t, sumResult.Points[0].Value.GetDoubleValue(), sum)
 	// Test count mapping
 	assert.Equal(t, countResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
-	assert.Equal(t, countResult.ValueType, metricpb.MetricDescriptor_INT64)
+	assert.Equal(t, countResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
 	assert.Equal(t, countResult.Unit, unit)
 	assert.Same(t, countResult.Resource, mr)
 	assert.Equal(t, countResult.Metric.Type, "workload.googleapis.com/mysummary_count")
@@ -625,7 +625,7 @@ func TestSummaryPointToTimeSeries(t *testing.T) {
 		StartTime: timestamppb.New(start),
 		EndTime:   timestamppb.New(end),
 	})
-	assert.Equal(t, countResult.Points[0].Value.GetInt64Value(), int64(count))
+	assert.Equal(t, countResult.Points[0].Value.GetDoubleValue(), float64(count))
 	// Test quantile mapping
 	assert.Equal(t, quantileResult.MetricKind, metricpb.MetricDescriptor_GAUGE)
 	assert.Equal(t, quantileResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
@@ -956,7 +956,7 @@ func TestMetricDescriptorMapping(t *testing.T) {
 					DisplayName: "test.metric_count",
 					Type:        "workload.googleapis.com/test.metric_count",
 					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-					ValueType:   metricpb.MetricDescriptor_INT64,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
 					Unit:        "1",
 					Description: "Description",
 					Labels: []*label.LabelDescriptor{


### PR DESCRIPTION
All metrics in prometheus are sent as floats, including the summary `_count` metric points.  We should send these series as floats for better compatibility with Prometheus-style readers.