### PR TITLE
Add sum of squared deviation estimate

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -93,6 +93,11 @@ type MetricConfig struct {
 	// Defaults to empty, which won't include any additional resource labels. Note that the
 	// service_resource_labels option operates independently from resource_filters.
 	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
+
+	// This enables calculation of an estimated sum of squared deviation.  It isn't correct,
+	// so we don't send it by default, and don't expose it to users. For some uses, it is
+	// expected, however.
+	EnableSumOfSquaredDeviation bool
 }
 
 type ResourceFilter struct {

--- a/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics.json
@@ -137,6 +137,24 @@
                             {
                                "attributes":[
                                   {
+                                    "key":"A",
+                                    "value":{
+                                       "stringValue":"1"
+                                    }
+                                  },
+                                  {
+                                    "key":"B",
+                                    "value":{
+                                       "stringValue":"2"
+                                    }
+                                  },
+                                  {
+                                    "key":"C",
+                                    "value":{
+                                       "stringValue":"3"
+                                    }
+                                  },
+                                  {
                                      "key":"ex_com_lemons",
                                      "value":{
                                         "stringValue":"13"

--- a/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
@@ -136,6 +136,7 @@
                 "distributionValue": {
                   "count": "1",
                   "mean": 2,
+                  "sumOfSquaredDeviation": 2.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [
@@ -198,6 +199,7 @@
                 "distributionValue": {
                   "count": "2",
                   "mean": 7,
+                  "sumOfSquaredDeviation": 76.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [

--- a/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
@@ -139,7 +139,6 @@
                 "distributionValue": {
                   "count": "1",
                   "mean": 2,
-                  "sumOfSquaredDeviation": 2.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [
@@ -202,7 +201,6 @@
                 "distributionValue": {
                   "count": "2",
                   "mean": 7,
-                  "sumOfSquaredDeviation": 76.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [

--- a/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
@@ -107,6 +107,9 @@
           "metric": {
             "type": "workload.googleapis.com/ex_com_two",
             "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
               "ex_com_lemons": "13",
               "service_instance_id": "localhost:2222",
               "service_name": "demo",

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -519,12 +519,9 @@ func (m *metricMapper) histogramPoint(point pdata.HistogramDataPoint) *monitorin
 		prevBound = bound
 	}
 	// The infinity bucket is an implicit +Inf bound after the list of explicit bounds.
-	// Make sure we have a count for that bucket, just in-case.
-	if len(counts) == len(bounds)+1 {
-		// Assume points in the infinity bucket are at the top of the previous bucket
-		middleOfInfBucket := prevBound
-		deviation += float64(counts[len(counts)-1]) * (middleOfInfBucket - mean) * (middleOfInfBucket - mean)
-	}
+	// Assume points in the infinity bucket are at the top of the previous bucket
+	middleOfInfBucket := prevBound
+	deviation += float64(counts[len(counts)-1]) * (middleOfInfBucket - mean) * (middleOfInfBucket - mean)
 
 	return &monitoringpb.TypedValue{
 		Value: &monitoringpb.TypedValue_DistributionValue{

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -44,9 +44,11 @@ var (
 func newTestMetricMapper() (metricMapper, func()) {
 	obs := selfObservability{log: zap.NewNop()}
 	s := make(chan struct{})
+	cfg := DefaultConfig()
+	cfg.MetricConfig.EnableSumOfSquaredDeviation = true
 	return metricMapper{
 		obs,
-		DefaultConfig(),
+		cfg,
 		datapointstorage.NewCache(s),
 	}, func() { close(s) }
 }

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -301,6 +301,7 @@ func TestHistogramPointToTimeSeries(t *testing.T) {
 	hdp := ts.Points[0].Value.GetDistributionValue()
 	assert.Equal(t, int64(15), hdp.Count)
 	assert.ElementsMatch(t, []int64{1, 2, 3, 4, 5}, hdp.BucketCounts)
+	assert.Equal(t, float64(12847.600000000002), hdp.SumOfSquaredDeviation)
 	assert.Equal(t, float64(2.8), hdp.Mean)
 	assert.Equal(t, []float64{10, 20, 30, 40}, hdp.BucketOptions.GetExplicitBuckets().Bounds)
 	assert.Len(t, hdp.Exemplars, 1)


### PR DESCRIPTION
This is based on how google [prometheus-engine](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/17c5e8c475e0c224bf54c7a15531597f18885949/pkg/export/transform.go#L264) calculates the sum of squared deviations.  I need to double-check the implications of sending an estimate without having an exact SOSD.