### PR TITLE
feat(propagator): create a new one-way propagator

### DIFF
--- a/propagator/README.md
+++ b/propagator/README.md
@@ -1,0 +1,51 @@
+# OpenTelemetry Google Cloud Trace Propagators
+
+[![Docs](https://godoc.org/github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator?status.svg)](https://pkg.go.dev/github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator)
+
+This package contains Trace Context Propagators for use with [Google Cloud
+Trace](https://cloud.google.com/trace) that make it compatible with
+[OpenTelemetry](http://opentelemetry.io). 
+
+There are two available propagators in this package:
+
+### `CloudTraceOneWayPropagator`
+
+The `CloudTraceOneWayPropagator` reads the `X-Cloud-Trace-Context` header for
+trace and span IDs, and writes this data into the `traceparent` header.
+
+### `CloudTraceFormatPropagator`
+
+The `CloudTraceFormatPropagator` reads and writes the `X-Cloud-Trace-Context` header only.
+
+## Differences between Google Cloud Trace and W3C Trace Context
+
+Google Cloud Trace encodes trace information in the `X-Cloud-Trace-Context` HTTP
+header, using the format described in the [Trace documentation](https://cloud.google.com/trace/docs/setup#force-trace).
+
+OpenTelemetry uses the newer, W3C standard
+[`traceparent` header](https://www.w3.org/TR/trace-context/#traceparent-header)
+
+There is an important semantic difference between Cloud Trace's
+`TRACE_TRUE` flag, and W3C's `sampled` flag.
+
+As outlined in the [Trace
+documentation](https://cloud.google.com/trace/docs/setup#force-trace), setting
+the `TRACE_TRUE` flag will cause trace information to be collected.
+
+This differs from the W3C behavior, where the [`sampled`
+flag](https://www.w3.org/TR/trace-context/#sampled-flag) indicates that the
+caller *may* have recorded trace information, but does not necessarily impact
+the sampling done by other services.
+
+To preserve the Cloud-Trace behavior when using `traceparent`, you can use the
+[`ParentBased`
+sampler](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#ParentBased) like
+so:
+
+```go
+import sdktrace go.opentelemetry.io/otel/sdk/trace
+sampler := sdktrace.ParentBased(
+    sdktrace.NeverSample(),
+    sdktrace.WithRemoteParentSampled(sdktrace.AlwaysSample()))
+)
+```

--- a/propagator/README.md
+++ b/propagator/README.md
@@ -10,8 +10,12 @@ There are two available propagators in this package:
 
 ### `CloudTraceOneWayPropagator`
 
-The `CloudTraceOneWayPropagator` reads the `X-Cloud-Trace-Context` header for
-trace and span IDs, and writes this data into the `traceparent` header.
+The `CloudTraceOneWayPropagator` works like the standard `TraceContext`
+propagator if a `traceparent` header is present. If `traceparent` is not found,
+it reads the `X-Cloud-Trace-Context` header for trace and span IDs, and creates
+the corresponding `traceparent` header.
+
+This is useful for ensuring spans created in your code are attached to the traces that some Google Cloud services [automatically trace](https://cloud.google.com/trace/docs/overview#configurations_with_automatic_tracing).
 
 ### `CloudTraceFormatPropagator`
 

--- a/propagator/propagator.go
+++ b/propagator/propagator.go
@@ -42,9 +42,9 @@ var traceContextHeaderRe = regexp.MustCompile(traceContextHeaderFormat)
 // one element in the list.
 var cloudTraceContextHeaders = []string{TraceContextHeaderName}
 
-// TraceparentHeaderName is the HTTP header field for w3c standard trace information
+// traceparentHeaderName is the HTTP header field for w3c standard trace information
 // https://www.w3.org/TR/trace-context/
-const TraceparentHeaderName = "traceparent"
+const traceparentHeaderName = "traceparent"
 
 type errInvalidHeader struct {
 	header string
@@ -68,14 +68,14 @@ func (p CloudTraceOneWayPropagator) Extract(ctx context.Context, carrier propaga
 	}
 	sc, err := spanContextFromXCTCHeader(header)
 	if err != nil {
-		log.Printf("CloudTraceFormatPropagator: %v", err)
+		log.Printf("CloudTraceOneWayPropagator: %v", err)
 		return ctx
 	}
 	return trace.ContextWithRemoteSpanContext(ctx, sc)
 }
 
 func (p CloudTraceOneWayPropagator) Fields() []string {
-	return []string{TraceContextHeaderName, TraceparentHeaderName}
+	return []string{traceparentHeaderName}
 }
 
 var _ propagation.TextMapPropagator = CloudTraceOneWayPropagator{}

--- a/propagator/propagator_test.go
+++ b/propagator/propagator_test.go
@@ -188,7 +188,7 @@ func TestOneWayPropagatorInject(t *testing.T) {
 				TraceFlags: trace.FlagsSampled,
 			},
 			map[string]string{
-				TraceparentHeaderName: fmt.Sprintf("00-%s-%s-01", validTraceID.String(), validSpanID.String()),
+				traceparentHeaderName: fmt.Sprintf("00-%s-%s-01", validTraceID.String(), validSpanID.String()),
 			},
 		},
 		{
@@ -198,7 +198,7 @@ func TestOneWayPropagatorInject(t *testing.T) {
 				SpanID:  validSpanID,
 			},
 			map[string]string{
-				TraceparentHeaderName: fmt.Sprintf("00-%s-%s-00", validTraceID.String(), validSpanID.String()),
+				traceparentHeaderName: fmt.Sprintf("00-%s-%s-00", validTraceID.String(), validSpanID.String()),
 			},
 		},
 	}


### PR DESCRIPTION
CloudTraceOneWayPropagator moves trace info from X-cloud-trace-context
into 'traceparent'.

Fixes #268