### PR TITLE
Update fixtures based on upstream changes to the prometheus receiver

### DIFF
--- a/exporter/collector/integrationtest/testcases.go
+++ b/exporter/collector/integrationtest/testcases.go
@@ -85,6 +85,7 @@ var (
 			Configure: func(cfg *collector.Config) {
 				cfg.MetricConfig.Prefix = "workload.googleapis.com/"
 				cfg.MetricConfig.SkipCreateMetricDescriptor = true
+				cfg.MetricConfig.ServiceResourceLabels = false
 			},
 		},
 		{

--- a/exporter/collector/integrationtest/testdata/fixtures/gke_control_plane_metrics_agent_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/gke_control_plane_metrics_agent_metrics.json
@@ -16,15 +16,9 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"127.0.0.1:10254"
-                   }
-                },
-                {
-                   "key":"job",
-                   "value":{
-                      "stringValue":"clustermetrics-node"
                    }
                 },
                 {
@@ -40,13 +34,13 @@
                    }
                 },
                 {
-                   "key":"port",
+                   "key":"net.host.port",
                    "value":{
                       "stringValue":"10254"
                    }
                 },
                 {
-                   "key":"scheme",
+                   "key":"http.scheme",
                    "value":{
                       "stringValue":"http"
                    }
@@ -283,15 +277,9 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"127.0.0.1:10254"
-                   }
-                },
-                {
-                   "key":"job",
-                   "value":{
-                      "stringValue":"clustermetrics-node"
                    }
                 },
                 {
@@ -307,13 +295,13 @@
                    }
                 },
                 {
-                   "key":"port",
+                   "key":"net.host.port",
                    "value":{
                       "stringValue":"10254"
                    }
                 },
                 {
-                   "key":"scheme",
+                   "key":"http.scheme",
                    "value":{
                       "stringValue":"http"
                    }
@@ -550,15 +538,9 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"127.0.0.1:10254"
-                   }
-                },
-                {
-                   "key":"job",
-                   "value":{
-                      "stringValue":"clustermetrics-node"
                    }
                 },
                 {
@@ -574,13 +556,13 @@
                    }
                 },
                 {
-                   "key":"port",
+                   "key":"net.host.port",
                    "value":{
                       "stringValue":"10254"
                    }
                 },
                 {
-                   "key":"scheme",
+                   "key":"http.scheme",
                    "value":{
                       "stringValue":"http"
                    }
@@ -817,15 +799,9 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"127.0.0.1:10254"
-                   }
-                },
-                {
-                   "key":"job",
-                   "value":{
-                      "stringValue":"clustermetrics-node"
                    }
                 },
                 {
@@ -841,13 +817,13 @@
                    }
                 },
                 {
-                   "key":"port",
+                   "key":"net.host.port",
                    "value":{
                       "stringValue":"10254"
                    }
                 },
                 {
-                   "key":"scheme",
+                   "key":"http.scheme",
                    "value":{
                       "stringValue":"http"
                    }
@@ -1064,15 +1040,9 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"127.0.0.1:10254"
-                   }
-                },
-                {
-                   "key":"job",
-                   "value":{
-                      "stringValue":"clustermetrics-node"
                    }
                 },
                 {
@@ -1088,13 +1058,13 @@
                    }
                 },
                 {
-                   "key":"port",
+                   "key":"net.host.port",
                    "value":{
                       "stringValue":"10254"
                    }
                 },
                 {
-                   "key":"scheme",
+                   "key":"http.scheme",
                    "value":{
                       "stringValue":"http"
                    }
@@ -1331,15 +1301,9 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"127.0.0.1:10254"
-                   }
-                },
-                {
-                   "key":"job",
-                   "value":{
-                      "stringValue":"clustermetrics-node"
                    }
                 },
                 {
@@ -1355,13 +1319,13 @@
                    }
                 },
                 {
-                   "key":"port",
+                   "key":"net.host.port",
                    "value":{
                       "stringValue":"10254"
                    }
                 },
                 {
-                   "key":"scheme",
+                   "key":"http.scheme",
                    "value":{
                       "stringValue":"http"
                    }

--- a/exporter/collector/integrationtest/testdata/fixtures/ops_agent_host_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/ops_agent_host_metrics.json
@@ -28,7 +28,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -886,7 +886,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -1080,7 +1080,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -1175,7 +1175,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -1866,7 +1866,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -1928,7 +1928,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -2470,7 +2470,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }
@@ -2760,7 +2760,7 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.josh-opsagenttester.internal"
                         }

--- a/exporter/collector/integrationtest/testdata/fixtures/ops_agent_self_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/ops_agent_self_metrics.json
@@ -10,31 +10,25 @@
                         }
                     },
                     {
-                        "key": "host.name",
+                        "key": "net.host.name",
                         "value": {
                             "stringValue": "ops-agent-metrics.c.otel-opsagenttester.internal"
                         }
                     },
                     {
-                        "key": "job",
-                        "value": {
-                            "stringValue": "otel-collector"
-                        }
-                    },
-                    {
-                        "key": "instance",
+                        "key": "service.instance.id",
                         "value": {
                             "stringValue": "0.0.0.0:8888"
                         }
                     },
                     {
-                        "key": "port",
+                        "key": "net.host.port",
                         "value": {
                             "stringValue": "8888"
                         }
                     },
                     {
-                        "key": "scheme",
+                        "key": "http.scheme",
                         "value": {
                             "stringValue": "http"
                         }

--- a/exporter/collector/integrationtest/testdata/fixtures/workload_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/workload_metrics.json
@@ -22,13 +22,13 @@
                    }
                 },
                 {
-                   "key":"instance",
+                   "key":"service.instance.id",
                    "value":{
                       "stringValue":"10.92.5.2:15692"
                    }
                 },
                 {
-                   "key":"job",
+                   "key":"service.name",
                    "value":{
                       "stringValue":"default/rabbitmq/0"
                    }

--- a/exporter/collector/integrationtest/testdata/fixtures/workload_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/workload_metrics.json
@@ -28,12 +28,6 @@
                    }
                 },
                 {
-                   "key":"service.name",
-                   "value":{
-                      "stringValue":"default/rabbitmq/0"
-                   }
-                },
-                {
                    "key":"k8s.cluster.name",
                    "value":{
                       "stringValue":"rabbitmq-test-dev"


### PR DESCRIPTION
The resource labels set by the upstream prometheus receiver are changed to better align with OpenTelemetry semantic conventions: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/8266

This changes the input fixtures to reflect those changes.  It does not change any of the expectations, since those labels aren't used.  The GMP exporter will on these new values, though.