### PR TITLE
Prepare for releasing v1.4.0 and v0.28.0

### DIFF
--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	cloud.google.com/go/iam v0.1.1 // indirect
 	cloud.google.com/go/pubsub v1.19.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.3.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.4.0
 	go.opentelemetry.io/otel v1.6.2
 	go.opentelemetry.io/otel/sdk v1.6.2
 	go.opentelemetry.io/otel/trace v1.6.2

--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -5,7 +5,7 @@ go 1.17
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric => ../../exporter/metric
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.26.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.28.0
 	go.opentelemetry.io/otel v1.6.2
 	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.2

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -5,7 +5,7 @@ go 1.17
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace => ../../../exporter/trace
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.3.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.4.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.31.0
 	go.opentelemetry.io/otel v1.6.2

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/colle
 go 1.17
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.3.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.4.0
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.48.0
 	github.com/stretchr/testify v1.7.1

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.11
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.26.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.28.0
 	github.com/aws/aws-sdk-go v1.42.49 // indirect
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
@@ -22,7 +22,7 @@ require (
 	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/monitoring v1.4.0 // indirect
 	cloud.google.com/go/trace v1.2.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.3.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.4.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.24.0"
+	return "0.28.0"
 }

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.0.0"
+	return "1.4.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.3.0"
-	unstable = "0.26.0"
+	stable   = "1.4.0"
+	unstable = "0.28.0"
 )
 
 var versions = map[string]string{


### PR DESCRIPTION
For stable minor releases, increment minor version by 1, from v1.3.0 to v1.4.0.

For unstable minor releases, increment to the minor version of the opentelemetry-go unstable dependency (v0.28.0).