### PR TITLE
Add make commands for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,3 +180,12 @@ update-otel:
 	$(MAKE) update-dep MODULE=github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus VERSION=$(COLLECTOR_CONTRIB_VERSION)
 	$(MAKE) build
 	$(MAKE) gotidy
+
+.PHONY: prepare-release
+prepare-release:
+	echo "make sure tools/release.go is updated to your desired stable and unstable versions"
+	go run tools/release.go prepare
+
+.PHONY: release
+release: prepare-release check-clean-work-tree
+	go run tools/release.go tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@
 $ git fetch
 $ git checkout origin/main -b pre-release
 $ # ensure that version numbers in tools/release.go are what you want
-$ go run tools/release.go prepare
+$ make prepare-release
 $ git commit -a
 $ git push -u origin HEAD
 $ # create a PR with a link to draft release notes
@@ -19,7 +19,7 @@ $ # get the PR reviewed and merged
 $ # do this after the pre-release PR is merged
 $ git fetch
 $ git checkout origin/main
-$ go run tools/release.go tag
+$ make release
 $ # make sure you don't have any stray tags lying around
 $ git push --tags
 ```


### PR DESCRIPTION
I had intended to add this in the release PR: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/353#issuecomment-1096760354.  It should make releasing simpler.