### PR TITLE
Parse basic attributes for cloud logging exporter

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -141,12 +141,12 @@ func (l logMapper) logToEntry(
 	// parse LogEntrySourceLocation struct from OTel attribute
 	sourceLocation, ok := log.Attributes().Get("com.google.sourceLocation")
 	if ok {
-		var logEntrySourceLocation *logpb.LogEntrySourceLocation
-		err := json.Unmarshal(sourceLocation.BytesVal(), logEntrySourceLocation)
+		var logEntrySourceLocation logpb.LogEntrySourceLocation
+		err := json.Unmarshal(sourceLocation.BytesVal(), &logEntrySourceLocation)
 		if err != nil {
 			return entry, err
 		}
-		entry.SourceLocation = logEntrySourceLocation
+		entry.SourceLocation = &logEntrySourceLocation
 	}
 
 	// parse TraceID and SpanID, if present

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -45,9 +45,9 @@ type logMapper struct {
 }
 
 func NewGoogleCloudLogsExporter(
-	ctx context.Context,
-	cfg Config,
-	log *zap.Logger,
+		ctx context.Context,
+		cfg Config,
+		log *zap.Logger,
 ) (*LogsExporter, error) {
 	client, err := logging.NewClient(ctx, cfg.ProjectID)
 	if err != nil {
@@ -110,10 +110,10 @@ func (l *LogsExporter) PushLogs(ctx context.Context, ld pdata.Logs) error {
 }
 
 func (l logMapper) logToEntry(
-	log pdata.LogRecord,
-	mr *monitoredres.MonitoredResource,
-	instrumentationSource string,
-	instrumentationVersion string,
+		log pdata.LogRecord,
+		mr *monitoredres.MonitoredResource,
+		instrumentationSource string,
+		instrumentationVersion string,
 ) (logging.Entry, error) {
 	entry := logging.Entry{
 		Resource: mr,
@@ -141,6 +141,14 @@ func (l logMapper) logToEntry(
 			return entry, err
 		}
 		entry.SourceLocation = logEntrySourceLocation
+	}
+
+	// parse TraceID and SpanID, if present
+	if emptyTraceID := log.TraceID().IsEmpty(); !emptyTraceID {
+		entry.Trace = log.TraceID().HexString()
+	}
+	if emptySpanID := log.SpanID().IsEmpty(); !emptySpanID {
+		entry.SpanID = log.SpanID().HexString()
 	}
 
 	logBody := log.Body().BytesVal()

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -122,6 +122,15 @@ func (l logMapper) logToEntry(
 	entry.Labels["instrumentation_source"] = instrumentationSource
 	entry.Labels["instrumentation_version"] = instrumentationVersion
 
+	// if timestamp has not been explicitly initialized, default to current time
+	// TODO: figure out how to fall back to observed_time_unix_nano as recommended
+	//   (see https://github.com/open-telemetry/opentelemetry-proto/blob/4abbb78/opentelemetry/proto/logs/v1/logs.proto#L176-L179)
+	timestamp := log.Timestamp().AsTime()
+	if timestamp.IsZero() {
+		timestamp = time.Now()
+	}
+	entry.Timestamp = timestamp
+
 	logBody := log.Body().BytesVal()
 	if len(logBody) > 0 {
 		entry.Payload = json.RawMessage(logBody)

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -190,7 +190,6 @@ func parseEntryPayload(logBody pdata.Value) (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("unknown log body value %v", logBody.Type().String())
 	}
-	return nil, nil
 }
 
 // JSON keys derived from:

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -15,10 +15,10 @@
 package collector
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/logging"
 	"github.com/stretchr/testify/assert"
@@ -45,6 +45,8 @@ type baseTestCase struct {
 }
 
 func TestLogMapping(t *testing.T) {
+	testObservedTime, _ := time.Parse("2006-01-02", "2022-04-12")
+	testSampleTime, _ := time.Parse("2006-01-02", "2021-07-10")
 	testCases := []baseTestCase{
 		{
 			name: "empty log, empty monitoredresource",
@@ -54,7 +56,9 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredres.MonitoredResource {
 				return nil
 			},
-			expectedEntry: logging.Entry{},
+			expectedEntry: logging.Entry{
+				Timestamp: testObservedTime,
+			},
 		},
 		{
 			name: "log with json, empty monitoredresource",
@@ -66,7 +70,10 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredres.MonitoredResource {
 				return nil
 			},
-			expectedEntry: logging.Entry{Payload: json.RawMessage(`{"this": "is json"}`)},
+			expectedEntry: logging.Entry{
+				Payload:   []byte(`{"this": "is json"}`),
+				Timestamp: testObservedTime,
+			},
 		},
 		{
 			name: "log with json and httpRequest, empty monitoredresource",
@@ -94,7 +101,8 @@ func TestLogMapping(t *testing.T) {
 				return nil
 			},
 			expectedEntry: logging.Entry{
-				Payload: json.RawMessage(`{"message": "hello!"}`),
+				Payload:   []byte(`{"message": "hello!"}`),
+				Timestamp: testObservedTime,
 				HTTPRequest: &logging.HTTPRequest{
 					Request:                        makeExpectedHTTPReq("GET", "https://www.example.com", "https://www.example2.com", "test", nil),
 					RequestSize:                    1,
@@ -109,6 +117,35 @@ func TestLogMapping(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "log with timestamp",
+			log: func() pdata.LogRecord {
+				log := pdata.NewLogRecord()
+				log.SetTimestamp(pdata.NewTimestampFromTime(testSampleTime))
+				return log
+			},
+			mr: func() *monitoredres.MonitoredResource {
+				return nil
+			},
+			expectedEntry: logging.Entry{
+				Timestamp: testSampleTime,
+			},
+		},
+		{
+			name: "log body with string value",
+			mr: func() *monitoredres.MonitoredResource {
+				return nil
+			},
+			log: func() pdata.LogRecord {
+				log := pdata.NewLogRecord()
+				log.Body().SetStringVal("{\"message\": \"hello!\"}")
+				return log
+			},
+			expectedEntry: logging.Entry{
+				Payload:   `{"message": "hello!"}`,
+				Timestamp: testObservedTime,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -116,7 +153,12 @@ func TestLogMapping(t *testing.T) {
 			log := testCase.log()
 			mr := testCase.mr()
 			mapper := newTestLogMapper()
-			entry, err := mapper.logToEntry(log, mr)
+			entry, err := mapper.logToEntry(
+				log,
+				mr,
+				"",
+				"",
+				testObservedTime)
 			if testCase.expectError {
 				assert.NotNil(t, err)
 			} else {

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -48,10 +48,10 @@ type baseTestCase struct {
 func TestLogMapping(t *testing.T) {
 	testObservedTime, _ := time.Parse("2006-01-02", "2022-04-12")
 	testSampleTime, _ := time.Parse("2006-01-02", "2021-07-10")
-	testTraceId := pdata.NewTraceID([16]byte{
+	testTraceID := pdata.NewTraceID([16]byte{
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 	})
-	testSpanId := pdata.NewSpanID([8]byte{
+	testSpanID := pdata.NewSpanID([8]byte{
 		0, 0, 0, 0, 0, 0, 0, 1,
 	})
 
@@ -184,13 +184,13 @@ func TestLogMapping(t *testing.T) {
 			},
 			log: func() pdata.LogRecord {
 				log := pdata.NewLogRecord()
-				log.SetTraceID(testTraceId)
-				log.SetSpanID(testSpanId)
+				log.SetTraceID(testTraceID)
+				log.SetSpanID(testSpanID)
 				return log
 			},
 			expectedEntry: logging.Entry{
-				Trace:     testTraceId.HexString(),
-				SpanID:    testSpanId.HexString(),
+				Trace:     testTraceID.HexString(),
+				SpanID:    testSpanID.HexString(),
 				Timestamp: testObservedTime,
 			},
 		},


### PR DESCRIPTION
Parse out some basic fields from OTel LogRecord to GCP Entry:
* Instrumentation scope/version
* Timestamp (need to figure out how to read `observed_time_unix_nano`)
* SourceLocation
* Trace/Span ID

And changes how `log.Body()` is passed to Payload depending on the body's value type

xref https://b.corp.google.com/issues/228845177