### PR TITLE
fix: trace http server example for probability sampler

### DIFF
--- a/example/trace/http/server/server.go
+++ b/example/trace/http/server/server.go
@@ -42,7 +42,7 @@ func initTracer() func() {
 	}
 	tp := sdktrace.NewTracerProvider(
 		// For this example code we use sdktrace.AlwaysSample sampler to sample all traces.
-		// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
+		// In a production application, use sdktrace.TraceIDRatioBased with a desired probability.
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter))
 


### PR DESCRIPTION
There is no `ProbabilitySampler` (I believe that opencensus did have this though...), the probability functionality is available through the `TraceIDRatioBased`.