### PR TITLE
Normalize histograms, summaries, and exponential histograms

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -94,6 +94,12 @@ type MetricConfig struct {
 	// service_resource_labels option operates independently from resource_filters.
 	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
 
+	// CumulativeNormalization normalizes cumulative metrics without start times or with
+	// explicit reset points by subtracting subsequent points from the initial point.
+	// It is enabled by default. Since it caches starting points, it may result in
+	// increased memory usage.
+	CumulativeNormalization bool `mapstructure:"cumulative_normalization"`
+
 	// This enables calculation of an estimated sum of squared deviation.  It isn't correct,
 	// so we don't send it by default, and don't expose it to users. For some uses, it is
 	// expected, however.
@@ -118,6 +124,7 @@ func DefaultConfig() Config {
 			CreateMetricDescriptorBufferSize: 10,
 			InstrumentationLibraryLabels:     true,
 			ServiceResourceLabels:            true,
+			CumulativeNormalization:          true,
 		},
 	}
 }

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -74,6 +74,7 @@ func TestLoadConfig(t *testing.T) {
 					InstrumentationLibraryLabels:     true,
 					CreateMetricDescriptorBufferSize: 10,
 					ServiceResourceLabels:            true,
+					CumulativeNormalization:          true,
 				},
 			},
 		})

--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -25,16 +25,41 @@ import (
 
 const gcInterval = 20 * time.Minute
 
-type Cache map[string]usedPoint
+type Cache struct {
+	numberCache               map[string]usedNumberPoint
+	summaryCache              map[string]usedSummaryPoint
+	histogramCache            map[string]usedHistogramPoint
+	exponentialHistogramCache map[string]usedExponentialHistogramPoint
+}
 
-type usedPoint struct {
+type usedNumberPoint struct {
 	point *pdata.NumberDataPoint
 	used  bool
 }
 
-// New instantiates a cache and starts background processes
+type usedSummaryPoint struct {
+	point *pdata.SummaryDataPoint
+	used  bool
+}
+
+type usedHistogramPoint struct {
+	point *pdata.HistogramDataPoint
+	used  bool
+}
+
+type usedExponentialHistogramPoint struct {
+	point *pdata.ExponentialHistogramDataPoint
+	used  bool
+}
+
+// NewCache instantiates a cache and starts background processes
 func NewCache(shutdown <-chan struct{}) Cache {
-	c := make(Cache)
+	c := Cache{
+		numberCache:               make(map[string]usedNumberPoint),
+		summaryCache:              make(map[string]usedSummaryPoint),
+		histogramCache:            make(map[string]usedHistogramPoint),
+		exponentialHistogramCache: make(map[string]usedExponentialHistogramPoint),
+	}
 	go func() {
 		ticker := time.NewTicker(gcInterval)
 		for c.gc(shutdown, ticker.C) {
@@ -43,20 +68,68 @@ func NewCache(shutdown <-chan struct{}) Cache {
 	return c
 }
 
-// Get retrieves the point associated with the identifier, and whether
+// GetNumberDataPoint retrieves the point associated with the identifier, and whether
 // or not it was found
-func (c Cache) Get(identifier string) (*pdata.NumberDataPoint, bool) {
-	point, found := c[identifier]
+func (c Cache) GetNumberDataPoint(identifier string) (*pdata.NumberDataPoint, bool) {
+	point, found := c.numberCache[identifier]
 	if found {
 		point.used = true
-		c[identifier] = point
+		c.numberCache[identifier] = point
 	}
 	return point.point, found
 }
 
-// Set assigns the point to the identifier in the cache
-func (c Cache) Set(identifier string, point *pdata.NumberDataPoint) {
-	c[identifier] = usedPoint{point, true}
+// SetNumberDataPoint assigns the point to the identifier in the cache
+func (c Cache) SetNumberDataPoint(identifier string, point *pdata.NumberDataPoint) {
+	c.numberCache[identifier] = usedNumberPoint{point, true}
+}
+
+// GetSummaryDataPoint retrieves the point associated with the identifier, and whether
+// or not it was found
+func (c Cache) GetSummaryDataPoint(identifier string) (*pdata.SummaryDataPoint, bool) {
+	point, found := c.summaryCache[identifier]
+	if found {
+		point.used = true
+		c.summaryCache[identifier] = point
+	}
+	return point.point, found
+}
+
+// SetSummaryDataPoint assigns the point to the identifier in the cache
+func (c Cache) SetSummaryDataPoint(identifier string, point *pdata.SummaryDataPoint) {
+	c.summaryCache[identifier] = usedSummaryPoint{point, true}
+}
+
+// GetHistogramDataPoint retrieves the point associated with the identifier, and whether
+// or not it was found
+func (c Cache) GetHistogramDataPoint(identifier string) (*pdata.HistogramDataPoint, bool) {
+	point, found := c.histogramCache[identifier]
+	if found {
+		point.used = true
+		c.histogramCache[identifier] = point
+	}
+	return point.point, found
+}
+
+// SetHistogramDataPoint assigns the point to the identifier in the cache
+func (c Cache) SetHistogramDataPoint(identifier string, point *pdata.HistogramDataPoint) {
+	c.histogramCache[identifier] = usedHistogramPoint{point, true}
+}
+
+// GetExponentialHistogramDataPoint retrieves the point associated with the identifier, and whether
+// or not it was found
+func (c Cache) GetExponentialHistogramDataPoint(identifier string) (*pdata.ExponentialHistogramDataPoint, bool) {
+	point, found := c.exponentialHistogramCache[identifier]
+	if found {
+		point.used = true
+		c.exponentialHistogramCache[identifier] = point
+	}
+	return point.point, found
+}
+
+// SetExponentialHistogramDataPoint assigns the point to the identifier in the cache
+func (c Cache) SetExponentialHistogramDataPoint(identifier string, point *pdata.ExponentialHistogramDataPoint) {
+	c.exponentialHistogramCache[identifier] = usedExponentialHistogramPoint{point, true}
 }
 
 // gc garbage collects the cache after the ticker ticks
@@ -65,15 +138,48 @@ func (c Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
 	case <-shutdown:
 		return false
 	case <-tickerCh:
-		// garbage collect the cache
-		for id, point := range c {
+		// garbage collect the numberCache
+		for id, point := range c.numberCache {
 			if point.used {
 				// for points that have been used, mark them as unused
 				point.used = false
-				c[id] = point
+				c.numberCache[id] = point
 			} else {
 				// for points that have not been used, delete points
-				delete(c, id)
+				delete(c.numberCache, id)
+			}
+		}
+		// garbage collect the summaryCache
+		for id, point := range c.summaryCache {
+			if point.used {
+				// for points that have been used, mark them as unused
+				point.used = false
+				c.summaryCache[id] = point
+			} else {
+				// for points that have not been used, delete points
+				delete(c.summaryCache, id)
+			}
+		}
+		// garbage collect the histogramCache
+		for id, point := range c.histogramCache {
+			if point.used {
+				// for points that have been used, mark them as unused
+				point.used = false
+				c.histogramCache[id] = point
+			} else {
+				// for points that have not been used, delete points
+				delete(c.histogramCache, id)
+			}
+		}
+		// garbage collect the exponentialHistogramCache
+		for id, point := range c.exponentialHistogramCache {
+			if point.used {
+				// for points that have been used, mark them as unused
+				point.used = false
+				c.exponentialHistogramCache[id] = point
+			} else {
+				// for points that have not been used, delete points
+				delete(c.exponentialHistogramCache, id)
 			}
 		}
 	}

--- a/exporter/collector/internal/normalization/disabled_normalizer.go
+++ b/exporter/collector/internal/normalization/disabled_normalizer.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalization
+
+import "go.opentelemetry.io/collector/model/pdata"
+
+// NewDisabledNormalizer returns a Normalizer which does not perform any
+// normalization. This may be useful if standard normalization consumes too
+// much memory.
+func NewDisabledNormalizer() Normalizer {
+	return &disabledNormalizer{}
+}
+
+type disabledNormalizer struct{}
+
+// NormalizeExponentialHistogramDataPoint returns the point without normalizing.
+func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pdata.ExponentialHistogramDataPoint, _ string) *pdata.ExponentialHistogramDataPoint {
+	return &point
+}
+
+// NormalizeHistogramDataPoint returns the point without normalizing.
+func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pdata.HistogramDataPoint, _ string) *pdata.HistogramDataPoint {
+	return &point
+}
+
+// NormalizeNumberDataPoint returns the point without normalizing.
+func (d *disabledNormalizer) NormalizeNumberDataPoint(point pdata.NumberDataPoint, _ string) *pdata.NumberDataPoint {
+	return &point
+}
+
+// NormalizeSummaryDataPoint returns the point without normalizing.
+func (d *disabledNormalizer) NormalizeSummaryDataPoint(point pdata.SummaryDataPoint, _ string) *pdata.SummaryDataPoint {
+	return &point
+}

--- a/exporter/collector/internal/normalization/standard_normalizer.go
+++ b/exporter/collector/internal/normalization/standard_normalizer.go
@@ -1,0 +1,247 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalization
+
+import (
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/datapointstorage"
+)
+
+// NewStandardNormalizer performs normalization on cumulative points which:
+//  (a) don't have a start time, OR
+//  (b) have been sent a preceding "reset" point as described in https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+// The first point without a start time or the reset point is cached, and is
+// NOT exported. Subsequent points "subtract" the initial point prior to exporting.
+func NewStandardNormalizer(shutdown <-chan struct{}, logger *zap.Logger) Normalizer {
+	return &standardNormalizer{
+		cache: datapointstorage.NewCache(shutdown),
+		log:   logger,
+	}
+}
+
+type standardNormalizer struct {
+	cache datapointstorage.Cache
+	log   *zap.Logger
+}
+
+func (s *standardNormalizer) NormalizeExponentialHistogramDataPoint(point pdata.ExponentialHistogramDataPoint, identifier string) *pdata.ExponentialHistogramDataPoint {
+	// if the point doesn't need to be normalized, use original point
+	normalizedPoint := &point
+	start, ok := s.cache.GetExponentialHistogramDataPoint(identifier)
+	if ok {
+		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// We found a cached start timestamp that wouldn't produce a valid point.
+			// Drop it and log.
+			s.log.Info(
+				"data point being processed older than last recorded reset, will not be emitted",
+				zap.String("lastRecordedReset", start.Timestamp().String()),
+				zap.String("dataPoint", point.Timestamp().String()),
+			)
+			return nil
+		}
+		if point.Scale() != start.Scale() {
+			// TODO(#366): It is possible, but difficult to compare exponential
+			// histograms with different scales. For now, treat a change in
+			// scale as a reset.
+			s.cache.SetExponentialHistogramDataPoint(identifier, &point)
+			return nil
+		}
+		// Make a copy so we don't mutate underlying data
+		newPoint := pdata.NewExponentialHistogramDataPoint()
+		point.CopyTo(newPoint)
+		// Use the start timestamp from the normalization point
+		newPoint.SetStartTimestamp(start.Timestamp())
+		// Adjust the value based on the start point's value
+		newPoint.SetCount(point.Count() - start.Count())
+		// We drop points without a sum, so no need to check here.
+		newPoint.SetSum(point.Sum() - start.Sum())
+		newPoint.SetZeroCount(point.ZeroCount() - start.ZeroCount())
+		normalizeExponentialBuckets(newPoint.Positive(), start.Positive())
+		normalizeExponentialBuckets(newPoint.Negative(), start.Negative())
+		normalizedPoint = &newPoint
+	}
+	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// This is the first time we've seen this metric, or we received
+		// an explicit reset point as described in
+		//
+		// Record it in history and drop the point.
+		s.cache.SetExponentialHistogramDataPoint(identifier, &point)
+		return nil
+	}
+	return normalizedPoint
+}
+
+func normalizeExponentialBuckets(pointBuckets, startBuckets pdata.Buckets) {
+	newBuckets := make([]uint64, len(pointBuckets.BucketCounts()))
+	offsetDiff := int(pointBuckets.Offset() - startBuckets.Offset())
+	for i := range pointBuckets.BucketCounts() {
+		startOffset := i + offsetDiff
+		// if there is no corresponding bucket for the starting bucketcounts, don't normalize
+		if startOffset < 0 || startOffset >= len(startBuckets.BucketCounts()) {
+			newBuckets[i] = pointBuckets.BucketCounts()[i]
+		} else {
+			newBuckets[i] = pointBuckets.BucketCounts()[i] - startBuckets.BucketCounts()[startOffset]
+		}
+	}
+	pointBuckets.SetOffset(pointBuckets.Offset())
+	pointBuckets.SetBucketCounts(newBuckets)
+}
+
+func (s *standardNormalizer) NormalizeHistogramDataPoint(point pdata.HistogramDataPoint, identifier string) *pdata.HistogramDataPoint {
+	// if the point doesn't need to be normalized, use original point
+	normalizedPoint := &point
+	start, ok := s.cache.GetHistogramDataPoint(identifier)
+	if ok {
+		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// We found a cached start timestamp that wouldn't produce a valid point.
+			// Drop it and log.
+			s.log.Info(
+				"data point being processed older than last recorded reset, will not be emitted",
+				zap.String("lastRecordedReset", start.Timestamp().String()),
+				zap.String("dataPoint", point.Timestamp().String()),
+			)
+			return nil
+		}
+		// Make a copy so we don't mutate underlying data
+		newPoint := pdata.NewHistogramDataPoint()
+		point.CopyTo(newPoint)
+		// Use the start timestamp from the normalization point
+		newPoint.SetStartTimestamp(start.Timestamp())
+		// Adjust the value based on the start point's value
+		newPoint.SetCount(point.Count() - start.Count())
+		// We drop points without a sum, so no need to check here.
+		newPoint.SetSum(point.Sum() - start.Sum())
+		pointBuckets := point.BucketCounts()
+		startBuckets := start.BucketCounts()
+		if !bucketBoundariesEqual(point.ExplicitBounds(), start.ExplicitBounds()) {
+			// The number of buckets changed, so we can't normalize points anymore.
+			// Treat this as a reset by recording and dropping this point.
+			s.cache.SetHistogramDataPoint(identifier, &point)
+			return nil
+		}
+		newBuckets := make([]uint64, len(pointBuckets))
+		for i := range pointBuckets {
+			newBuckets[i] = pointBuckets[i] - startBuckets[i]
+		}
+		newPoint.SetBucketCounts(newBuckets)
+		normalizedPoint = &newPoint
+	}
+	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// This is the first time we've seen this metric, or we received
+		// an explicit reset point as described in
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+		// Record it in history and drop the point.
+		s.cache.SetHistogramDataPoint(identifier, &point)
+		return nil
+	}
+	return normalizedPoint
+}
+
+func bucketBoundariesEqual(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// NormalizeNumberDataPoint normalizes a cumulative, monotonic sum.
+// It returns the normalized point, or nil if the point should be dropped.
+func (s *standardNormalizer) NormalizeNumberDataPoint(point pdata.NumberDataPoint, identifier string) *pdata.NumberDataPoint {
+	// if the point doesn't need to be normalized, use original point
+	normalizedPoint := &point
+	start, ok := s.cache.GetNumberDataPoint(identifier)
+	if ok {
+		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// We found a cached start timestamp that wouldn't produce a valid point.
+			// Drop it and log.
+			s.log.Info(
+				"data point being processed older than last recorded reset, will not be emitted",
+				zap.String("lastRecordedReset", start.Timestamp().String()),
+				zap.String("dataPoint", point.Timestamp().String()),
+			)
+			return nil
+		}
+		// Make a copy so we don't mutate underlying data
+		newPoint := pdata.NewNumberDataPoint()
+		point.CopyTo(newPoint)
+		// Use the start timestamp from the normalization point
+		newPoint.SetStartTimestamp(start.Timestamp())
+		// Adjust the value based on the start point's value
+		switch newPoint.ValueType() {
+		case pmetric.MetricValueTypeInt:
+			newPoint.SetIntVal(point.IntVal() - start.IntVal())
+		case pmetric.MetricValueTypeDouble:
+			newPoint.SetDoubleVal(point.DoubleVal() - start.DoubleVal())
+		}
+		normalizedPoint = &newPoint
+	}
+	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// This is the first time we've seen this metric, or we received
+		// an explicit reset point as described in
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+		// Record it in history and drop the point.
+		s.cache.SetNumberDataPoint(identifier, &point)
+		return nil
+	}
+	return normalizedPoint
+}
+
+func (s *standardNormalizer) NormalizeSummaryDataPoint(point pdata.SummaryDataPoint, identifier string) *pdata.SummaryDataPoint {
+	// if the point doesn't need to be normalized, use original point
+	normalizedPoint := &point
+	start, ok := s.cache.GetSummaryDataPoint(identifier)
+	if ok {
+		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// We found a cached start timestamp that wouldn't produce a valid point.
+			// Drop it and log.
+			s.log.Info(
+				"data point being processed older than last recorded reset, will not be emitted",
+				zap.String("lastRecordedReset", start.Timestamp().String()),
+				zap.String("dataPoint", point.Timestamp().String()),
+			)
+			return nil
+		}
+		// Make a copy so we don't mutate underlying data.
+		newPoint := pdata.NewSummaryDataPoint()
+		// Quantile values are copied, and are not modified. Quantiles are
+		// computed over the same time period as sum and count, but it isn't
+		// possible to normalize them.
+		point.CopyTo(newPoint)
+		// Use the start timestamp from the normalization point
+		newPoint.SetStartTimestamp(start.Timestamp())
+		// Adjust the value based on the start point's value
+		newPoint.SetCount(point.Count() - start.Count())
+		// We drop points without a sum, so no need to check here.
+		newPoint.SetSum(point.Sum() - start.Sum())
+		normalizedPoint = &newPoint
+	}
+	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// This is the first time we've seen this metric, or we received
+		// an explicit reset point as described in
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+		// Record it in history and drop the point.
+		s.cache.SetSummaryDataPoint(identifier, &point)
+		return nil
+	}
+	return normalizedPoint
+}

--- a/exporter/collector/internal/normalization/types.go
+++ b/exporter/collector/internal/normalization/types.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalization
+
+import "go.opentelemetry.io/collector/model/pdata"
+
+// Normalizer can normalize data points to handle cases in which the start time is unknown.
+type Normalizer interface {
+	// NormalizeExponentialHistogramDataPoint normalizes an exponential histogram.
+	// It returns the normalized point, or nil if the point should be dropped.
+	NormalizeExponentialHistogramDataPoint(point pdata.ExponentialHistogramDataPoint, identifier string) *pdata.ExponentialHistogramDataPoint
+	// NormalizeHistogramDataPoint normalizes a cumulative histogram.
+	// It returns the normalized point, or nil if the point should be dropped.
+	NormalizeHistogramDataPoint(point pdata.HistogramDataPoint, identifier string) *pdata.HistogramDataPoint
+	// NormalizeNumberDataPoint normalizes a cumulative, monotonic sum.
+	// It returns the normalized point, or nil if the point should be dropped.
+	NormalizeNumberDataPoint(point pdata.NumberDataPoint, identifier string) *pdata.NumberDataPoint
+	// NormalizeSummaryDataPoint normalizes a summary.
+	// It returns the normalized point, or nil if the point should be dropped.
+	NormalizeSummaryDataPoint(point pdata.SummaryDataPoint, identifier string) *pdata.SummaryDataPoint
+}

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -134,6 +134,10 @@ func NewGoogleCloudMetricsExporter(
 	}
 	obs := selfObservability{log: log}
 	shutdown := make(chan struct{})
+	normalizer := normalization.NewDisabledNormalizer()
+	if cfg.MetricConfig.CumulativeNormalization {
+		normalizer = normalization.NewStandardNormalizer(shutdown, log)
+	}
 	mExp := &MetricsExporter{
 		cfg:    cfg,
 		client: client,
@@ -141,7 +145,7 @@ func NewGoogleCloudMetricsExporter(
 		mapper: metricMapper{
 			obs,
 			cfg,
-			normalization.NewStandardNormalizer(shutdown, log),
+			normalizer,
 		},
 		// We create a buffered channel for metric descriptors.
 		// MetricDescritpors are asychronously sent and optimistic.

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -814,8 +814,11 @@ func (m *metricMapper) normalizeSummaryDataPoint(point pdata.SummaryDataPoint, i
 			)
 			return nil
 		}
-		// Make a copy so we don't mutate underlying data
+		// Make a copy so we don't mutate underlying data.
 		newPoint := pdata.NewSummaryDataPoint()
+		// Quantile values are copied, and are not modified. Quantiles are
+		// computed over the same time period as sum and count, but it isn't
+		// possible to normalize them.
 		point.CopyTo(newPoint)
 		// Use the start timestamp from the normalization point
 		newPoint.SetStartTimestamp(start.Timestamp())
@@ -918,7 +921,7 @@ func (m *metricMapper) normalizeExponentialHistogramDataPoint(point pdata.Expone
 			return nil
 		}
 		if point.Scale() != start.Scale() {
-			// TODO: It is possible, but difficult to compare exponential
+			// TODO(#366): It is possible, but difficult to compare exponential
 			// histograms with different scales. For now, treat a change in
 			// scale as a reset.
 			m.normalizationCache.SetExponentialHistogramDataPoint(identifier, &point)

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/datapointstorage"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization"
 )
 
 var (
@@ -49,7 +49,7 @@ func newTestMetricMapper() (metricMapper, func()) {
 	return metricMapper{
 		obs,
 		cfg,
-		datapointstorage.NewCache(s),
+		normalization.NewStandardNormalizer(s, zap.NewNop()),
 	}, func() { close(s) }
 }
 

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -322,6 +322,142 @@ func TestHistogramPointToTimeSeries(t *testing.T) {
 	assert.Equal(t, map[string]string{"test": "extra"}, dropped.Label)
 }
 
+func TestHistogramPointWithoutTimestampToTimeSeries(t *testing.T) {
+	mapper, shutdown := newTestMetricMapper()
+	defer shutdown()
+	mapper.cfg.ProjectID = "myproject"
+	mr := &monitoredrespb.MonitoredResource{}
+	metric := pdata.NewMetric()
+	metric.SetName("myhist")
+	metric.SetDataType(pmetric.MetricDataTypeHistogram)
+	unit := "1"
+	metric.SetUnit(unit)
+	hist := metric.Histogram()
+	point := hist.DataPoints().AppendEmpty()
+	// leave start time unset with the intended start time
+	point.SetTimestamp(pdata.NewTimestampFromTime(start))
+	point.SetBucketCounts([]uint64{1, 0, 0, 0, 0})
+	point.SetCount(1)
+	point.SetSum(2)
+	point.SetExplicitBounds([]float64{10, 20, 30, 40})
+	exemplar := point.Exemplars().AppendEmpty()
+	exemplar.SetDoubleVal(2)
+	exemplar.SetTimestamp(pdata.NewTimestampFromTime(start))
+	exemplar.SetTraceID(pdata.NewTraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6}))
+	exemplar.SetSpanID(pdata.NewSpanID([8]byte{0, 1, 2, 3, 4, 5, 6, 7}))
+	exemplar.FilteredAttributes().InsertString("test", "extra")
+
+	// second point
+	point = hist.DataPoints().AppendEmpty()
+	end := start.Add(time.Hour)
+	// leave start time unset
+	point.SetTimestamp(pdata.NewTimestampFromTime(end))
+	point.SetBucketCounts([]uint64{2, 2, 3, 4, 5})
+	point.SetCount(16)
+	point.SetSum(44)
+	point.SetExplicitBounds([]float64{10, 20, 30, 40})
+	exemplar = point.Exemplars().AppendEmpty()
+	exemplar.SetDoubleVal(2)
+	exemplar.SetTimestamp(pdata.NewTimestampFromTime(end))
+	exemplar.SetTraceID(pdata.NewTraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6}))
+	exemplar.SetSpanID(pdata.NewSpanID([8]byte{0, 1, 2, 3, 4, 5, 6, 7}))
+	exemplar.FilteredAttributes().InsertString("test", "extra")
+
+	// third point
+	point = hist.DataPoints().AppendEmpty()
+	end2 := end.Add(time.Hour)
+	// leave start time unset
+	point.SetTimestamp(pdata.NewTimestampFromTime(end2))
+	point.SetBucketCounts([]uint64{3, 2, 3, 4, 5})
+	point.SetCount(17)
+	point.SetSum(445)
+	point.SetExplicitBounds([]float64{10, 20, 30, 40})
+	exemplar = point.Exemplars().AppendEmpty()
+	exemplar.SetDoubleVal(2)
+	exemplar.SetTimestamp(pdata.NewTimestampFromTime(end2))
+	exemplar.SetTraceID(pdata.NewTraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6}))
+	exemplar.SetSpanID(pdata.NewSpanID([8]byte{0, 1, 2, 3, 4, 5, 6, 7}))
+	exemplar.FilteredAttributes().InsertString("test", "extra")
+
+	tsl := mapper.metricToTimeSeries(mr, labels{}, metric)
+	// the first point should be dropped, so we expect 2 points
+	assert.Len(t, tsl, 2)
+	ts := tsl[0]
+	// Verify aspects
+	assert.Equal(t, metricpb.MetricDescriptor_CUMULATIVE, ts.MetricKind)
+	assert.Equal(t, metricpb.MetricDescriptor_DISTRIBUTION, ts.ValueType)
+	assert.Equal(t, unit, ts.Unit)
+	assert.Same(t, mr, ts.Resource)
+
+	assert.Equal(t, "workload.googleapis.com/myhist", ts.Metric.Type)
+	assert.Equal(t, map[string]string{}, ts.Metric.Labels)
+
+	assert.Nil(t, ts.Metadata)
+
+	assert.Len(t, ts.Points, 1)
+	assert.Equal(t, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	}, ts.Points[0].Interval)
+	hdp := ts.Points[0].Value.GetDistributionValue()
+	assert.Equal(t, int64(15), hdp.Count)
+	assert.ElementsMatch(t, []int64{1, 2, 3, 4, 5}, hdp.BucketCounts)
+	assert.Equal(t, float64(2.8), hdp.Mean)
+	assert.Equal(t, []float64{10, 20, 30, 40}, hdp.BucketOptions.GetExplicitBuckets().Bounds)
+	assert.Len(t, hdp.Exemplars, 1)
+	ex := hdp.Exemplars[0]
+	assert.Equal(t, float64(2), ex.Value)
+	assert.Equal(t, timestamppb.New(end), ex.Timestamp)
+	// We should see trace + dropped labels
+	assert.Len(t, ex.Attachments, 2)
+	spanctx := &monitoringpb.SpanContext{}
+	err := ex.Attachments[0].UnmarshalTo(spanctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "projects/myproject/traces/00010203040506070809010203040506/spans/0001020304050607", spanctx.SpanName)
+	dropped := &monitoringpb.DroppedLabels{}
+	err = ex.Attachments[1].UnmarshalTo(dropped)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{"test": "extra"}, dropped.Label)
+
+	// verify second point
+	ts = tsl[1]
+	// Verify aspects
+	assert.Equal(t, metricpb.MetricDescriptor_CUMULATIVE, ts.MetricKind)
+	assert.Equal(t, metricpb.MetricDescriptor_DISTRIBUTION, ts.ValueType)
+	assert.Equal(t, unit, ts.Unit)
+	assert.Same(t, mr, ts.Resource)
+
+	assert.Equal(t, "workload.googleapis.com/myhist", ts.Metric.Type)
+	assert.Equal(t, map[string]string{}, ts.Metric.Labels)
+
+	assert.Nil(t, ts.Metadata)
+
+	assert.Len(t, ts.Points, 1)
+	assert.Equal(t, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end2),
+	}, ts.Points[0].Interval)
+	hdp = ts.Points[0].Value.GetDistributionValue()
+	assert.Equal(t, int64(16), hdp.Count)
+	assert.ElementsMatch(t, []int64{2, 2, 3, 4, 5}, hdp.BucketCounts)
+	assert.Equal(t, float64(27.6875), hdp.Mean)
+	assert.Equal(t, []float64{10, 20, 30, 40}, hdp.BucketOptions.GetExplicitBuckets().Bounds)
+	assert.Len(t, hdp.Exemplars, 1)
+	ex = hdp.Exemplars[0]
+	assert.Equal(t, float64(2), ex.Value)
+	assert.Equal(t, timestamppb.New(end2), ex.Timestamp)
+	// We should see trace + dropped labels
+	assert.Len(t, ex.Attachments, 2)
+	spanctx = &monitoringpb.SpanContext{}
+	err = ex.Attachments[0].UnmarshalTo(spanctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "projects/myproject/traces/00010203040506070809010203040506/spans/0001020304050607", spanctx.SpanName)
+	dropped = &monitoringpb.DroppedLabels{}
+	err = ex.Attachments[1].UnmarshalTo(dropped)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{"test": "extra"}, dropped.Label)
+}
+
 func TestNoValueHistogramPointToTimeSeries(t *testing.T) {
 	mapper, shutdown := newTestMetricMapper()
 	defer shutdown()
@@ -498,7 +634,7 @@ func TestExponentialHistogramPointToTimeSeries(t *testing.T) {
 	// Add a second point with no value
 	hist.DataPoints().AppendEmpty().SetFlags(pmetric.MetricDataPointFlags(pmetric.MetricDataPointFlagNoRecordedValue))
 
-	tsl := mapper.exponentialHistogramToTimeSeries(mr, labels{}, metric, hist, point)
+	tsl := mapper.metricToTimeSeries(mr, labels{}, metric)
 	assert.Len(t, tsl, 1)
 	ts := tsl[0]
 	// Verify aspects
@@ -535,6 +671,160 @@ func TestExponentialHistogramPointToTimeSeries(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "projects/myproject/traces/00010203040506070809010203040506/spans/0001020304050607", spanctx.SpanName)
 	dropped := &monitoringpb.DroppedLabels{}
+	err = ex.Attachments[1].UnmarshalTo(dropped)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{"test": "extra"}, dropped.Label)
+}
+
+func TestExponentialHistogramPointWithoutStartTimeToTimeSeries(t *testing.T) {
+	mapper, shutdown := newTestMetricMapper()
+	defer shutdown()
+	mapper.cfg.ProjectID = "myproject"
+	mr := &monitoredrespb.MonitoredResource{}
+	metric := pdata.NewMetric()
+	metric.SetName("myexphist")
+	metric.SetDataType(pmetric.MetricDataTypeExponentialHistogram)
+	unit := "1"
+	metric.SetUnit(unit)
+	hist := metric.ExponentialHistogram()
+
+	// First point will be dropped, since it has no start time.
+	point := hist.DataPoints().AppendEmpty()
+	// Omit start timestamp
+	point.SetTimestamp(pdata.NewTimestampFromTime(start))
+	point.Positive().SetOffset(2)
+	point.Positive().SetBucketCounts([]uint64{1, 1, 1})
+	point.Negative().SetOffset(1)
+	point.Negative().SetBucketCounts([]uint64{1, 1})
+	point.SetZeroCount(2)
+	point.SetCount(7)
+	point.SetScale(-1)
+	point.SetSum(10)
+	exemplar := point.Exemplars().AppendEmpty()
+	exemplar.SetDoubleVal(2)
+	exemplar.SetTimestamp(pdata.NewTimestampFromTime(start))
+	exemplar.SetTraceID(pdata.NewTraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6}))
+	exemplar.SetSpanID(pdata.NewSpanID([8]byte{0, 1, 2, 3, 4, 5, 6, 7}))
+	exemplar.FilteredAttributes().InsertString("test", "extra")
+
+	// Second point
+	point = hist.DataPoints().AppendEmpty()
+	end := start.Add(time.Hour)
+	// Omit start timestamp
+	point.SetTimestamp(pdata.NewTimestampFromTime(end))
+	point.Positive().SetOffset(1)
+	point.Positive().SetBucketCounts([]uint64{1, 2, 3, 4})
+	point.Negative().SetOffset(0)
+	point.Negative().SetBucketCounts([]uint64{1, 5, 6})
+	point.SetZeroCount(8)
+	point.SetCount(30)
+	point.SetScale(-1)
+	point.SetSum(56)
+	exemplar = point.Exemplars().AppendEmpty()
+	exemplar.SetDoubleVal(2)
+	exemplar.SetTimestamp(pdata.NewTimestampFromTime(end))
+	exemplar.SetTraceID(pdata.NewTraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6}))
+	exemplar.SetSpanID(pdata.NewSpanID([8]byte{0, 1, 2, 3, 4, 5, 6, 7}))
+	exemplar.FilteredAttributes().InsertString("test", "extra")
+
+	// Third point
+	point = hist.DataPoints().AppendEmpty()
+	end2 := end.Add(time.Hour)
+	// Omit start timestamp
+	point.SetTimestamp(pdata.NewTimestampFromTime(end2))
+	point.Positive().SetOffset(0)
+	point.Positive().SetBucketCounts([]uint64{1, 1, 3, 4, 5})
+	point.Negative().SetOffset(0)
+	point.Negative().SetBucketCounts([]uint64{1, 6, 7})
+	point.SetZeroCount(10)
+	point.SetCount(38)
+	point.SetScale(-1)
+	point.SetSum(72)
+	exemplar = point.Exemplars().AppendEmpty()
+	exemplar.SetDoubleVal(2)
+	exemplar.SetTimestamp(pdata.NewTimestampFromTime(end2))
+	exemplar.SetTraceID(pdata.NewTraceID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6}))
+	exemplar.SetSpanID(pdata.NewSpanID([8]byte{0, 1, 2, 3, 4, 5, 6, 7}))
+	exemplar.FilteredAttributes().InsertString("test", "extra")
+
+	tsl := mapper.metricToTimeSeries(mr, labels{}, metric)
+	// expect 2 timeseries, since the first is dropped
+	assert.Len(t, tsl, 2)
+	ts := tsl[0]
+	// Verify aspects
+	assert.Equal(t, metricpb.MetricDescriptor_CUMULATIVE, ts.MetricKind)
+	assert.Equal(t, metricpb.MetricDescriptor_DISTRIBUTION, ts.ValueType)
+	assert.Equal(t, unit, ts.Unit)
+	assert.Same(t, mr, ts.Resource)
+
+	assert.Equal(t, "workload.googleapis.com/myexphist", ts.Metric.Type)
+	assert.Equal(t, map[string]string{}, ts.Metric.Labels)
+
+	assert.Nil(t, ts.Metadata)
+
+	assert.Len(t, ts.Points, 1)
+	assert.Equal(t, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	}, ts.Points[0].Interval)
+	hdp := ts.Points[0].Value.GetDistributionValue()
+	assert.Equal(t, int64(23), hdp.Count)
+	assert.ElementsMatch(t, []int64{16, 1, 1, 2, 3, 0}, hdp.BucketCounts)
+	assert.Equal(t, float64(2), hdp.Mean)
+	assert.Equal(t, float64(4), hdp.BucketOptions.GetExponentialBuckets().GrowthFactor)
+	assert.Equal(t, float64(4), hdp.BucketOptions.GetExponentialBuckets().Scale)
+	assert.Equal(t, int32(4), hdp.BucketOptions.GetExponentialBuckets().NumFiniteBuckets)
+	assert.Len(t, hdp.Exemplars, 1)
+	ex := hdp.Exemplars[0]
+	assert.Equal(t, float64(2), ex.Value)
+	assert.Equal(t, timestamppb.New(end), ex.Timestamp)
+	// We should see trace + dropped labels
+	assert.Len(t, ex.Attachments, 2)
+	spanctx := &monitoringpb.SpanContext{}
+	err := ex.Attachments[0].UnmarshalTo(spanctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "projects/myproject/traces/00010203040506070809010203040506/spans/0001020304050607", spanctx.SpanName)
+	dropped := &monitoringpb.DroppedLabels{}
+	err = ex.Attachments[1].UnmarshalTo(dropped)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{"test": "extra"}, dropped.Label)
+
+	// Check the second point
+	ts = tsl[1]
+	// Verify aspects
+	assert.Equal(t, metricpb.MetricDescriptor_CUMULATIVE, ts.MetricKind)
+	assert.Equal(t, metricpb.MetricDescriptor_DISTRIBUTION, ts.ValueType)
+	assert.Equal(t, unit, ts.Unit)
+	assert.Same(t, mr, ts.Resource)
+
+	assert.Equal(t, "workload.googleapis.com/myexphist", ts.Metric.Type)
+	assert.Equal(t, map[string]string{}, ts.Metric.Labels)
+
+	assert.Nil(t, ts.Metadata)
+
+	assert.Len(t, ts.Points, 1)
+	assert.Equal(t, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end2),
+	}, ts.Points[0].Interval)
+	hdp = ts.Points[0].Value.GetDistributionValue()
+	assert.Equal(t, int64(31), hdp.Count)
+	assert.ElementsMatch(t, []int64{20, 1, 1, 2, 3, 4, 0}, hdp.BucketCounts)
+	assert.Equal(t, float64(2), hdp.Mean)
+	assert.Equal(t, float64(4), hdp.BucketOptions.GetExponentialBuckets().GrowthFactor)
+	assert.Equal(t, float64(1), hdp.BucketOptions.GetExponentialBuckets().Scale)
+	assert.Equal(t, int32(5), hdp.BucketOptions.GetExponentialBuckets().NumFiniteBuckets)
+	assert.Len(t, hdp.Exemplars, 1)
+	ex = hdp.Exemplars[0]
+	assert.Equal(t, float64(2), ex.Value)
+	assert.Equal(t, timestamppb.New(end2), ex.Timestamp)
+	// We should see trace + dropped labels
+	assert.Len(t, ex.Attachments, 2)
+	spanctx = &monitoringpb.SpanContext{}
+	err = ex.Attachments[0].UnmarshalTo(spanctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "projects/myproject/traces/00010203040506070809010203040506/spans/0001020304050607", spanctx.SpanName)
+	dropped = &monitoringpb.DroppedLabels{}
 	err = ex.Attachments[1].UnmarshalTo(dropped)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]string{"test": "extra"}, dropped.Label)
@@ -966,6 +1256,149 @@ func TestSummaryPointToTimeSeries(t *testing.T) {
 	assert.Len(t, quantileResult.Points, 1)
 	assert.Equal(t, quantileResult.Points[0].Interval, &monitoringpb.TimeInterval{
 		EndTime: timestamppb.New(end),
+	})
+	assert.Equal(t, quantileResult.Points[0].Value.GetDoubleValue(), 1.0)
+}
+
+func TestSummaryPointWithoutStartTimeToTimeSeries(t *testing.T) {
+	mapper, shutdown := newTestMetricMapper()
+	defer shutdown()
+	mr := &monitoredrespb.MonitoredResource{}
+
+	metric := pdata.NewMetric()
+	metric.SetDataType(pmetric.MetricDataTypeSummary)
+	summary := metric.Summary()
+	point := summary.DataPoints().AppendEmpty()
+
+	metric.SetName("mysummary")
+	metric.SetUnit("1")
+	point.SetCount(10)
+	point.SetSum(100.0)
+	quantile := point.QuantileValues().AppendEmpty()
+	quantile.SetQuantile(1.0)
+	quantile.SetValue(1.0)
+	// Don't set start timestamp.  This point will be dropped
+	point.SetTimestamp(pdata.NewTimestampFromTime(start))
+
+	point = summary.DataPoints().AppendEmpty()
+	metric.SetName("mysummary")
+	metric.SetUnit("1")
+	point.SetCount(20)
+	point.SetSum(200.0)
+	quantile = point.QuantileValues().AppendEmpty()
+	quantile.SetQuantile(1.0)
+	quantile.SetValue(1.0)
+	end := start.Add(time.Hour)
+	// Don't set start timestamp.  This point will be normalized
+	point.SetTimestamp(pdata.NewTimestampFromTime(end))
+
+	point = summary.DataPoints().AppendEmpty()
+	metric.SetName("mysummary")
+	metric.SetUnit("1")
+	point.SetCount(30)
+	point.SetSum(300.0)
+	quantile = point.QuantileValues().AppendEmpty()
+	quantile.SetQuantile(1.0)
+	quantile.SetValue(1.0)
+	end2 := end.Add(time.Hour)
+	// Don't set start timestamp.  This point will be normalized
+	point.SetTimestamp(pdata.NewTimestampFromTime(end2))
+
+	ts := mapper.metricToTimeSeries(mr, labels{}, metric)
+	assert.Len(t, ts, 6)
+	sumResult := ts[0]
+	countResult := ts[1]
+	quantileResult := ts[2]
+
+	// Test sum mapping
+	assert.Equal(t, sumResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+	assert.Equal(t, sumResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, sumResult.Unit, "1")
+	assert.Same(t, sumResult.Resource, mr)
+	assert.Equal(t, sumResult.Metric.Type, "workload.googleapis.com/mysummary_sum")
+	assert.Equal(t, sumResult.Metric.Labels, map[string]string{})
+	assert.Nil(t, sumResult.Metadata)
+	assert.Len(t, sumResult.Points, 1)
+	assert.Equal(t, sumResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	})
+	assert.Equal(t, sumResult.Points[0].Value.GetDoubleValue(), 100.0)
+	// Test count mapping
+	assert.Equal(t, countResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+	assert.Equal(t, countResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, countResult.Unit, "1")
+	assert.Same(t, countResult.Resource, mr)
+	assert.Equal(t, countResult.Metric.Type, "workload.googleapis.com/mysummary_count")
+	assert.Equal(t, countResult.Metric.Labels, map[string]string{})
+	assert.Nil(t, countResult.Metadata)
+	assert.Len(t, countResult.Points, 1)
+	assert.Equal(t, countResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+	})
+	assert.Equal(t, countResult.Points[0].Value.GetDoubleValue(), float64(10))
+	// Test quantile mapping
+	assert.Equal(t, quantileResult.MetricKind, metricpb.MetricDescriptor_GAUGE)
+	assert.Equal(t, quantileResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, quantileResult.Unit, "1")
+	assert.Same(t, quantileResult.Resource, mr)
+	assert.Equal(t, quantileResult.Metric.Type, "workload.googleapis.com/mysummary")
+	assert.Equal(t, quantileResult.Metric.Labels, map[string]string{
+		"quantile": "1",
+	})
+	assert.Nil(t, quantileResult.Metadata)
+	assert.Len(t, quantileResult.Points, 1)
+	assert.Equal(t, quantileResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: timestamppb.New(end),
+	})
+	assert.Equal(t, quantileResult.Points[0].Value.GetDoubleValue(), 1.0)
+
+	sumResult = ts[3]
+	countResult = ts[4]
+	quantileResult = ts[5]
+
+	// Test sum mapping
+	assert.Equal(t, sumResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+	assert.Equal(t, sumResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, sumResult.Unit, "1")
+	assert.Same(t, sumResult.Resource, mr)
+	assert.Equal(t, sumResult.Metric.Type, "workload.googleapis.com/mysummary_sum")
+	assert.Equal(t, sumResult.Metric.Labels, map[string]string{})
+	assert.Nil(t, sumResult.Metadata)
+	assert.Len(t, sumResult.Points, 1)
+	assert.Equal(t, sumResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end2),
+	})
+	assert.Equal(t, sumResult.Points[0].Value.GetDoubleValue(), 200.0)
+	// Test count mapping
+	assert.Equal(t, countResult.MetricKind, metricpb.MetricDescriptor_CUMULATIVE)
+	assert.Equal(t, countResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, countResult.Unit, "1")
+	assert.Same(t, countResult.Resource, mr)
+	assert.Equal(t, countResult.Metric.Type, "workload.googleapis.com/mysummary_count")
+	assert.Equal(t, countResult.Metric.Labels, map[string]string{})
+	assert.Nil(t, countResult.Metadata)
+	assert.Len(t, countResult.Points, 1)
+	assert.Equal(t, countResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end2),
+	})
+	assert.Equal(t, countResult.Points[0].Value.GetDoubleValue(), float64(20))
+	// Test quantile mapping
+	assert.Equal(t, quantileResult.MetricKind, metricpb.MetricDescriptor_GAUGE)
+	assert.Equal(t, quantileResult.ValueType, metricpb.MetricDescriptor_DOUBLE)
+	assert.Equal(t, quantileResult.Unit, "1")
+	assert.Same(t, quantileResult.Resource, mr)
+	assert.Equal(t, quantileResult.Metric.Type, "workload.googleapis.com/mysummary")
+	assert.Equal(t, quantileResult.Metric.Labels, map[string]string{
+		"quantile": "1",
+	})
+	assert.Nil(t, quantileResult.Metadata)
+	assert.Len(t, quantileResult.Points, 1)
+	assert.Equal(t, quantileResult.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: timestamppb.New(end2),
 	})
 	assert.Equal(t, quantileResult.Points[0].Value.GetDoubleValue(), 1.0)
 }

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -333,6 +333,7 @@ func TestHistogramPointWithoutTimestampToTimeSeries(t *testing.T) {
 	unit := "1"
 	metric.SetUnit(unit)
 	hist := metric.Histogram()
+	hist.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 	point := hist.DataPoints().AppendEmpty()
 	// leave start time unset with the intended start time
 	point.SetTimestamp(pdata.NewTimestampFromTime(start))
@@ -687,6 +688,7 @@ func TestExponentialHistogramPointWithoutStartTimeToTimeSeries(t *testing.T) {
 	unit := "1"
 	metric.SetUnit(unit)
 	hist := metric.ExponentialHistogram()
+	hist.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 
 	// First point will be dropped, since it has no start time.
 	point := hist.DataPoints().AppendEmpty()


### PR DESCRIPTION
## Background

Normalization is done for cumulative streams of metrics.  For example, if we have a counter that counts the number of seconds since 1970, we wouldn't want to report that number as having happened since we started reading it, since that would produce an enormous rate  (>1 billion over 10 seconds).  Instead, the first time we see a metric, we record its current value.  Then, each time we see the metric again, we "subtract" the original value from the new one.  That is trivial for a counter, and we already did that in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/323.  It is harder for other data types (how do you subtract a histogram from another histogram?).

## Changes

This PR extends tracking for the first time we saw a metric by extending the data point cache for other types.  It then copies logic for setting the start time for intervals from the sum implementation.  Finally, it implements "subtraction" for each of the remaining types: summaries, histograms, and exponential histograms.

For histograms, just subtract the previous sum, previous count, and subtract each bucket from the previous point.

For summaries, leave the quantiles as they are (treat them like gauges passing through), and just subtract previous sum and previous count.

For exponential histograms, subtract the previous sum, previous count.  Also subtract each bucket from the previous point, taking the offset into account.