### PR TITLE
Batch multiple entries into a maximum request size

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -104,13 +104,6 @@ type ResourceFilter struct {
 
 type LogConfig struct {
 	DefaultLogName string `mapstructure:"default_log_name"`
-
-	// MaxBatchSize defines the maximum size in bytes for a batched request of log entries
-	// 0 defaults to the Cloud Logging API's maximum request size (10 MB)
-	MaxBatchSize int `mapstructure:"max_batch_size"`
-	// MaxEntrySize defines the maximum size in bytes for an individual log entry.
-	// 0 uses the default as defined by the Cloud Logging API (256 KB)
-	MaxEntrySize int `mapstructure:"max_entry_size"`
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -104,6 +104,13 @@ type ResourceFilter struct {
 
 type LogConfig struct {
 	DefaultLogName string `mapstructure:"default_log_name"`
+
+	// MaxBatchSize defines the maximum size in bytes for a batched request of log entries
+	// 0 defaults to the Cloud Logging API's maximum request size (10 MB)
+	MaxBatchSize int `mapstructure:"max_batch_size"`
+	// MaxEntrySize defines the maximum size in bytes for an individual log entry.
+	// 0 uses the default as defined by the Cloud Logging API (256 KB)
+	MaxEntrySize int `mapstructure:"max_entry_size"`
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -237,6 +237,7 @@ func TestLogMapping(t *testing.T) {
 			if testCase.expectError {
 				assert.NotNil(t, err)
 			} else {
+				assert.Nil(t, err)
 				assert.Equal(t, testCase.expectedEntry, entry)
 			}
 		})
@@ -277,7 +278,57 @@ func TestGetLogName(t *testing.T) {
 			if testCase.expectError {
 				assert.NotNil(t, err)
 			} else {
+				assert.Nil(t, err)
 				assert.Equal(t, testCase.expectedName, name)
+			}
+		})
+	}
+}
+
+func TestCreateBatches(t *testing.T) {
+	testCases := []struct {
+		name          string
+		logs          func() plog.Logs
+		expectError   bool
+		expectedCount int
+	}{
+		{
+			name: "test batching requests",
+			logs: func() plog.Logs {
+				logs := plog.NewLogs()
+				rl := plog.NewResourceLogsSlice()
+				resourceLogs := rl.AppendEmpty()
+				sl := plog.NewScopeLogsSlice()
+				scopeLogs := sl.AppendEmpty()
+				lr := plog.NewLogRecordSlice()
+
+				logRecordOne := lr.AppendEmpty()
+				logRecordOne.Body().SetStringVal("foo")
+				logRecordTwo := lr.AppendEmpty()
+				logRecordTwo.Body().SetStringVal("bar")
+				logRecordThree := lr.AppendEmpty()
+				logRecordThree.Body().SetStringVal("baz")
+
+				lr.CopyTo(scopeLogs.LogRecords())
+				sl.CopyTo(resourceLogs.ScopeLogs())
+				rl.CopyTo(logs.ResourceLogs())
+				return logs
+			},
+			expectedCount: 3,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			le := newTestLogMapper()
+			le.cfg.LogConfig.MaxBatchSize = 1
+
+			batches, err := le.createBatches(testCase.logs())
+			if testCase.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.NoErrorf(t, err, "error")
+				assert.Equal(t, testCase.expectedCount, len(batches))
 			}
 		})
 	}

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -285,55 +285,6 @@ func TestGetLogName(t *testing.T) {
 	}
 }
 
-func TestCreateBatches(t *testing.T) {
-	testCases := []struct {
-		name          string
-		logs          func() plog.Logs
-		expectError   bool
-		expectedCount int
-	}{
-		{
-			name: "test batching requests",
-			logs: func() plog.Logs {
-				logs := plog.NewLogs()
-				rl := plog.NewResourceLogsSlice()
-				resourceLogs := rl.AppendEmpty()
-				sl := plog.NewScopeLogsSlice()
-				scopeLogs := sl.AppendEmpty()
-				lr := plog.NewLogRecordSlice()
-
-				logRecordOne := lr.AppendEmpty()
-				logRecordOne.Body().SetStringVal("foo")
-				logRecordTwo := lr.AppendEmpty()
-				logRecordTwo.Body().SetStringVal("bar")
-				logRecordThree := lr.AppendEmpty()
-				logRecordThree.Body().SetStringVal("baz")
-
-				lr.CopyTo(scopeLogs.LogRecords())
-				sl.CopyTo(resourceLogs.ScopeLogs())
-				rl.CopyTo(logs.ResourceLogs())
-				return logs
-			},
-			expectedCount: 3,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			le := newTestLogMapper()
-			le.cfg.LogConfig.MaxBatchSize = 1
-
-			batches, err := le.createBatches(testCase.logs())
-			if testCase.expectError {
-				assert.NotNil(t, err)
-			} else {
-				assert.NoErrorf(t, err, "error")
-				assert.Equal(t, testCase.expectedCount, len(batches))
-			}
-		})
-	}
-}
-
 func makeExpectedHTTPReq(method, url, referer, userAgent string, body io.Reader) *http.Request {
 	req, _ := http.NewRequest(method, url, body)
 	req.Header.Set("Referer", referer)


### PR DESCRIPTION
This adds batching for an entire request, grouping log records into requests below a configurable size

Follow up will add request sizing for an individual entry

xref b/228844902