### PR TITLE
Update logging exporter to use "gcp.*" prefix for attributes

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access.json
@@ -16,7 +16,7 @@
           "scope": {},
           "logRecords": [
             {
-              "timeUnixNano": "1650994483968433711",
+              "timeUnixNano": "1650984816000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -28,22 +28,10 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": "/"
-                          }
-                        },
                         {
                           "key": "userAgent",
                           "value": {
@@ -51,27 +39,9 @@
                           }
                         },
                         {
-                          "key": "host",
+                          "key": "requestMethod",
                           "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:36 +0800"
+                            "stringValue": "GET"
                           }
                         },
                         {
@@ -81,9 +51,39 @@
                           }
                         },
                         {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
                           "key": "referer",
                           "value": {
                             "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:36 +0800"
                           }
                         },
                         {
@@ -93,9 +93,9 @@
                           }
                         },
                         {
-                          "key": "responseSize",
+                          "key": "host",
                           "value": {
-                            "stringValue": "1247"
+                            "stringValue": "-"
                           }
                         }
                       ]
@@ -103,7 +103,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -113,7 +113,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968470678",
+              "timeUnixNano": "1650984817000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164"
               },
@@ -125,26 +125,20 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
                         {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
                           "key": "time",
                           "value": {
                             "stringValue": "26/Apr/2022:22:53:37 +0800"
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
                           }
                         },
                         {
@@ -154,9 +148,9 @@
                           }
                         },
                         {
-                          "key": "referer",
+                          "key": "remoteIp",
                           "value": {
-                            "stringValue": ""
+                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
@@ -166,9 +160,9 @@
                           }
                         },
                         {
-                          "key": "requestUrl",
+                          "key": "protocol",
                           "value": {
-                            "stringValue": "/lamp.png"
+                            "stringValue": "HTTP/1.1"
                           }
                         },
                         {
@@ -178,15 +172,15 @@
                           }
                         },
                         {
-                          "key": "protocol",
+                          "key": "host",
                           "value": {
-                            "stringValue": "HTTP/1.1"
+                            "stringValue": "-"
                           }
                         },
                         {
-                          "key": "user",
+                          "key": "requestUrl",
                           "value": {
-                            "stringValue": "-"
+                            "stringValue": "/lamp.png"
                           }
                         },
                         {
@@ -194,13 +188,19 @@
                           "value": {
                             "stringValue": "51164"
                           }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
                         }
                       ]
                     }
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -210,7 +210,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968481764",
+              "timeUnixNano": "1650984817000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990"
               },
@@ -222,62 +222,14 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
                         {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "3990"
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
                           "key": "requestUrl",
                           "value": {
                             "stringValue": "/favicon.ico"
-                          }
-                        },
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:37 +0800"
                           }
                         },
                         {
@@ -287,9 +239,57 @@
                           }
                         },
                         {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "3990"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
                           "key": "host",
                           "value": {
                             "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:37 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
                           }
                         }
                       ]
@@ -297,7 +297,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -307,7 +307,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968490059",
+              "timeUnixNano": "1650984831000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -319,14 +319,14 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
                         {
-                          "key": "user",
+                          "key": "remoteIp",
                           "value": {
-                            "stringValue": "-"
+                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
@@ -342,39 +342,9 @@
                           }
                         },
                         {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
                           "key": "referer",
                           "value": {
                             "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
@@ -384,9 +354,39 @@
                           }
                         },
                         {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
                           "key": "requestUrl",
                           "value": {
                             "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
                           }
                         }
                       ]
@@ -394,7 +394,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -404,7 +404,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968496637",
+              "timeUnixNano": "1650984832000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -416,20 +416,14 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
                         {
-                          "key": "responseSize",
+                          "key": "user",
                           "value": {
-                            "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
+                            "stringValue": "-"
                           }
                         },
                         {
@@ -439,6 +433,42 @@
                           }
                         },
                         {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
                           "key": "requestMethod",
                           "value": {
                             "stringValue": "GET"
@@ -448,6 +478,67 @@
                           "key": "requestUrl",
                           "value": {
                             "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984833000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
                           }
                         },
                         {
@@ -463,21 +554,124 @@
                           }
                         },
                         {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:53 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
                           "key": "user",
                           "value": {
                             "stringValue": "-"
                           }
                         },
                         {
-                          "key": "status",
+                          "key": "protocol",
                           "value": {
-                            "stringValue": "200"
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984833000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:53 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
                           "key": "host",
                           "value": {
                             "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
                           }
                         },
                         {
@@ -491,7 +685,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -501,7 +695,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968517647",
+              "timeUnixNano": "1650984833000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -513,7 +707,7 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
@@ -524,21 +718,39 @@
                           }
                         },
                         {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
                           "key": "remoteIp",
                           "value": {
                             "stringValue": "127.0.0.1"
                           }
                         },
                         {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
                           "key": "host",
                           "value": {
                             "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
                           }
                         },
                         {
@@ -560,27 +772,9 @@
                           }
                         },
                         {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
                           "key": "protocol",
                           "value": {
                             "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
                           }
                         }
                       ]
@@ -588,7 +782,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -598,7 +792,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968525857",
+              "timeUnixNano": "1650984833000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -610,7 +804,7 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
@@ -618,42 +812,6 @@
                           "key": "responseSize",
                           "value": {
                             "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": "/"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
                           }
                         },
                         {
@@ -669,67 +827,6 @@
                           }
                         },
                         {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "key": "com.google.logName",
-                  "value": {
-                    "stringValue": "my-log-name-foo"
-                  }
-                }
-              ],
-              "traceId": "",
-              "spanId": ""
-            },
-            {
-              "timeUnixNano": "1650994483968532546",
-              "body": {
-                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
-              },
-              "attributes": [
-                {
-                  "key": "log.file.name",
-                  "value": {
-                    "stringValue": "test.log"
-                  }
-                },
-                {
-                  "key": "com.google.httpRequest",
-                  "value": {
-                    "kvlistValue": {
-                      "values": [
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:53 +0800"
-                          }
-                        },
-                        {
                           "key": "userAgent",
                           "value": {
                             "stringValue": ""
@@ -742,15 +839,27 @@
                           }
                         },
                         {
-                          "key": "responseSize",
+                          "key": "referer",
                           "value": {
-                            "stringValue": "1247"
+                            "stringValue": ""
                           }
                         },
                         {
                           "key": "host",
                           "value": {
                             "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
@@ -764,25 +873,13 @@
                           "value": {
                             "stringValue": "200"
                           }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
                         }
                       ]
                     }
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -792,104 +889,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968539797",
-              "body": {
-                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
-              },
-              "attributes": [
-                {
-                  "key": "log.file.name",
-                  "value": {
-                    "stringValue": "test.log"
-                  }
-                },
-                {
-                  "key": "com.google.httpRequest",
-                  "value": {
-                    "kvlistValue": {
-                      "values": [
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": "/"
-                          }
-                        },
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:53 +0800"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "key": "com.google.logName",
-                  "value": {
-                    "stringValue": "my-log-name-foo"
-                  }
-                }
-              ],
-              "traceId": "",
-              "spanId": ""
-            },
-            {
-              "timeUnixNano": "1650994483968548970",
+              "timeUnixNano": "1650984834000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -901,131 +901,10 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": "/"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:54 +0800"
-                          }
-                        },
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "key": "com.google.logName",
-                  "value": {
-                    "stringValue": "my-log-name-foo"
-                  }
-                }
-              ],
-              "traceId": "",
-              "spanId": ""
-            },
-            {
-              "timeUnixNano": "1650994483968557408",
-              "body": {
-                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
-              },
-              "attributes": [
-                {
-                  "key": "log.file.name",
-                  "value": {
-                    "stringValue": "test.log"
-                  }
-                },
-                {
-                  "key": "com.google.httpRequest",
-                  "value": {
-                    "kvlistValue": {
-                      "values": [
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": "/"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
                         {
                           "key": "remoteIp",
                           "value": {
@@ -1039,183 +918,13 @@
                           }
                         },
                         {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:54 +0800"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
                           "key": "protocol",
                           "value": {
                             "stringValue": "HTTP/1.1"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "key": "com.google.logName",
-                  "value": {
-                    "stringValue": "my-log-name-foo"
-                  }
-                }
-              ],
-              "traceId": "",
-              "spanId": ""
-            },
-            {
-              "timeUnixNano": "1650994483968564828",
-              "body": {
-                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
-              },
-              "attributes": [
-                {
-                  "key": "log.file.name",
-                  "value": {
-                    "stringValue": "test.log"
-                  }
-                },
-                {
-                  "key": "com.google.httpRequest",
-                  "value": {
-                    "kvlistValue": {
-                      "values": [
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": "/"
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:54 +0800"
-                          }
-                        },
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
                           }
                         },
                         {
                           "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "key": "com.google.logName",
-                  "value": {
-                    "stringValue": "my-log-name-foo"
-                  }
-                }
-              ],
-              "traceId": "",
-              "spanId": ""
-            },
-            {
-              "timeUnixNano": "1650994483968571303",
-              "body": {
-                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
-              },
-              "attributes": [
-                {
-                  "key": "com.google.httpRequest",
-                  "value": {
-                    "kvlistValue": {
-                      "values": [
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "protocol",
-                          "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "responseSize",
-                          "value": {
-                            "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
                           "value": {
                             "stringValue": ""
                           }
@@ -1233,9 +942,27 @@
                           }
                         },
                         {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
                           "key": "host",
                           "value": {
                             "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
                           }
                         },
                         {
@@ -1243,31 +970,13 @@
                           "value": {
                             "stringValue": "/"
                           }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
                         }
                       ]
                     }
                   }
                 },
                 {
-                  "key": "log.file.name",
-                  "value": {
-                    "stringValue": "test.log"
-                  }
-                },
-                {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -1277,7 +986,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968578924",
+              "timeUnixNano": "1650984834000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -1289,10 +998,58 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
                         {
                           "key": "requestUrl",
                           "value": {
@@ -1300,9 +1057,70 @@
                           }
                         },
                         {
-                          "key": "responseSize",
+                          "key": "status",
                           "value": {
-                            "stringValue": "1247"
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
                           }
                         },
                         {
@@ -1318,9 +1136,185 @@
                           }
                         },
                         {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
                           "key": "referer",
                           "value": {
                             "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
                           }
                         },
                         {
@@ -1348,13 +1342,13 @@
                           }
                         },
                         {
-                          "key": "time",
+                          "key": "protocol",
                           "value": {
-                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                            "stringValue": "HTTP/1.1"
                           }
                         },
                         {
-                          "key": "userAgent",
+                          "key": "referer",
                           "value": {
                             "stringValue": ""
                           }
@@ -1364,7 +1358,13 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -1374,7 +1374,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968584858",
+              "timeUnixNano": "1650984834000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
               },
@@ -1386,20 +1386,14 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
                         {
-                          "key": "requestUrl",
+                          "key": "referer",
                           "value": {
-                            "stringValue": "/"
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
+                            "stringValue": ""
                           }
                         },
                         {
@@ -1409,21 +1403,15 @@
                           }
                         },
                         {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
                           "key": "responseSize",
                           "value": {
                             "stringValue": "1247"
-                          }
-                        },
-                        {
-                          "key": "time",
-                          "value": {
-                            "stringValue": "26/Apr/2022:22:53:54 +0800"
-                          }
-                        },
-                        {
-                          "key": "requestMethod",
-                          "value": {
-                            "stringValue": "GET"
                           }
                         },
                         {
@@ -1433,21 +1421,9 @@
                           }
                         },
                         {
-                          "key": "protocol",
+                          "key": "remoteIp",
                           "value": {
-                            "stringValue": "HTTP/1.1"
-                          }
-                        },
-                        {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "referer",
-                          "value": {
-                            "stringValue": ""
+                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
@@ -1455,13 +1431,37 @@
                           "value": {
                             "stringValue": "-"
                           }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
                         }
                       ]
                     }
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -1471,7 +1471,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968591035",
+              "timeUnixNano": "1650984878000000000",
               "body": {
                 "stringValue": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429"
               },
@@ -1483,10 +1483,34 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
                         {
                           "key": "time",
                           "value": {
@@ -1500,33 +1524,15 @@
                           }
                         },
                         {
-                          "key": "status",
-                          "value": {
-                            "stringValue": "200"
-                          }
-                        },
-                        {
-                          "key": "userAgent",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
                           "key": "protocol",
                           "value": {
                             "stringValue": "HTTP/1.1"
                           }
                         },
                         {
-                          "key": "host",
+                          "key": "remoteIp",
                           "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
-                          "key": "user",
-                          "value": {
-                            "stringValue": "-"
+                            "stringValue": "127.0.0.2"
                           }
                         },
                         {
@@ -1542,15 +1548,9 @@
                           }
                         },
                         {
-                          "key": "referer",
+                          "key": "host",
                           "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.2"
+                            "stringValue": "-"
                           }
                         }
                       ]
@@ -1558,7 +1558,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }
@@ -1568,7 +1568,7 @@
               "spanId": ""
             },
             {
-              "timeUnixNano": "1650994483968597344",
+              "timeUnixNano": "1650984883000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -"
               },
@@ -1580,7 +1580,7 @@
                   }
                 },
                 {
-                  "key": "com.google.httpRequest",
+                  "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {
                       "values": [
@@ -1591,33 +1591,27 @@
                           }
                         },
                         {
-                          "key": "remoteIp",
-                          "value": {
-                            "stringValue": "127.0.0.1"
-                          }
-                        },
-                        {
-                          "key": "requestUrl",
-                          "value": {
-                            "stringValue": ""
-                          }
-                        },
-                        {
-                          "key": "host",
-                          "value": {
-                            "stringValue": "-"
-                          }
-                        },
-                        {
                           "key": "user",
                           "value": {
                             "stringValue": "-"
                           }
                         },
                         {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:54:43 +0800"
+                          }
+                        },
+                        {
                           "key": "responseSize",
                           "value": {
                             "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
                           }
                         },
                         {
@@ -1639,15 +1633,21 @@
                           }
                         },
                         {
-                          "key": "referer",
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
                           "value": {
                             "stringValue": ""
                           }
                         },
                         {
-                          "key": "time",
+                          "key": "referer",
                           "value": {
-                            "stringValue": "26/Apr/2022:22:54:43 +0800"
+                            "stringValue": ""
                           }
                         }
                       ]
@@ -1655,7 +1655,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
                   }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access_expected.json
@@ -12,7 +12,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -32,7 +32,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/lamp.png",
@@ -52,7 +52,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/favicon.ico",
@@ -72,7 +72,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -92,7 +92,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -112,7 +112,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -132,7 +132,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -152,7 +152,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -172,7 +172,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -192,7 +192,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -212,7 +212,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -232,7 +232,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -252,7 +252,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -272,7 +272,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -292,7 +292,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -312,7 +312,7 @@
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -332,7 +332,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         }
       ],
       "partialSuccess": true

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error.json
@@ -1,7 +1,16 @@
 {
   "resourceLogs": [
     {
-      "resource": {},
+      "resource": {
+        "attributes": [
+          {
+            "key": "cloud.platform",
+            "value": {
+              "stringValue": "gcp_compute_engine"
+            }
+          }
+        ]
+      },
       "scopeLogs": [
         {
           "scope": {},
@@ -12,6 +21,12 @@
                 "kvlistValue": {
                   "values": [
                     {
+                      "key": "message",
+                      "value": {
+                        "stringValue": "[pid 417652:tid 139808755448704] AH01232: suEXEC mechanism enabled (wrapper: /usr/local/apache/bin/suexec)"
+                      }
+                    },
+                    {
                       "key": "time",
                       "value": {
                         "stringValue": "Tue Apr 26 00:46:21.412645 2022"
@@ -21,12 +36,6 @@
                       "key": "severity",
                       "value": {
                         "stringValue": "notice"
-                      }
-                    },
-                    {
-                      "key": "message",
-                      "value": {
-                        "stringValue": "[pid 417652:tid 139808755448704] AH01232: suEXEC mechanism enabled (wrapper: /usr/local/apache/bin/suexec)"
                       }
                     }
                   ]
@@ -40,7 +49,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -85,7 +94,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -128,7 +137,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -143,6 +152,12 @@
                 "kvlistValue": {
                   "values": [
                     {
+                      "key": "time",
+                      "value": {
+                        "stringValue": "Tue Apr 26 00:46:21.503003 2022"
+                      }
+                    },
+                    {
                       "key": "severity",
                       "value": {
                         "stringValue": "notice"
@@ -152,12 +167,6 @@
                       "key": "message",
                       "value": {
                         "stringValue": "[pid 417653:tid 139808755448704] AH00094: Command line: '/usr/local/apache/bin/httpd'"
-                      }
-                    },
-                    {
-                      "key": "time",
-                      "value": {
-                        "stringValue": "Tue Apr 26 00:46:21.503003 2022"
                       }
                     }
                   ]
@@ -171,7 +180,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -186,12 +195,6 @@
                 "kvlistValue": {
                   "values": [
                     {
-                      "key": "message",
-                      "value": {
-                        "stringValue": "[pid 417653:tid 139808755448704] AH00491: caught SIGTERM, shutting down"
-                      }
-                    },
-                    {
                       "key": "time",
                       "value": {
                         "stringValue": "Tue Apr 26 00:46:38.988423 2022"
@@ -201,6 +204,12 @@
                       "key": "severity",
                       "value": {
                         "stringValue": "notice"
+                      }
+                    },
+                    {
+                      "key": "message",
+                      "value": {
+                        "stringValue": "[pid 417653:tid 139808755448704] AH00491: caught SIGTERM, shutting down"
                       }
                     }
                   ]
@@ -214,7 +223,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -257,7 +266,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -302,7 +311,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -317,6 +326,12 @@
                 "kvlistValue": {
                   "values": [
                     {
+                      "key": "time",
+                      "value": {
+                        "stringValue": "Tue Apr 26 22:48:35.606223 2022"
+                      }
+                    },
+                    {
                       "key": "severity",
                       "value": {
                         "stringValue": "notice"
@@ -326,12 +341,6 @@
                       "key": "message",
                       "value": {
                         "stringValue": "[pid 769:tid 140159306111872] AH00489: Apache/2.4.46 (Unix) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.6 configured -- resuming normal operations"
-                      }
-                    },
-                    {
-                      "key": "time",
-                      "value": {
-                        "stringValue": "Tue Apr 26 22:48:35.606223 2022"
                       }
                     }
                   ]
@@ -345,7 +354,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }
@@ -360,6 +369,12 @@
                 "kvlistValue": {
                   "values": [
                     {
+                      "key": "time",
+                      "value": {
+                        "stringValue": "Tue Apr 26 22:48:35.606298 2022"
+                      }
+                    },
+                    {
                       "key": "severity",
                       "value": {
                         "stringValue": "notice"
@@ -369,12 +384,6 @@
                       "key": "message",
                       "value": {
                         "stringValue": "[pid 769:tid 140159306111872] AH00094: Command line: '/usr/local/apache/bin/httpd'"
-                      }
-                    },
-                    {
-                      "key": "time",
-                      "value": {
-                        "stringValue": "Tue Apr 26 22:48:35.606298 2022"
                       }
                     }
                   ]
@@ -388,7 +397,7 @@
                   }
                 },
                 {
-                  "key": "com.google.logName",
+                  "key": "gcp.log_name",
                   "value": {
                     "stringValue": "apache-error-fixture"
                   }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error_expected.json
@@ -5,11 +5,10 @@
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -17,16 +16,15 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.412645 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -34,17 +32,16 @@
             "severity": "warn",
             "time": "Tue Apr 26 00:46:21.457314 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "severity": "WARNING"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -52,16 +49,15 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.502940 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -69,16 +65,15 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.503003 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -86,16 +81,15 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:38.988423 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -103,16 +97,15 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:34.466058 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -120,17 +113,16 @@
             "severity": "warn",
             "time": "Tue Apr 26 22:48:34.740290 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z",
+          "timestamp": "2022-05-02T12:16:14.574548493Z",
           "severity": "WARNING"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -138,16 +130,15 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:35.606223 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
           "resource": {
-            "type": "generic_node",
+            "type": "gce_instance",
             "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
+              "instance_id": "",
+              "zone": ""
             }
           },
           "jsonPayload": {
@@ -155,7 +146,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:35.606298 2022"
           },
-          "timestamp": "2022-04-28T17:26:45.136110082Z"
+          "timestamp": "2022-05-02T12:16:14.574548493Z"
         }
       ],
       "partialSuccess": true

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -34,10 +34,12 @@ import (
 )
 
 const (
-	HTTPRequestAttributeKey = "com.google.httpRequest"
-
 	defaultMaxEntrySize   = 256000   // 256 KB
 	defaultMaxRequestSize = 10000000 // 10 MB
+
+	HTTPRequestAttributeKey    = "gcp.http_request"
+	LogNameAttributeKey        = "gcp.log_name"
+	SourceLocationAttributeKey = "gcp.source_location"
 )
 
 // severityMapping maps the integer severity level values from OTel [0-24]
@@ -225,14 +227,14 @@ func (l *LogsExporter) writeLogEntries(ctx context.Context, batch []*logpb.LogEn
 }
 
 func (l logMapper) getLogName(log plog.LogRecord) (string, error) {
-	logNameAttr, exists := log.Attributes().Get("com.google.logName")
+	logNameAttr, exists := log.Attributes().Get(LogNameAttributeKey)
 	if exists {
 		return logNameAttr.AsString(), nil
 	}
 	if len(l.cfg.LogConfig.DefaultLogName) > 0 {
 		return l.cfg.LogConfig.DefaultLogName, nil
 	}
-	return "", fmt.Errorf("no log name provided.  Set the 'default_log_name' option, or add the 'com.google.logName' attribute to set a log name")
+	return "", fmt.Errorf("no log name provided.  Set the 'default_log_name' option, or add the 'gcp.log_name' attribute to set a log name")
 }
 
 func (l logMapper) logToEntry(
@@ -263,7 +265,7 @@ func (l logMapper) logToEntry(
 	}
 
 	// parse LogEntrySourceLocation struct from OTel attribute
-	sourceLocation, ok := log.Attributes().Get("com.google.sourceLocation")
+	sourceLocation, ok := log.Attributes().Get(SourceLocationAttributeKey)
 	if ok {
 		var logEntrySourceLocation logpb.LogEntrySourceLocation
 		err := json.Unmarshal(sourceLocation.BytesVal(), &logEntrySourceLocation)

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -163,7 +163,7 @@ func TestLogMapping(t *testing.T) {
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
 				log.Attributes().Insert(
-					"com.google.sourceLocation",
+					SourceLocationAttributeKey,
 					pcommon.NewValueBytes([]byte(`{"file": "test.php", "line":100, "function":"helloWorld"}`)),
 				)
 				return log
@@ -255,7 +255,7 @@ func TestGetLogName(t *testing.T) {
 			name: "log with name attribute",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
-				log.Attributes().Insert("com.google.logName", pcommon.NewValueString("foo-log"))
+				log.Attributes().Insert(LogNameAttributeKey, pcommon.NewValueString("foo-log"))
 				return log
 			},
 			expectedName: "foo-log",


### PR DESCRIPTION
With https://github.com/open-telemetry/opentelemetry-specification/pull/2514 merged the upstream specification now uses `gcp.*` for GCP-specific attributes