### PR TITLE
Add struct tag for sum of squared deviations estimate and factory test.

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -105,7 +105,7 @@ type MetricConfig struct {
 	// This enables calculation of an estimated sum of squared deviation.  It isn't correct,
 	// so we don't send it by default, and don't expose it to users. For some uses, it is
 	// expected, however.
-	EnableSumOfSquaredDeviation bool
+	EnableSumOfSquaredDeviation bool `mapstructure:"sum_of_squared_deviation"`
 }
 
 type ResourceFilter struct {

--- a/exporter/collector/integrationtest/factory_test.go
+++ b/exporter/collector/integrationtest/factory_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/config/configtest"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := collector.DefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+}


### PR DESCRIPTION
This should fix failures in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9679, and adds a test to make sure we don't hit them again.