### PR TITLE
collector: Sanitize invalid UTF-8 in label values.

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -106,6 +106,9 @@ type MetricConfig struct {
 	// so we don't send it by default, and don't expose it to users. For some uses, it is
 	// expected, however.
 	EnableSumOfSquaredDeviation bool `mapstructure:"sum_of_squared_deviation"`
+
+	// This enables sanitization of UTF-8 characters in labels.
+	EnforceUTF8 *bool `mapstructure:"enforce_utf8"`
 }
 
 type ResourceFilter struct {

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -106,9 +106,6 @@ type MetricConfig struct {
 	// so we don't send it by default, and don't expose it to users. For some uses, it is
 	// expected, however.
 	EnableSumOfSquaredDeviation bool `mapstructure:"sum_of_squared_deviation"`
-
-	// This enables sanitization of UTF-8 characters in labels.
-	EnforceUTF8 *bool `mapstructure:"enforce_utf8"`
 }
 
 type ResourceFilter struct {

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -320,8 +320,8 @@ func (m *metricMapper) instrumentationScopeToLabels(is pdata.InstrumentationScop
 		return labels{}
 	}
 	return labels{
-		"instrumentation_source":  is.Name(),
-		"instrumentation_version": is.Version(),
+		"instrumentation_source":  m.maybeSanitizeUTF8(is.Name()),
+		"instrumentation_version": m.maybeSanitizeUTF8(is.Version()),
 	}
 }
 
@@ -414,7 +414,7 @@ func (m *metricMapper) summaryPointToTimeSeries(
 			Metric: &metricpb.Metric{
 				Type: m.metricNameToType(sumName),
 				Labels: mergeLabels(
-					attributesToLabels(point.Attributes()),
+					m.attributesToLabels(point.Attributes()),
 					extraLabels,
 				),
 			},
@@ -436,7 +436,7 @@ func (m *metricMapper) summaryPointToTimeSeries(
 			Metric: &metricpb.Metric{
 				Type: m.metricNameToType(countName),
 				Labels: mergeLabels(
-					attributesToLabels(point.Attributes()),
+					m.attributesToLabels(point.Attributes()),
 					extraLabels,
 				),
 			},
@@ -464,7 +464,7 @@ func (m *metricMapper) summaryPointToTimeSeries(
 			Metric: &metricpb.Metric{
 				Type: m.metricNameToType(metric.Name()),
 				Labels: mergeLabels(
-					attributesToLabels(point.Attributes()),
+					m.attributesToLabels(point.Attributes()),
 					extraLabels,
 					pLabel,
 				),
@@ -493,7 +493,7 @@ func (m *metricMapper) exemplar(ex pdata.Exemplar) *distribution.Distribution_Ex
 	}
 	if ex.FilteredAttributes().Len() > 0 {
 		attr, err := anypb.New(&monitoringpb.DroppedLabels{
-			Label: attributesToLabels(ex.FilteredAttributes()),
+			Label: m.attributesToLabels(ex.FilteredAttributes()),
 		})
 		if err == nil {
 			attachments = append(attachments, attr)
@@ -663,7 +663,7 @@ func (m *metricMapper) histogramToTimeSeries(
 		Metric: &metricpb.Metric{
 			Type: m.metricNameToType(metric.Name()),
 			Labels: mergeLabels(
-				attributesToLabels(point.Attributes()),
+				m.attributesToLabels(point.Attributes()),
 				extraLabels,
 			),
 		},
@@ -710,7 +710,7 @@ func (m *metricMapper) exponentialHistogramToTimeSeries(
 		Metric: &metricpb.Metric{
 			Type: m.metricNameToType(metric.Name()),
 			Labels: mergeLabels(
-				attributesToLabels(point.Attributes()),
+				m.attributesToLabels(point.Attributes()),
 				extraLabels,
 			),
 		},
@@ -762,7 +762,7 @@ func (m *metricMapper) sumPointToTimeSeries(
 		Metric: &metricpb.Metric{
 			Type: m.metricNameToType(metric.Name()),
 			Labels: mergeLabels(
-				attributesToLabels(point.Attributes()),
+				m.attributesToLabels(point.Attributes()),
 				extraLabels,
 			),
 		},
@@ -797,7 +797,7 @@ func (m *metricMapper) gaugePointToTimeSeries(
 		Metric: &metricpb.Metric{
 			Type: m.metricNameToType(metric.Name()),
 			Labels: mergeLabels(
-				attributesToLabels(point.Attributes()),
+				m.attributesToLabels(point.Attributes()),
 				extraLabels,
 			),
 		},
@@ -819,6 +819,24 @@ func (m *metricMapper) metricNameToType(name string) string {
 	return path.Join(m.getMetricNamePrefix(name), name)
 }
 
+func (m *metricMapper) attributesToLabels(attrs pdata.Map) labels {
+	ls := make(labels, attrs.Len())
+	attrs.Range(func(k string, v pdata.Value) bool {
+		ls[sanitizeKey(k)] = m.maybeSanitizeUTF8(v.AsString())
+		return true
+	})
+	return ls
+}
+
+func (m *metricMapper) maybeSanitizeUTF8(s string) string {
+	// Defaults to true if unset
+	enforceUTF8 := m.cfg.MetricConfig.EnforceUTF8
+	if enforceUTF8 != nil && !*enforceUTF8 {
+		return s
+	}
+	return strings.ToValidUTF8(s, "�")
+}
+
 func numberDataPointToValue(
 	point pdata.NumberDataPoint,
 ) (*monitoringpb.TypedValue, metricpb.MetricDescriptor_ValueType) {
@@ -832,17 +850,6 @@ func numberDataPointToValue(
 			DoubleValue: point.DoubleVal(),
 		}},
 		metricpb.MetricDescriptor_DOUBLE
-}
-
-func attributesToLabels(
-	attrs pdata.Map,
-) labels {
-	ls := make(labels, attrs.Len())
-	attrs.Range(func(k string, v pdata.Value) bool {
-		ls[sanitizeKey(k)] = v.AsString()
-		return true
-	})
-	return ls
 }
 
 // Replaces non-alphanumeric characters to underscores. Note, this does not truncate label keys

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -1974,18 +1974,18 @@ var (
 )
 
 func TestAttributesToLabelsUTF8(t *testing.T) {
-		attributes := map[string]interface{}{
-			"valid_ascii":         "abcdefg",
-			"valid_utf8":          "שלום",
-			"invalid_two_octet":   invalidUtf8TwoOctet,
-			"invalid_sequence_id": invalidUtf8SequenceID,
-		}
-		expectLabels := labels{
-			"valid_ascii":         "abcdefg",
-			"valid_utf8":          "שלום",
-			"invalid_two_octet":   "�(",
-			"invalid_sequence_id": "�",
-		}
+	attributes := map[string]interface{}{
+		"valid_ascii":         "abcdefg",
+		"valid_utf8":          "שלום",
+		"invalid_two_octet":   invalidUtf8TwoOctet,
+		"invalid_sequence_id": invalidUtf8SequenceID,
+	}
+	expectLabels := labels{
+		"valid_ascii":         "abcdefg",
+		"valid_utf8":          "שלום",
+		"invalid_two_octet":   "�(",
+		"invalid_sequence_id": "�",
+	}
 
 	assert.Equal(
 		t,

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -46,9 +46,13 @@ func (m *metricMapper) resourceToMonitoredResource(
 	gmr := resourcemapping.ResourceAttributesToMonitoredResource(&attributes{
 		Attrs: &attrs,
 	})
+	newLabels := make(labels, len(gmr.Labels))
+	for k, v := range gmr.Labels {
+		newLabels[k] = m.maybeSanitizeUTF8(v)
+	}
 	mr := &monitoredrespb.MonitoredResource{
 		Type:   gmr.Type,
-		Labels: gmr.Labels,
+		Labels: newLabels,
 	}
 	return mr, m.resourceToMetricLabels(resource)
 }
@@ -77,5 +81,5 @@ func (m *metricMapper) resourceToMetricLabels(
 		}
 		return true
 	})
-	return attributesToLabels(attrs)
+	return m.attributesToLabels(attrs)
 }

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -48,7 +48,7 @@ func (m *metricMapper) resourceToMonitoredResource(
 	})
 	newLabels := make(labels, len(gmr.Labels))
 	for k, v := range gmr.Labels {
-		newLabels[k] = m.maybeSanitizeUTF8(v)
+		newLabels[k] = sanitizeUTF8(v)
 	}
 	mr := &monitoredrespb.MonitoredResource{
 		Type:   gmr.Type,
@@ -81,5 +81,5 @@ func (m *metricMapper) resourceToMetricLabels(
 		}
 		return true
 	})
-	return m.attributesToLabels(attrs)
+	return attributesToLabels(attrs)
 }

--- a/exporter/collector/monitoredresource_test.go
+++ b/exporter/collector/monitoredresource_test.go
@@ -383,3 +383,128 @@ func TestResourceMetricsToMonitoredResource(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceMetricsToMonitoredResourceUTF8(t *testing.T) {
+	invalidUtf8TwoOctet := string([]byte{0xc3, 0x28})   // Invalid 2-octet sequence
+	invalidUtf8SequenceID := string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
+	bTrue := true
+	bFalse := false
+
+	tests := []struct {
+		name              string
+		enforceUTF8       *bool
+		resourceLabels    map[string]string
+		expectMr          *monitoredrespb.MonitoredResource
+		expectExtraLabels labels
+		updateMapper      func(mapper *metricMapper)
+	}{
+		{
+			name:        "UTF-8 sanitization enabled",
+			enforceUTF8: &bTrue,
+			resourceLabels: map[string]string{
+				"cloud.platform":          "gcp_kubernetes_engine",
+				"cloud.availability_zone": "abcdefg", // valid ascii
+				"k8s.cluster.name":        "שלום",    // valid utf8
+				"k8s.namespace.name":      invalidUtf8TwoOctet,
+				"k8s.pod.name":            invalidUtf8SequenceID,
+				"valid_ascii":             "abcdefg",
+				"valid_utf8":              "שלום",
+				"invalid_two_octet":       invalidUtf8TwoOctet,
+				"invalid_sequence_id":     invalidUtf8SequenceID,
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"cluster_name":   "שלום",
+					"location":       "abcdefg",
+					"namespace_name": "�(",
+					"pod_name":       "�",
+				},
+			},
+			expectExtraLabels: labels{
+				"valid_ascii":         "abcdefg",
+				"valid_utf8":          "שלום",
+				"invalid_two_octet":   "�(",
+				"invalid_sequence_id": "�",
+			},
+		},
+		{
+			name:        "UTF-8 sanitization disabled",
+			enforceUTF8: &bFalse,
+			resourceLabels: map[string]string{
+				"cloud.platform":          "gcp_kubernetes_engine",
+				"cloud.availability_zone": "abcdefg", // valid ascii
+				"k8s.cluster.name":        "שלום",    // valid utf8
+				"k8s.namespace.name":      invalidUtf8TwoOctet,
+				"k8s.pod.name":            invalidUtf8SequenceID,
+				"valid_ascii":             "abcdefg",
+				"valid_utf8":              "שלום",
+				"invalid_two_octet":       invalidUtf8TwoOctet,
+				"invalid_sequence_id":     invalidUtf8SequenceID,
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"cluster_name":   "שלום",
+					"location":       "abcdefg",
+					"namespace_name": invalidUtf8TwoOctet,
+					"pod_name":       invalidUtf8SequenceID,
+				},
+			},
+			expectExtraLabels: labels{
+				"valid_ascii":         "abcdefg",
+				"valid_utf8":          "שלום",
+				"invalid_two_octet":   invalidUtf8TwoOctet,
+				"invalid_sequence_id": invalidUtf8SequenceID,
+			},
+		},
+		{
+			name:        "UTF-8 sanitization default",
+			enforceUTF8: nil,
+			resourceLabels: map[string]string{
+				"cloud.platform":          "gcp_kubernetes_engine",
+				"cloud.availability_zone": "abcdefg", // valid ascii
+				"k8s.cluster.name":        "שלום",    // valid utf8
+				"k8s.namespace.name":      invalidUtf8TwoOctet,
+				"k8s.pod.name":            invalidUtf8SequenceID,
+				"valid_ascii":             "abcdefg",
+				"valid_utf8":              "שלום",
+				"invalid_two_octet":       invalidUtf8TwoOctet,
+				"invalid_sequence_id":     invalidUtf8SequenceID,
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"cluster_name":   "שלום",
+					"location":       "abcdefg",
+					"namespace_name": "�(",
+					"pod_name":       "�",
+				},
+			},
+			expectExtraLabels: labels{
+				"valid_ascii":         "abcdefg",
+				"valid_utf8":          "שלום",
+				"invalid_two_octet":   "�(",
+				"invalid_sequence_id": "�",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapper := metricMapper{cfg: DefaultConfig()}
+			mapper.cfg.MetricConfig.ResourceFilters = []ResourceFilter{
+				{Prefix: "valid_"},
+				{Prefix: "invalid_"},
+			}
+			mapper.cfg.MetricConfig.EnforceUTF8 = test.enforceUTF8
+			r := pdata.NewResource()
+			for k, v := range test.resourceLabels {
+				r.Attributes().InsertString(k, v)
+			}
+			mr, extraLabels := mapper.resourceToMonitoredResource(r)
+			assert.Equal(t, test.expectMr, mr)
+			assert.Equal(t, test.expectExtraLabels, extraLabels)
+		})
+	}
+}


### PR DESCRIPTION
Invalid UTF-8 values in Cloud Monitoring data structures will break gRPC, causing it to fail to encode the resulting request protobufs (`grpc: error while marshaling: string field contains invalid UTF-8`). I added the flag in case it was preferable to fail rather than ingest modified values, but we could also unconditionally sanitize those strings instead.

See also #382.