### PR TITLE
Fix monitored resource test

### DIFF
--- a/exporter/collector/monitoredresource_test.go
+++ b/exporter/collector/monitoredresource_test.go
@@ -514,7 +514,8 @@ func TestResourceMetricsToMonitoredResourceUTF8(t *testing.T) {
 	for k, v := range resourceLabels {
 		r.Attributes().InsertString(k, v)
 	}
-	mr, extraLabels := mapper.resourceToMonitoredResource(r)
+	mr := defaultResourceToMonitoredResource(r)
 	assert.Equal(t, expectMr, mr)
+	extraLabels := mapper.resourceToMetricLabels(r)
 	assert.Equal(t, expectExtraLabels, extraLabels)
 }


### PR DESCRIPTION
It is currently broken at HEAD.  https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/381 wasn't rebased when it was merged, and the test it added wasn't compatible with a previous change.