### PR TITLE
Retract stable releases of the base module, and prepare for minor v1.6.0/v0.30.0

### DIFF
--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	cloud.google.com/go/iam v0.1.1 // indirect
 	cloud.google.com/go/pubsub v1.19.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.5.1
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.6.0
 	go.opentelemetry.io/otel v1.6.3
 	go.opentelemetry.io/otel/sdk v1.6.2
 	go.opentelemetry.io/otel/trace v1.6.3
@@ -16,7 +16,7 @@ require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/trace v1.2.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.29.1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.30.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -5,7 +5,7 @@ go 1.17
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric => ../../exporter/metric
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.29.1
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.30.0
 	go.opentelemetry.io/otel v1.6.2
 	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.2

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -7,7 +7,7 @@ replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trac
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping => ../../../internal/resourcemapping
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.5.1
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.6.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.31.0
 	go.opentelemetry.io/otel v1.6.3
@@ -18,7 +18,7 @@ require (
 require (
 	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/trace v1.2.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.29.1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.30.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	cloud.google.com/go/logging v1.4.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.5.1
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.6.0
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.49.0
 	github.com/stretchr/testify v1.7.1
@@ -22,7 +22,7 @@ require (
 require (
 	cloud.google.com/go/monitoring v1.4.0
 	cloud.google.com/go/trace v1.2.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.29.1
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.30.0
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/google/go-cmp v0.5.7
 	go.opentelemetry.io/collector/pdata v0.49.0

--- a/exporter/collector/googlemanagedprometheus/go.mod
+++ b/exporter/collector/googlemanagedprometheus/go.mod
@@ -3,7 +3,7 @@ module github.com/dashpole/opentelemetry-operations-go/exporter/collector/google
 go 1.17
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.28.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.30.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.49.0
 	go.opentelemetry.io/collector/model v0.49.0
@@ -17,8 +17,8 @@ require (
 	cloud.google.com/go/logging v1.4.2 // indirect
 	cloud.google.com/go/monitoring v1.4.0 // indirect
 	cloud.google.com/go/trace v1.2.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.5.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.29.1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.6.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.30.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.11
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.29.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.0.0-00010101000000-000000000000
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.30.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.30.0
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
 	go.opencensus.io v0.23.0
@@ -25,8 +25,8 @@ require (
 	cloud.google.com/go/logging v1.4.2 // indirect
 	cloud.google.com/go/monitoring v1.4.0 // indirect
 	cloud.google.com/go/trace v1.2.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.5.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.29.1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.6.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.30.0 // indirect
 	github.com/aws/aws-sdk-go v1.42.49 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.29.1"
+	return "0.30.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -21,7 +21,7 @@ require (
 	google.golang.org/protobuf v1.28.0
 )
 
-require github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.29.1
+require github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.30.0
 
 require (
 	cloud.google.com/go/compute v1.5.0 // indirect

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.5.1"
+	return "1.6.0"
 }

--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,13 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+retract (
+	v1.5.1
+	v1.5.0
+	v1.4.0
+	v1.3.0
+	v1.0.0
+	v1.0.0-RC2
+	v1.0.0-RC1
+)

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,20 +29,20 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.5.1"
-	unstable = "0.29.1"
+	stable   = "1.6.0"
+	unstable = "0.30.0"
 )
 
 var versions = map[string]string{
-	"":                    stable,
+	"":                    unstable,
 	"exporter/trace/":     stable,
 	"example/trace/http/": unstable,
 
 	"exporter/metric/": unstable,
 	"example/metric/":  unstable,
 
-	"exporter/collector/":                        unstable,
-	"exporter/collector/googlemanagedprometheus": unstable,
+	"exporter/collector/":                         unstable,
+	"exporter/collector/googlemanagedprometheus/": unstable,
 
 	"internal/resourcemapping/": unstable,
 }


### PR DESCRIPTION
The stable base module release accidentally released stable versions of the propagator package unintentionally.

The minor release will include the experimental GMP collector.