### PR TITLE
Log exporter individual log splitting

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -318,7 +318,8 @@ func (l logMapper) logToSplitEntries(
 
 	httpRequestAttr, ok := log.Attributes().Get(HTTPRequestAttributeKey)
 	if ok {
-		httpRequest, err := l.parseHTTPRequest(httpRequestAttr)
+		var httpRequest *logging.HTTPRequest
+		httpRequest, err = l.parseHTTPRequest(httpRequestAttr)
 		if err != nil {
 			l.obs.log.Debug("Unable to parse httpRequest", zap.Error(err))
 		}
@@ -371,10 +372,9 @@ func (l logMapper) logToSplitEntries(
 			endIndex = int(math.Floor((float64(i+1) / splits) * float64(len(payloadString))))
 		}
 		return entries, logName, nil
-	} else {
-		entry.Payload = payload
 	}
 
+	entry.Payload = payload
 	return []logging.Entry{entry}, logName, nil
 }
 

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -243,7 +243,7 @@ func (l logMapper) logEntryToInternal(
 	internalLogEntry.Resource = mr
 	if splits > 1 {
 		internalLogEntry.Split = &logpb.LogSplit{
-			Uid:         entry.Timestamp.String(),
+			Uid:         fmt.Sprintf("%s-%s", logName, entry.Timestamp.String()),
 			Index:       int32(splitIndex),
 			TotalSplits: int32(splits),
 		}

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -275,12 +275,15 @@ func TestLogMapping(t *testing.T) {
 			log := testCase.log()
 			mr := testCase.mr()
 			mapper := newTestLogMapper(testCase.maxEntrySize)
+			logName, _ := mapper.getLogName(log)
 			entries, _, err := mapper.logToSplitEntries(
 				log,
 				mr,
 				"",
 				"",
-				testObservedTime)
+				testObservedTime,
+				logName,
+			)
 
 			if testCase.expectError {
 				assert.NotNil(t, err)

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -276,7 +276,7 @@ func TestLogMapping(t *testing.T) {
 			mr := testCase.mr()
 			mapper := newTestLogMapper(testCase.maxEntrySize)
 			logName, _ := mapper.getLogName(log)
-			entries, _, err := mapper.logToSplitEntries(
+			entries, err := mapper.logToSplitEntries(
 				log,
 				mr,
 				"",

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -60,7 +60,7 @@ func TestLogMapping(t *testing.T) {
 	}{
 		{
 			name:         "split entry size",
-			maxEntrySize: 3,
+			maxEntrySize: 3 + 38, // 3 bytes for payload + 38 for overhead
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
 				log.Body().SetStringVal("abcxyz")
@@ -275,7 +275,7 @@ func TestLogMapping(t *testing.T) {
 			log := testCase.log()
 			mr := testCase.mr()
 			mapper := newTestLogMapper(testCase.maxEntrySize)
-			entries, err := mapper.logToSplitEntries(
+			entries, _, err := mapper.logToSplitEntries(
 				log,
 				mr,
 				"",


### PR DESCRIPTION
This sizes and splits individual log entries based on the default maximum quotas per cloud logging