### PR TITLE
Update normalization to handle value resets, and don't modify values after those resets

### DIFF
--- a/exporter/collector/googlemanagedprometheus/factory.go
+++ b/exporter/collector/googlemanagedprometheus/factory.go
@@ -88,8 +88,6 @@ func (c *GMPConfig) toCollectorConfig() collector.Config {
 	// Map to the prometheus_target monitored resource
 	cfg.MetricConfig.MapMonitoredResource = MapToPrometheusTarget
 	cfg.MetricConfig.EnableSumOfSquaredDeviation = true
-	// TODO: Change to GMP's method of reset handling.
-	cfg.MetricConfig.CumulativeNormalization = false
 	// map the GMP config's fields to the collector config
 	cfg.ProjectID = c.ProjectID
 	cfg.UserAgent = c.UserAgent

--- a/exporter/collector/internal/normalization/standard_normalizer.go
+++ b/exporter/collector/internal/normalization/standard_normalizer.go
@@ -15,6 +15,9 @@
 package normalization
 
 import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
@@ -26,129 +29,217 @@ import (
 //  (b) have been sent a preceding "reset" point as described in https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
 // The first point without a start time or the reset point is cached, and is
 // NOT exported. Subsequent points "subtract" the initial point prior to exporting.
+// This normalizer also detects subsequent resets, and produces a new start time for those points.
+// It doesn't modify values after a reset, but does give it a new start time.
 func NewStandardNormalizer(shutdown <-chan struct{}, logger *zap.Logger) Normalizer {
 	return &standardNormalizer{
-		cache: datapointstorage.NewCache(shutdown),
-		log:   logger,
+		startCache:    datapointstorage.NewCache(shutdown),
+		previousCache: datapointstorage.NewCache(shutdown),
+		log:           logger,
 	}
 }
 
 type standardNormalizer struct {
-	cache datapointstorage.Cache
-	log   *zap.Logger
+	startCache    datapointstorage.Cache
+	previousCache datapointstorage.Cache
+	log           *zap.Logger
 }
 
 func (s *standardNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier string) *pmetric.ExponentialHistogramDataPoint {
-	// if the point doesn't need to be normalized, use original point
-	normalizedPoint := &point
-	start, ok := s.cache.GetExponentialHistogramDataPoint(identifier)
-	if ok {
-		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-			// We found a cached start timestamp that wouldn't produce a valid point.
-			// Drop it and log.
-			s.log.Info(
-				"data point being processed older than last recorded reset, will not be emitted",
-				zap.String("lastRecordedReset", start.Timestamp().String()),
-				zap.String("dataPoint", point.Timestamp().String()),
-			)
+	start, hasStart := s.startCache.GetExponentialHistogramDataPoint(identifier)
+	if !hasStart {
+		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// This is the first time we've seen this metric, or we received
+			// an explicit reset point as described in
+			// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+			// Record it in history and drop the point.
+			s.startCache.SetExponentialHistogramDataPoint(identifier, &point)
+			s.previousCache.SetExponentialHistogramDataPoint(identifier, &point)
 			return nil
 		}
-		if point.Scale() != start.Scale() {
-			// TODO(#366): It is possible, but difficult to compare exponential
-			// histograms with different scales. For now, treat a change in
-			// scale as a reset.
-			s.cache.SetExponentialHistogramDataPoint(identifier, &point)
-			return nil
-		}
-		// Make a copy so we don't mutate underlying data
-		newPoint := pmetric.NewExponentialHistogramDataPoint()
-		point.CopyTo(newPoint)
-		// Use the start timestamp from the normalization point
-		newPoint.SetStartTimestamp(start.Timestamp())
-		// Adjust the value based on the start point's value
-		newPoint.SetCount(point.Count() - start.Count())
-		// We drop points without a sum, so no need to check here.
-		newPoint.SetSum(point.Sum() - start.Sum())
-		newPoint.SetZeroCount(point.ZeroCount() - start.ZeroCount())
-		normalizeExponentialBuckets(newPoint.Positive(), start.Positive())
-		normalizeExponentialBuckets(newPoint.Negative(), start.Negative())
-		normalizedPoint = &newPoint
+		// No normalization required, since we haven't cached anything, and the start TS is non-zero.
+		return &point
 	}
-	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-		// This is the first time we've seen this metric, or we received
-		// an explicit reset point as described in
-		//
-		// Record it in history and drop the point.
-		s.cache.SetExponentialHistogramDataPoint(identifier, &point)
+
+	// TODO(#366): It is possible, but difficult to compare exponential
+	// histograms with different scales. For now, treat a change in
+	// scale as a reset.  Drop this point, and normalize against it for
+	// subsequent points.
+	if point.Scale() != start.Scale() {
+		s.startCache.SetExponentialHistogramDataPoint(identifier, &point)
+		s.previousCache.SetExponentialHistogramDataPoint(identifier, &point)
 		return nil
 	}
-	return normalizedPoint
+
+	previous, hasPrevious := s.previousCache.GetExponentialHistogramDataPoint(identifier)
+	if !hasPrevious {
+		// This should never happen, but fall-back to the start point if we
+		// don't find a previous point
+		previous = start
+	}
+	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) ||
+		(point.StartTimestamp() == 0 && lessThanExponentialHistogramDataPoint(&point, previous)) {
+		// Make a copy so we don't mutate underlying data
+		newPoint := pmetric.NewExponentialHistogramDataPoint()
+		// This is a reset point, but we have seen this timeseries before, so we know the reset happened in the time period since the last point.
+		// Assume the reset occurred at T - 1 ms, and leave the value untouched.
+		point.CopyTo(newPoint)
+		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
+		s.previousCache.SetExponentialHistogramDataPoint(identifier, &newPoint)
+		// For subsequent points, we don't want to modify the value, but we do
+		// want to make the start timestamp match the point we write here.
+		// Store a point with the same timestamps, but zero value to achieve
+		// that behavior.
+		zeroPoint := pmetric.NewExponentialHistogramDataPoint()
+		zeroPoint.SetTimestamp(newPoint.StartTimestamp())
+		zeroPoint.SetScale(newPoint.Scale())
+		s.startCache.SetExponentialHistogramDataPoint(identifier, &zeroPoint)
+		return &newPoint
+	}
+	if !start.Timestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// We found a cached start timestamp that wouldn't produce a valid point.
+		// Drop it and log.
+		s.log.Info(
+			"data point being processed older than last recorded reset, will not be emitted",
+			zap.String("lastRecordedReset", start.Timestamp().String()),
+			zap.String("dataPoint", point.Timestamp().String()),
+		)
+		return nil
+	}
+	// There was no reset, so normalize the point against the start point
+	newPoint := subtractExponentialHistogramDataPoint(&point, start)
+	s.previousCache.SetExponentialHistogramDataPoint(identifier, newPoint)
+	return newPoint
 }
 
-func normalizeExponentialBuckets(pointBuckets, startBuckets pmetric.Buckets) {
-	newBuckets := make([]uint64, len(pointBuckets.MBucketCounts()))
-	offsetDiff := int(pointBuckets.Offset() - startBuckets.Offset())
-	for i := range pointBuckets.MBucketCounts() {
-		startOffset := i + offsetDiff
+// lessThanExponentialHistogramDataPoint returns a < b
+func lessThanExponentialHistogramDataPoint(a, b *pmetric.ExponentialHistogramDataPoint) bool {
+	return a.Count() < b.Count() || a.Sum() < b.Sum()
+}
+
+// subtractExponentialHistogramDataPoint returns a - b
+func subtractExponentialHistogramDataPoint(a, b *pmetric.ExponentialHistogramDataPoint) *pmetric.ExponentialHistogramDataPoint {
+	// Make a copy so we don't mutate underlying data
+	newPoint := pmetric.NewExponentialHistogramDataPoint()
+	a.CopyTo(newPoint)
+	// Use the timestamp from the normalization point
+	newPoint.SetStartTimestamp(b.Timestamp())
+	// Adjust the value based on the start point's value
+	newPoint.SetCount(a.Count() - b.Count())
+	// We drop points without a sum, so no need to check here.
+	newPoint.SetSum(a.Sum() - b.Sum())
+	newPoint.SetZeroCount(a.ZeroCount() - b.ZeroCount())
+	newPoint.Positive().SetMBucketCounts(subtractExponentialBuckets(a.Positive(), b.Positive()))
+	newPoint.Negative().SetMBucketCounts(subtractExponentialBuckets(a.Negative(), b.Negative()))
+	return &newPoint
+}
+
+// subtractExponentialBuckets returns a - b
+func subtractExponentialBuckets(a, b pmetric.Buckets) []uint64 {
+	newBuckets := make([]uint64, len(a.MBucketCounts()))
+	offsetDiff := int(a.Offset() - b.Offset())
+	for i := range a.MBucketCounts() {
+		bOffset := i + offsetDiff
 		// if there is no corresponding bucket for the starting MBucketCounts, don't normalize
-		if startOffset < 0 || startOffset >= len(startBuckets.MBucketCounts()) {
-			newBuckets[i] = pointBuckets.MBucketCounts()[i]
+		if bOffset < 0 || bOffset >= len(b.MBucketCounts()) {
+			newBuckets[i] = a.MBucketCounts()[i]
 		} else {
-			newBuckets[i] = pointBuckets.MBucketCounts()[i] - startBuckets.MBucketCounts()[startOffset]
+			newBuckets[i] = a.MBucketCounts()[i] - b.MBucketCounts()[bOffset]
 		}
 	}
-	pointBuckets.SetOffset(pointBuckets.Offset())
-	pointBuckets.SetMBucketCounts(newBuckets)
+	return newBuckets
 }
 
 func (s *standardNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier string) *pmetric.HistogramDataPoint {
-	// if the point doesn't need to be normalized, use original point
-	normalizedPoint := &point
-	start, ok := s.cache.GetHistogramDataPoint(identifier)
-	if ok {
-		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-			// We found a cached start timestamp that wouldn't produce a valid point.
-			// Drop it and log.
-			s.log.Info(
-				"data point being processed older than last recorded reset, will not be emitted",
-				zap.String("lastRecordedReset", start.Timestamp().String()),
-				zap.String("dataPoint", point.Timestamp().String()),
-			)
+	start, hasStart := s.startCache.GetHistogramDataPoint(identifier)
+	if !hasStart {
+		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// This is the first time we've seen this metric, or we received
+			// an explicit reset point as described in
+			// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+			// Record it in history and drop the point.
+			s.startCache.SetHistogramDataPoint(identifier, &point)
+			s.previousCache.SetHistogramDataPoint(identifier, &point)
 			return nil
 		}
-		// Make a copy so we don't mutate underlying data
-		newPoint := pmetric.NewHistogramDataPoint()
-		point.CopyTo(newPoint)
-		// Use the start timestamp from the normalization point
-		newPoint.SetStartTimestamp(start.Timestamp())
-		// Adjust the value based on the start point's value
-		newPoint.SetCount(point.Count() - start.Count())
-		// We drop points without a sum, so no need to check here.
-		newPoint.SetSum(point.Sum() - start.Sum())
-		pointBuckets := point.MBucketCounts()
-		startBuckets := start.MBucketCounts()
-		if !bucketBoundariesEqual(point.MExplicitBounds(), start.MExplicitBounds()) {
-			// The number of buckets changed, so we can't normalize points anymore.
-			// Treat this as a reset by recording and dropping this point.
-			s.cache.SetHistogramDataPoint(identifier, &point)
-			return nil
-		}
-		newBuckets := make([]uint64, len(pointBuckets))
-		for i := range pointBuckets {
-			newBuckets[i] = pointBuckets[i] - startBuckets[i]
-		}
-		newPoint.SetMBucketCounts(newBuckets)
-		normalizedPoint = &newPoint
+		// No normalization required, since we haven't cached anything, and the start TS is non-zero.
+		return &point
 	}
-	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-		// This is the first time we've seen this metric, or we received
-		// an explicit reset point as described in
-		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
-		// Record it in history and drop the point.
-		s.cache.SetHistogramDataPoint(identifier, &point)
+
+	// The number of buckets changed, so we can't normalize points anymore.
+	// Treat this as a reset.
+	if !bucketBoundariesEqual(point.MExplicitBounds(), start.MExplicitBounds()) {
+		s.startCache.SetHistogramDataPoint(identifier, &point)
+		s.previousCache.SetHistogramDataPoint(identifier, &point)
 		return nil
 	}
-	return normalizedPoint
+
+	previous, hasPrevious := s.previousCache.GetHistogramDataPoint(identifier)
+	if !hasPrevious {
+		// This should never happen, but fall-back to the start point if we
+		// don't find a previous point
+		previous = start
+	}
+	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) ||
+		(point.StartTimestamp() == 0 && lessThanHistogramDataPoint(&point, previous)) {
+		// Make a copy so we don't mutate underlying data
+		newPoint := pmetric.NewHistogramDataPoint()
+		// This is a reset point, but we have seen this timeseries before, so we know the reset happened in the time period since the last point.
+		// Assume the reset occurred at T - 1 ms, and leave the value untouched.
+		point.CopyTo(newPoint)
+		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
+		s.previousCache.SetHistogramDataPoint(identifier, &newPoint)
+		// For subsequent points, we don't want to modify the value, but we do
+		// want to make the start timestamp match the point we write here.
+		// Store a point with the same timestamps, but zero value to achieve
+		// that behavior.
+		zeroPoint := pmetric.NewHistogramDataPoint()
+		zeroPoint.SetTimestamp(newPoint.StartTimestamp())
+		zeroPoint.SetExplicitBounds(newPoint.MExplicitBounds())
+		zeroPoint.SetMBucketCounts(make([]uint64, len(newPoint.MBucketCounts())))
+		s.startCache.SetHistogramDataPoint(identifier, &zeroPoint)
+		return &newPoint
+	}
+	if !start.Timestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// We found a cached start timestamp that wouldn't produce a valid point.
+		// Drop it and log.
+		s.log.Info(
+			"data point being processed older than last recorded reset, will not be emitted",
+			zap.String("lastRecordedReset", start.Timestamp().String()),
+			zap.String("dataPoint", point.Timestamp().String()),
+		)
+		return nil
+	}
+	// There was no reset, so normalize the point against the start point
+	newPoint := subtractHistogramDataPoint(&point, start)
+	s.previousCache.SetHistogramDataPoint(identifier, newPoint)
+	return newPoint
+}
+
+// lessThanHistogramDataPoint returns a < b
+func lessThanHistogramDataPoint(a, b *pmetric.HistogramDataPoint) bool {
+	return a.Count() < b.Count() || a.Sum() < b.Sum()
+}
+
+// subtractHistogramDataPoint returns a - b
+func subtractHistogramDataPoint(a, b *pmetric.HistogramDataPoint) *pmetric.HistogramDataPoint {
+	// Make a copy so we don't mutate underlying data
+	newPoint := pmetric.NewHistogramDataPoint()
+	a.CopyTo(newPoint)
+	// Use the timestamp from the normalization point
+	newPoint.SetStartTimestamp(b.Timestamp())
+	// Adjust the value based on the start point's value
+	newPoint.SetCount(a.Count() - b.Count())
+	// We drop points without a sum, so no need to check here.
+	newPoint.SetSum(a.Sum() - b.Sum())
+	aBuckets := a.MBucketCounts()
+	bBuckets := b.MBucketCounts()
+	newBuckets := make([]uint64, len(aBuckets))
+	for i := range aBuckets {
+		newBuckets[i] = aBuckets[i] - bBuckets[i]
+	}
+	newPoint.SetMBucketCounts(newBuckets)
+	return &newPoint
 }
 
 func bucketBoundariesEqual(a, b []float64) bool {
@@ -166,81 +257,161 @@ func bucketBoundariesEqual(a, b []float64) bool {
 // NormalizeNumberDataPoint normalizes a cumulative, monotonic sum.
 // It returns the normalized point, or nil if the point should be dropped.
 func (s *standardNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier string) *pmetric.NumberDataPoint {
-	// if the point doesn't need to be normalized, use original point
-	normalizedPoint := &point
-	start, ok := s.cache.GetNumberDataPoint(identifier)
-	if ok {
-		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-			// We found a cached start timestamp that wouldn't produce a valid point.
-			// Drop it and log.
-			s.log.Info(
-				"data point being processed older than last recorded reset, will not be emitted",
-				zap.String("lastRecordedReset", start.Timestamp().String()),
-				zap.String("dataPoint", point.Timestamp().String()),
-			)
+	start, hasStart := s.startCache.GetNumberDataPoint(identifier)
+	if !hasStart {
+		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// This is the first time we've seen this metric, or we received
+			// an explicit reset point as described in
+			// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+			// Record it in history and drop the point.
+			s.startCache.SetNumberDataPoint(identifier, &point)
+			s.previousCache.SetNumberDataPoint(identifier, &point)
 			return nil
 		}
+		// No normalization required, since we haven't cached anything, and the start TS is non-zer0.
+		return &point
+	}
+
+	previous, hasPrevious := s.previousCache.GetNumberDataPoint(identifier)
+	if !hasPrevious {
+		// This should never happen, but fall-back to the start point if we
+		// don't find a previous point
+		previous = start
+	}
+	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) || (point.StartTimestamp() == 0 && lessThanNumberDataPoint(&point, previous)) {
 		// Make a copy so we don't mutate underlying data
 		newPoint := pmetric.NewNumberDataPoint()
+		// This is a reset point, but we have seen this timeseries before, so we know the reset happened in the time period since the last point.
+		// Assume the reset occurred at T - 1 ms, and leave the value untouched.
 		point.CopyTo(newPoint)
-		// Use the start timestamp from the normalization point
-		newPoint.SetStartTimestamp(start.Timestamp())
-		// Adjust the value based on the start point's value
-		switch newPoint.ValueType() {
-		case pmetric.NumberDataPointValueTypeInt:
-			newPoint.SetIntVal(point.IntVal() - start.IntVal())
-		case pmetric.NumberDataPointValueTypeDouble:
-			newPoint.SetDoubleVal(point.DoubleVal() - start.DoubleVal())
-		}
-		normalizedPoint = &newPoint
+		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
+		s.previousCache.SetNumberDataPoint(identifier, &newPoint)
+		// For subsequent points, we don't want to modify the value, but we do
+		// want to make the start timestamp match the point we write here.
+		// Store a point with the same timestamps, but zero value to achieve
+		// that behavior.
+		zeroPoint := pmetric.NewNumberDataPoint()
+		zeroPoint.SetTimestamp(newPoint.StartTimestamp())
+		s.startCache.SetNumberDataPoint(identifier, &zeroPoint)
+		return &newPoint
 	}
-	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-		// This is the first time we've seen this metric, or we received
-		// an explicit reset point as described in
-		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
-		// Record it in history and drop the point.
-		s.cache.SetNumberDataPoint(identifier, &point)
+	if !start.Timestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// We found a cached start timestamp that wouldn't produce a valid point.
+		// Drop it and log.
+		s.log.Info(
+			"data point being processed older than last recorded reset, will not be emitted",
+			zap.String("lastRecordedReset", start.Timestamp().String()),
+			zap.String("dataPoint", point.Timestamp().String()),
+		)
 		return nil
 	}
-	return normalizedPoint
+	// There was no reset, so normalize the point against the start point
+	newPoint := subtractNumberDataPoint(&point, start)
+	s.previousCache.SetNumberDataPoint(identifier, newPoint)
+	return newPoint
+}
+
+// lessThanNumberDataPoint returns a < b
+func lessThanNumberDataPoint(a, b *pmetric.NumberDataPoint) bool {
+	switch a.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		return a.IntVal() < b.IntVal()
+	case pmetric.NumberDataPointValueTypeDouble:
+		return a.DoubleVal() < b.DoubleVal()
+	}
+	return false
+}
+
+// subtractNumberDataPoint returns a - b
+func subtractNumberDataPoint(a, b *pmetric.NumberDataPoint) *pmetric.NumberDataPoint {
+	// Make a copy so we don't mutate underlying data
+	newPoint := pmetric.NewNumberDataPoint()
+	a.CopyTo(newPoint)
+	// Use the timestamp from the normalization point
+	newPoint.SetStartTimestamp(b.Timestamp())
+	// Adjust the value based on the start point's value
+	switch newPoint.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		newPoint.SetIntVal(a.IntVal() - b.IntVal())
+	case pmetric.NumberDataPointValueTypeDouble:
+		newPoint.SetDoubleVal(a.DoubleVal() - b.DoubleVal())
+	}
+	return &newPoint
 }
 
 func (s *standardNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier string) *pmetric.SummaryDataPoint {
-	// if the point doesn't need to be normalized, use original point
-	normalizedPoint := &point
-	start, ok := s.cache.GetSummaryDataPoint(identifier)
-	if ok {
-		if !start.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-			// We found a cached start timestamp that wouldn't produce a valid point.
-			// Drop it and log.
-			s.log.Info(
-				"data point being processed older than last recorded reset, will not be emitted",
-				zap.String("lastRecordedReset", start.Timestamp().String()),
-				zap.String("dataPoint", point.Timestamp().String()),
-			)
+	start, hasStart := s.startCache.GetSummaryDataPoint(identifier)
+	if !hasStart {
+		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
+			// This is the first time we've seen this metric, or we received
+			// an explicit reset point as described in
+			// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
+			// Record it in history and drop the point.
+			s.startCache.SetSummaryDataPoint(identifier, &point)
+			s.previousCache.SetSummaryDataPoint(identifier, &point)
 			return nil
 		}
-		// Make a copy so we don't mutate underlying data.
-		newPoint := pmetric.NewSummaryDataPoint()
-		// Quantile values are copied, and are not modified. Quantiles are
-		// computed over the same time period as sum and count, but it isn't
-		// possible to normalize them.
-		point.CopyTo(newPoint)
-		// Use the start timestamp from the normalization point
-		newPoint.SetStartTimestamp(start.Timestamp())
-		// Adjust the value based on the start point's value
-		newPoint.SetCount(point.Count() - start.Count())
-		// We drop points without a sum, so no need to check here.
-		newPoint.SetSum(point.Sum() - start.Sum())
-		normalizedPoint = &newPoint
+		// No normalization required, since we haven't cached anything, and the start TS is non-zer0.
+		return &point
 	}
-	if (!ok && point.StartTimestamp() == 0) || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
-		// This is the first time we've seen this metric, or we received
-		// an explicit reset point as described in
-		// https://github.com/open-telemetry/opentelemetry-specification/blob/9555f9594c7ffe5dc333b53da5e0f880026cead1/specification/metrics/datamodel.md#resets-and-gaps
-		// Record it in history and drop the point.
-		s.cache.SetSummaryDataPoint(identifier, &point)
+
+	previous, hasPrevious := s.previousCache.GetSummaryDataPoint(identifier)
+	if !hasPrevious {
+		// This should never happen, but fall-back to the start point if we
+		// don't find a previous point
+		previous = start
+	}
+	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) || (point.StartTimestamp() == 0 && lessThanSummaryDataPoint(&point, previous)) {
+		// Make a copy so we don't mutate underlying data
+		newPoint := pmetric.NewSummaryDataPoint()
+		// This is a reset point, but we have seen this timeseries before, so we know the reset happened in the time period since the last point.
+		// Assume the reset occurred at T - 1 ms, and leave the value untouched.
+		point.CopyTo(newPoint)
+		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
+		s.previousCache.SetSummaryDataPoint(identifier, &newPoint)
+		// For subsequent points, we don't want to modify the value, but we do
+		// want to make the start timestamp match the point we write here.
+		// Store a point with the same timestamps, but zero value to achieve
+		// that behavior.
+		zeroPoint := pmetric.NewSummaryDataPoint()
+		zeroPoint.SetTimestamp(newPoint.StartTimestamp())
+		s.startCache.SetSummaryDataPoint(identifier, &zeroPoint)
+		return &newPoint
+	}
+	if !start.Timestamp().AsTime().Before(point.Timestamp().AsTime()) {
+		// We found a cached start timestamp that wouldn't produce a valid point.
+		// Drop it and log.
+		s.log.Info(
+			"data point being processed older than last recorded reset, will not be emitted",
+			zap.String("lastRecordedReset", start.Timestamp().String()),
+			zap.String("dataPoint", point.Timestamp().String()),
+		)
 		return nil
 	}
-	return normalizedPoint
+	// There was no reset, so normalize the point against the start point
+	newPoint := subtractSummaryDataPoint(&point, start)
+	s.previousCache.SetSummaryDataPoint(identifier, newPoint)
+	return newPoint
+}
+
+// lessThanSummaryDataPoint returns a < b
+func lessThanSummaryDataPoint(a, b *pmetric.SummaryDataPoint) bool {
+	return a.Count() < b.Count() || a.Sum() < b.Sum()
+}
+
+// subtractSummaryDataPoint returns a - b
+func subtractSummaryDataPoint(a, b *pmetric.SummaryDataPoint) *pmetric.SummaryDataPoint {
+	// Make a copy so we don't mutate underlying data.
+	newPoint := pmetric.NewSummaryDataPoint()
+	// Quantile values are copied, and are not modified. Quantiles are
+	// computed over the same time period as sum and count, but it isn't
+	// possible to normalize them.
+	a.CopyTo(newPoint)
+	// Use the timestamp from the normalization point
+	newPoint.SetStartTimestamp(b.Timestamp())
+	// Adjust the value based on the start point's value
+	newPoint.SetCount(a.Count() - b.Count())
+	// We drop points without a sum, so no need to check here.
+	newPoint.SetSum(a.Sum() - b.Sum())
+	return &newPoint
 }


### PR DESCRIPTION
This matches the behavior of the GMP [series cache](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/main/pkg/export/series_cache.go#L254).

The rules are:
* When first observing a series, drop the first point, and normalize subsequent points against that point.  This is important, because the start time may be very far in the past, so the rate would be enormous.
* When we detect a decrease in a series, we know the series has reset fairly recently (probably since the last scrape).  It is safe to keep the value, but change the start time to TS - 1ms to ensure the interval is valid.  For subsequent points, don't modify their values, but do change the start time to match the start time of the first point.

Since we are now tracking when a series decreases, we need to keep track of the previous point in that series.  This PR splits the cache into a cache for the start point, and a cache for the most recent point.

The only difference between the implementations for different data types are:

* the lessThan function
* the subtract function
* special reset conditions.  For exponential histograms, a change in scale is considered a reset.  For Histograms, a change in bucket boundaries is considered a reset.  We treat those resets like entirely new series (and normalize against the first point) because it may not be an actual reset at all, and could still be the initial series, which has a start time far in the past.