### PR TITLE
optionally configure service account impersonation

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -30,11 +30,12 @@ const (
 
 // Config defines configuration for Google Cloud exporter.
 type Config struct {
-	LogConfig    LogConfig    `mapstructure:"log"`
-	ProjectID    string       `mapstructure:"project"`
-	UserAgent    string       `mapstructure:"user_agent"`
-	TraceConfig  TraceConfig  `mapstructure:"trace"`
-	MetricConfig MetricConfig `mapstructure:"metric"`
+	ImpersonateConfig ImpersonateConfig `mapstructure:"impersonate"`
+	ProjectID         string            `mapstructure:"project"`
+	UserAgent         string            `mapstructure:"user_agent"`
+	TraceConfig       TraceConfig       `mapstructure:"trace"`
+	LogConfig         LogConfig         `mapstructure:"log"`
+	MetricConfig      MetricConfig      `mapstructure:"metric"`
 }
 
 type ClientConfig struct {
@@ -111,6 +112,13 @@ type MetricConfig struct {
 	// deviation.  It isn't correct, so we don't send it by default, and don't expose
 	// it to users. For some uses, it is expected, however.
 	EnableSumOfSquaredDeviation bool `mapstructure:"sum_of_squared_deviation"`
+}
+
+// ImpersonateConfig defines configuration for service account impersonation
+type ImpersonateConfig struct {
+	TargetPrincipal string   `mapstructure:"target_principal"`
+	Subject         string   `mapstructure:"subject"`
+	Delegates       []string `mapstructure:"delegates"`
 }
 
 type ResourceFilter struct {

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -98,7 +98,7 @@ func NewGoogleCloudLogsExporter(
 		return nil, err
 	}
 
-	clientOpts, err := generateClientOptions(&cfg.LogConfig.ClientConfig, cfg.UserAgent)
+	clientOpts, err := generateClientOptions(ctx, &cfg.LogConfig.ClientConfig, cfg.UserAgent, cfg.ImpersonateConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -122,7 +122,7 @@ func NewGoogleCloudMetricsExporter(
 	setVersionInUserAgent(&cfg, version)
 	setProjectFromADC(ctx, &cfg, monitoring.DefaultAuthScopes())
 
-	clientOpts, err := generateClientOptions(&cfg.MetricConfig.ClientConfig, cfg.UserAgent)
+	clientOpts, err := generateClientOptions(ctx, &cfg.MetricConfig.ClientConfig, cfg.UserAgent, cfg.ImpersonateConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Note: this replaces https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10173 per a suggestion from @dashpole.

GCP supports authentication using short-lived credentials obtained by
"impersonating" a service account. This is useful for cross-project
access, for example: a service account in one project is trusted to
impersonate a service account in another project and export metrics on
its behalf. This patch adds support for service account impersonation
for metrics, logs, and traces.

See https://cloud.google.com/iam/docs/impersonating-service-accounts for
details.