### PR TITLE
Allow overriding location, cluster, and namespace using metric labels

### DIFF
--- a/exporter/collector/googlemanagedprometheus/README.md
+++ b/exporter/collector/googlemanagedprometheus/README.md
@@ -39,6 +39,16 @@ receivers:
                 - action: labelmap
                 regex: __meta_kubernetes_pod_label_(.+)
 processors:
+    # groupbyattrs promotes labels from metrics to resources, allowing them to
+    # be added to the prometheus_target monitored resource.
+    # This allows exporters which monitor multiple namespaces, such as
+    # kube-state-metrics, to override the namespace in the resource by setting
+    # metric labels.
+    groupbyattrs:
+      keys:
+        - namespace
+        - cluster
+        - location
     batch:
         # batch metrics before sending to reduce API usage
         send_batch_max_size: 200
@@ -60,7 +70,7 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch, memory_limiter, resourcedetection]
+      processors: [groupbyattrs, batch, memory_limiter, resourcedetection]
       exporters: [googlemanagedprometheus]
 ```
 

--- a/exporter/collector/googlemanagedprometheus/monitoredresource.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource.go
@@ -20,6 +20,17 @@ import (
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
+const (
+	// In GMP, location, cluster, and namespace labels can be overridden by
+	// users to set corresponding fields in the monitored resource. To
+	// replicate that behavior in the collector, we expect these labels
+	// to be moved from metric labels to resource labels using the groupbyattrs
+	// processor. If these resource labels are present, use them to set the MR.
+	locationLabel  = "location"
+	clusterLabel   = "cluster"
+	namespaceLabel = "namespace"
+)
+
 func MapToPrometheusTarget(res pcommon.Resource) *monitoredrespb.MonitoredResource {
 	attrs := res.Attributes()
 	// Prepend namespace if it exists to match what is specified in
@@ -32,9 +43,9 @@ func MapToPrometheusTarget(res pcommon.Resource) *monitoredrespb.MonitoredResour
 	return &monitoredrespb.MonitoredResource{
 		Type: "prometheus_target",
 		Labels: map[string]string{
-			"location":  getStringOrEmpty(attrs, "location", semconv.AttributeCloudAvailabilityZone, semconv.AttributeCloudRegion),
-			"cluster":   getStringOrEmpty(attrs, "cluster", semconv.AttributeK8SClusterName),
-			"namespace": getStringOrEmpty(attrs, "namespace", semconv.AttributeK8SNamespaceName),
+			"location":  getStringOrEmpty(attrs, locationLabel, semconv.AttributeCloudAvailabilityZone, semconv.AttributeCloudRegion),
+			"cluster":   getStringOrEmpty(attrs, clusterLabel, semconv.AttributeK8SClusterName),
+			"namespace": getStringOrEmpty(attrs, namespaceLabel, semconv.AttributeK8SNamespaceName),
 			"job":       job,
 			"instance":  getStringOrEmpty(attrs, semconv.AttributeServiceInstanceID),
 		},

--- a/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
@@ -66,6 +66,32 @@ func TestMapToPrometheusTarget(t *testing.T) {
 			},
 		},
 		{
+			desc: "overridden attributes",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "gcp_kubernetes_engine",
+				"cloud.availability_zone": "us-central1-c",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+				"k8s.container.name":      "mycontainer",
+				"service.name":            "myservicename",
+				"service.instance.id":     "myserviceinstanceid",
+				"location":                "overridden-location",
+				"cluster":                 "overridden-cluster",
+				"namespace":               "overridden-namespace",
+			},
+			expected: &monitoredrespb.MonitoredResource{
+				Type: "prometheus_target",
+				Labels: map[string]string{
+					"location":  "overridden-location",
+					"cluster":   "overridden-cluster",
+					"namespace": "overridden-namespace",
+					"job":       "myservicename",
+					"instance":  "myserviceinstanceid",
+				},
+			},
+		},
+		{
 			desc: "Attributes from prometheus receiver, and zone",
 			resourceLabels: map[string]string{
 				"cloud.availability_zone": "us-central1-c",


### PR DESCRIPTION
With GMP, if you set "location", "cluster" or "namespace" labels on your metrics, they are [moved](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/c4e6189ecd21fcc5333ec4c04f116b98701ff8ff/pkg/export/series_cache.go#L520) to the monitored resource from the set of labels.

To achieve the same behavior in the otel collector, use a processor to move those labels from metric to resource, and then map those from otel resource to monitored resource.  They take precedence over other ways of setting those labels (i.e. a "namespace" label on a KSM metric will be used over the namespace of the KSM exporter.

cc @xichen2020