### PR TITLE
Replace deprecated method with current.

### DIFF
--- a/exporter/collector/internal/normalization/standard_normalizer.go
+++ b/exporter/collector/internal/normalization/standard_normalizer.go
@@ -195,7 +195,7 @@ func (s *standardNormalizer) NormalizeHistogramDataPoint(point pmetric.Histogram
 		// that behavior.
 		zeroPoint := pmetric.NewHistogramDataPoint()
 		zeroPoint.SetTimestamp(newPoint.StartTimestamp())
-		zeroPoint.SetExplicitBounds(newPoint.MExplicitBounds())
+		zeroPoint.SetMExplicitBounds(newPoint.MExplicitBounds())
 		zeroPoint.SetMBucketCounts(make([]uint64, len(newPoint.MBucketCounts())))
 		s.startCache.SetHistogramDataPoint(identifier, &zeroPoint)
 		return &newPoint


### PR DESCRIPTION
I tried upgrading this package from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter and got the following error:

```
❯ go get -u github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector
# github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization
../../../../go/pkg/mod/github.com/!google!cloud!platform/opentelemetry-operations-go/exporter/collector@v0.31.0/internal/normalization/standard_normalizer.go:198:12: zeroPoint.SetExplicitBounds undefined (type internal.HistogramDataPoint has no field or method SetExplicitBounds)
```

Fixing the deprecated method fixes the issue.