### PR TITLE
Test project ID in fixtures

### DIFF
--- a/exporter/collector/integrationtest/logs_integration_test.go
+++ b/exporter/collector/integrationtest/logs_integration_test.go
@@ -19,6 +19,7 @@ package integrationtest
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -34,9 +35,12 @@ func createLogsExporter(
 	test *TestCase,
 ) *collector.LogsExporter {
 	logger, _ := zap.NewProduction()
+	cfg := test.CreateLogConfig()
+	// For sending to a real project, set the project ID from an env var.
+	cfg.ProjectID = os.Getenv("PROJECT_ID")
 	exporter, err := collector.NewGoogleCloudLogsExporter(
 		ctx,
-		test.CreateLogConfig(),
+		cfg,
 		logger,
 	)
 	require.NoError(t, err)

--- a/exporter/collector/integrationtest/metrics_integration_test.go
+++ b/exporter/collector/integrationtest/metrics_integration_test.go
@@ -19,6 +19,7 @@ package integrationtest
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -34,9 +35,12 @@ func createMetricsExporter(
 	test *TestCase,
 ) *collector.MetricsExporter {
 	logger, _ := zap.NewProduction()
+	cfg := test.CreateMetricConfig()
+	// For sending to a real project, set the project ID from an env var.
+	cfg.ProjectID = os.Getenv("PROJECT_ID")
 	exporter, err := collector.NewGoogleCloudMetricsExporter(
 		ctx,
-		test.CreateMetricConfig(),
+		cfg,
 		logger,
 		"latest",
 		collector.DefaultTimeout,

--- a/exporter/collector/integrationtest/testcase.go
+++ b/exporter/collector/integrationtest/testcase.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -89,8 +88,7 @@ func (tc *TestCase) LoadOTLPLogsInput(
 
 func (tc *TestCase) CreateLogConfig() collector.Config {
 	cfg := collector.DefaultConfig()
-	// If not set it will use ADC
-	cfg.ProjectID = os.Getenv("PROJECT_ID")
+	cfg.ProjectID = "fake-project"
 
 	if tc.Configure != nil {
 		tc.Configure(&cfg)
@@ -343,7 +341,6 @@ func (tc *TestCase) SkipIfNeeded(t testing.TB) {
 
 func (tc *TestCase) CreateMetricConfig() collector.Config {
 	cfg := collector.DefaultConfig()
-	// If not set it will use ADC
 	cfg.ProjectID = "fake-project"
 	// Set a big buffer to capture all CMD requests without dropping
 	cfg.MetricConfig.CreateMetricDescriptorBufferSize = 500

--- a/exporter/collector/integrationtest/testcase.go
+++ b/exporter/collector/integrationtest/testcase.go
@@ -260,9 +260,6 @@ func normalizeFixture(t testing.TB, fixture *MetricExpectFixture) {
 
 func normalizeTimeSeriesReqs(t testing.TB, reqs ...*monitoringpb.CreateTimeSeriesRequest) {
 	for _, req := range reqs {
-		// clear project ID
-		req.Name = ""
-
 		for _, ts := range req.TimeSeries {
 			for _, p := range ts.Points {
 				// Normalize timestamps if they are set
@@ -282,12 +279,10 @@ func normalizeTimeSeriesReqs(t testing.TB, reqs ...*monitoringpb.CreateTimeSerie
 
 func normalizeMetricDescriptorReqs(t testing.TB, reqs ...*monitoringpb.CreateMetricDescriptorRequest) {
 	for _, req := range reqs {
-		req.Name = ""
 		if req.MetricDescriptor == nil {
 			continue
 		}
 		md := req.MetricDescriptor
-		md.Name = ""
 		sort.Slice(md.Labels, func(i, j int) bool {
 			return md.Labels[i].Key < md.Labels[j].Key
 		})
@@ -349,7 +344,7 @@ func (tc *TestCase) SkipIfNeeded(t testing.TB) {
 func (tc *TestCase) CreateMetricConfig() collector.Config {
 	cfg := collector.DefaultConfig()
 	// If not set it will use ADC
-	cfg.ProjectID = os.Getenv("PROJECT_ID")
+	cfg.ProjectID = "fake-project"
 	// Set a big buffer to capture all CMD requests without dropping
 	cfg.MetricConfig.CreateMetricDescriptorBufferSize = 500
 	cfg.MetricConfig.InstrumentationLibraryLabels = false

--- a/exporter/collector/integrationtest/testdata/fixtures/basic_counter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/basic_counter_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -37,7 +38,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "testcounter",
         "type": "workload.googleapis.com/testcounter",
         "labels": [
           {
@@ -55,6 +58,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -597,7 +601,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -612,7 +618,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -627,7 +635,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -642,7 +652,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -657,7 +669,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -672,7 +686,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -690,7 +706,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -705,7 +723,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -720,7 +740,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/basic_prometheus_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -353,7 +354,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "scrape_series_added",
         "type": "workload.googleapis.com/scrape_series_added",
         "labels": [
           {
@@ -370,7 +373,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "ex_com_one",
         "type": "workload.googleapis.com/ex_com_one",
         "labels": [
           {
@@ -407,7 +412,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "ex_com_two",
         "type": "workload.googleapis.com/ex_com_two",
         "labels": [
           {
@@ -444,7 +451,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "up",
         "type": "workload.googleapis.com/up",
         "labels": [
           {
@@ -461,7 +470,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "scrape_duration_seconds",
         "type": "workload.googleapis.com/scrape_duration_seconds",
         "labels": [
           {
@@ -479,7 +490,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "scrape_samples_scraped",
         "type": "workload.googleapis.com/scrape_samples_scraped",
         "labels": [
           {
@@ -496,7 +509,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "scrape_samples_post_metric_relabeling",
         "type": "workload.googleapis.com/scrape_samples_post_metric_relabeling",
         "labels": [
           {
@@ -516,6 +531,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -1058,7 +1074,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -1073,7 +1091,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -1088,7 +1108,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -1103,7 +1125,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -1118,7 +1142,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -1133,7 +1159,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -1151,7 +1179,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -1166,7 +1196,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -1181,7 +1213,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/batching_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/batching_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -6005,6 +6006,7 @@
       ]
     },
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -6161,6 +6163,7 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_1_sum",
         "labels": [
@@ -6176,6 +6179,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_1_count",
         "labels": [
@@ -6191,6 +6195,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_1",
         "labels": [
@@ -6210,6 +6215,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_2_sum",
         "labels": [
@@ -6225,6 +6231,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_2_count",
         "labels": [
@@ -6240,6 +6247,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_2",
         "labels": [
@@ -6259,6 +6267,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_3_sum",
         "labels": [
@@ -6274,6 +6283,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_3_count",
         "labels": [
@@ -6289,6 +6299,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_3",
         "labels": [
@@ -6308,6 +6319,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_4_sum",
         "labels": [
@@ -6323,6 +6335,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_4_count",
         "labels": [
@@ -6338,6 +6351,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_4",
         "labels": [
@@ -6357,6 +6371,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_5_sum",
         "labels": [
@@ -6372,6 +6387,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_5_count",
         "labels": [
@@ -6387,6 +6403,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_5",
         "labels": [
@@ -6406,6 +6423,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_6_sum",
         "labels": [
@@ -6421,6 +6439,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_6_count",
         "labels": [
@@ -6436,6 +6455,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_6",
         "labels": [
@@ -6455,6 +6475,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_7_sum",
         "labels": [
@@ -6470,6 +6491,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_7_count",
         "labels": [
@@ -6485,6 +6507,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_7",
         "labels": [
@@ -6504,6 +6527,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_8_sum",
         "labels": [
@@ -6519,6 +6543,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_8_count",
         "labels": [
@@ -6534,6 +6559,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_8",
         "labels": [
@@ -6553,6 +6579,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_9_sum",
         "labels": [
@@ -6568,6 +6595,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_9_count",
         "labels": [
@@ -6583,6 +6611,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_9",
         "labels": [
@@ -6602,6 +6631,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_10_sum",
         "labels": [
@@ -6617,6 +6647,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_10_count",
         "labels": [
@@ -6632,6 +6663,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_10",
         "labels": [
@@ -6651,6 +6683,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_11_sum",
         "labels": [
@@ -6666,6 +6699,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_11_count",
         "labels": [
@@ -6681,6 +6715,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_11",
         "labels": [
@@ -6700,6 +6735,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_12_sum",
         "labels": [
@@ -6715,6 +6751,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_12_count",
         "labels": [
@@ -6730,6 +6767,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_12",
         "labels": [
@@ -6749,6 +6787,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_13_sum",
         "labels": [
@@ -6764,6 +6803,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_13_count",
         "labels": [
@@ -6779,6 +6819,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_13",
         "labels": [
@@ -6798,6 +6839,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_14_sum",
         "labels": [
@@ -6813,6 +6855,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_14_count",
         "labels": [
@@ -6828,6 +6871,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_14",
         "labels": [
@@ -6847,6 +6891,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_15_sum",
         "labels": [
@@ -6862,6 +6907,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_15_count",
         "labels": [
@@ -6877,6 +6923,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_15",
         "labels": [
@@ -6896,6 +6943,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_16_sum",
         "labels": [
@@ -6911,6 +6959,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_16_count",
         "labels": [
@@ -6926,6 +6975,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_16",
         "labels": [
@@ -6945,6 +6995,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_17_sum",
         "labels": [
@@ -6960,6 +7011,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_17_count",
         "labels": [
@@ -6975,6 +7027,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_17",
         "labels": [
@@ -6994,6 +7047,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_18_sum",
         "labels": [
@@ -7009,6 +7063,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_18_count",
         "labels": [
@@ -7024,6 +7079,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_18",
         "labels": [
@@ -7043,6 +7099,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_19_sum",
         "labels": [
@@ -7058,6 +7115,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_19_count",
         "labels": [
@@ -7073,6 +7131,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_19",
         "labels": [
@@ -7092,6 +7151,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_20_sum",
         "labels": [
@@ -7107,6 +7167,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_20_count",
         "labels": [
@@ -7122,6 +7183,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_20",
         "labels": [
@@ -7141,6 +7203,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_21_sum",
         "labels": [
@@ -7156,6 +7219,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_21_count",
         "labels": [
@@ -7171,6 +7235,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_21",
         "labels": [
@@ -7190,6 +7255,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_22_sum",
         "labels": [
@@ -7205,6 +7271,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_22_count",
         "labels": [
@@ -7220,6 +7287,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_22",
         "labels": [
@@ -7239,6 +7307,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_23_sum",
         "labels": [
@@ -7254,6 +7323,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_23_count",
         "labels": [
@@ -7269,6 +7339,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_23",
         "labels": [
@@ -7288,6 +7359,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_24_sum",
         "labels": [
@@ -7303,6 +7375,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_24_count",
         "labels": [
@@ -7318,6 +7391,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_24",
         "labels": [
@@ -7337,6 +7411,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_25_sum",
         "labels": [
@@ -7352,6 +7427,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_25_count",
         "labels": [
@@ -7367,6 +7443,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_25",
         "labels": [
@@ -7386,6 +7463,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_26_sum",
         "labels": [
@@ -7401,6 +7479,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_26_count",
         "labels": [
@@ -7416,6 +7495,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_26",
         "labels": [
@@ -7435,6 +7515,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_27_sum",
         "labels": [
@@ -7450,6 +7531,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_27_count",
         "labels": [
@@ -7465,6 +7547,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_27",
         "labels": [
@@ -7484,6 +7567,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_28_sum",
         "labels": [
@@ -7499,6 +7583,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_28_count",
         "labels": [
@@ -7514,6 +7599,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_28",
         "labels": [
@@ -7533,6 +7619,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_29_sum",
         "labels": [
@@ -7548,6 +7635,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_29_count",
         "labels": [
@@ -7563,6 +7651,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_29",
         "labels": [
@@ -7582,6 +7671,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_30_sum",
         "labels": [
@@ -7597,6 +7687,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_30_count",
         "labels": [
@@ -7612,6 +7703,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_30",
         "labels": [
@@ -7631,6 +7723,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_31_sum",
         "labels": [
@@ -7646,6 +7739,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_31_count",
         "labels": [
@@ -7661,6 +7755,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_31",
         "labels": [
@@ -7680,6 +7775,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_32_sum",
         "labels": [
@@ -7695,6 +7791,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_32_count",
         "labels": [
@@ -7710,6 +7807,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_32",
         "labels": [
@@ -7729,6 +7827,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_33_sum",
         "labels": [
@@ -7744,6 +7843,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_33_count",
         "labels": [
@@ -7759,6 +7859,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_33",
         "labels": [
@@ -7778,6 +7879,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_34_sum",
         "labels": [
@@ -7793,6 +7895,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_34_count",
         "labels": [
@@ -7808,6 +7911,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_34",
         "labels": [
@@ -7827,6 +7931,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_35_sum",
         "labels": [
@@ -7842,6 +7947,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_35_count",
         "labels": [
@@ -7857,6 +7963,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_35",
         "labels": [
@@ -7876,6 +7983,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_36_sum",
         "labels": [
@@ -7891,6 +7999,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_36_count",
         "labels": [
@@ -7906,6 +8015,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_36",
         "labels": [
@@ -7925,6 +8035,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_37_sum",
         "labels": [
@@ -7940,6 +8051,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_37_count",
         "labels": [
@@ -7955,6 +8067,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_37",
         "labels": [
@@ -7974,6 +8087,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_38_sum",
         "labels": [
@@ -7989,6 +8103,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_38_count",
         "labels": [
@@ -8004,6 +8119,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_38",
         "labels": [
@@ -8023,6 +8139,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_39_sum",
         "labels": [
@@ -8038,6 +8155,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_39_count",
         "labels": [
@@ -8053,6 +8171,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_39",
         "labels": [
@@ -8072,6 +8191,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_40_sum",
         "labels": [
@@ -8087,6 +8207,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_40_count",
         "labels": [
@@ -8102,6 +8223,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_40",
         "labels": [
@@ -8121,6 +8243,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_41_sum",
         "labels": [
@@ -8136,6 +8259,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_41_count",
         "labels": [
@@ -8151,6 +8275,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_41",
         "labels": [
@@ -8173,6 +8298,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -8715,7 +8841,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -8730,7 +8858,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -8745,7 +8875,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -8760,7 +8892,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -8775,7 +8909,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -8790,7 +8926,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -8808,7 +8946,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -8823,7 +8963,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -8838,7 +8980,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/create_service_timeseries_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/create_service_timeseries_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createServiceTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -36,6 +37,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -321,7 +323,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -336,7 +340,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -351,7 +357,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -366,7 +374,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -381,7 +391,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -396,7 +408,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -414,7 +428,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -429,7 +445,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -444,7 +462,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/delta_counter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/delta_counter_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -37,7 +38,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "deltacounter",
         "type": "workload.googleapis.com/deltacounter",
         "labels": [
           {
@@ -55,6 +58,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -597,7 +601,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -612,7 +618,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -627,7 +635,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -642,7 +652,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -657,7 +669,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -672,7 +686,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -690,7 +706,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -705,7 +723,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -720,7 +740,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/exponential_histogram_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/exponential_histogram_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -205,7 +206,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "durationhist",
         "type": "workload.googleapis.com/durationhist",
         "metricKind": "CUMULATIVE",
         "valueType": "DISTRIBUTION",
@@ -215,7 +218,9 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "foohist",
         "type": "workload.googleapis.com/foohist",
         "metricKind": "CUMULATIVE",
         "valueType": "DISTRIBUTION",
@@ -228,6 +233,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -770,7 +776,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -785,7 +793,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -800,7 +810,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -815,7 +827,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -830,7 +844,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -845,7 +861,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -863,7 +881,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -878,7 +898,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -893,7 +915,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/gke_control_plane_metrics_agent_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/gke_control_plane_metrics_agent_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createServiceTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -1066,6 +1067,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -1351,7 +1353,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -1366,7 +1370,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -1381,7 +1387,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -1396,7 +1404,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -1411,7 +1421,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -1426,7 +1438,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -1444,7 +1458,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -1459,7 +1475,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -1474,7 +1492,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/gke_metrics_agent_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/gke_metrics_agent_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createServiceTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -4050,6 +4051,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -4335,7 +4337,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -4350,7 +4354,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -4365,7 +4371,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -4380,7 +4388,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -4395,7 +4405,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -4410,7 +4422,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -4428,7 +4442,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -4443,7 +4459,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -4458,7 +4476,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/google_managed_prometheus_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -647,6 +648,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -932,7 +934,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -947,7 +951,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -962,7 +968,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -977,7 +985,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -992,7 +1002,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -1007,7 +1019,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -1025,7 +1039,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -1040,7 +1056,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -1055,7 +1073,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access_expected.json
@@ -12,7 +12,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -32,7 +32,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/lamp.png",
@@ -52,7 +52,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/favicon.ico",
@@ -72,7 +72,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -92,7 +92,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -112,7 +112,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -132,7 +132,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -152,7 +152,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -172,7 +172,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -192,7 +192,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -212,7 +212,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -232,7 +232,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -252,7 +252,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -272,7 +272,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -292,7 +292,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -312,7 +312,7 @@
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -332,7 +332,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         }
       ],
       "partialSuccess": true

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error_expected.json
@@ -16,7 +16,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.412645 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -32,7 +32,7 @@
             "severity": "warn",
             "time": "Tue Apr 26 00:46:21.457314 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "severity": "WARNING"
         },
         {
@@ -49,7 +49,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.502940 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -65,7 +65,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.503003 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -81,7 +81,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:38.988423 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -97,7 +97,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:34.466058 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -113,7 +113,7 @@
             "severity": "warn",
             "time": "Tue Apr 26 22:48:34.740290 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z",
+          "timestamp": "2022-05-25T21:07:00.969486683Z",
           "severity": "WARNING"
         },
         {
@@ -130,7 +130,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:35.606223 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -146,7 +146,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:35.606298 2022"
           },
-          "timestamp": "2022-05-02T12:16:14.574548493Z"
+          "timestamp": "2022-05-25T21:07:00.969486683Z"
         }
       ],
       "partialSuccess": true

--- a/exporter/collector/integrationtest/testdata/fixtures/nonmonotonic_counter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/nonmonotonic_counter_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -36,7 +37,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "system.memory.usage",
         "type": "workload.googleapis.com/system.memory.usage",
         "labels": [
           {
@@ -54,6 +57,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -596,7 +600,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -611,7 +617,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -626,7 +634,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -641,7 +651,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -656,7 +668,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -671,7 +685,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -689,7 +705,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -704,7 +722,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -719,7 +739,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/ops_agent_host_metrics.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/ops_agent_host_metrics.json
@@ -16,12 +16,6 @@
                         }
                     },
                     {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
-                        }
-                    },
-                    {
                         "key": "cloud.availability_zone",
                         "value": {
                             "stringValue": "us-central1-a"
@@ -874,12 +868,6 @@
                         }
                     },
                     {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
-                        }
-                    },
-                    {
                         "key": "cloud.availability_zone",
                         "value": {
                             "stringValue": "us-central1-a"
@@ -1068,12 +1056,6 @@
                         }
                     },
                     {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
-                        }
-                    },
-                    {
                         "key": "cloud.availability_zone",
                         "value": {
                             "stringValue": "us-central1-a"
@@ -1160,12 +1142,6 @@
                         "key": "cloud.platform",
                         "value": {
                             "stringValue": "gcp_compute_engine"
-                        }
-                    },
-                    {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
                         }
                     },
                     {
@@ -1854,12 +1830,6 @@
                         }
                     },
                     {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
-                        }
-                    },
-                    {
                         "key": "cloud.availability_zone",
                         "value": {
                             "stringValue": "us-central1-a"
@@ -1913,12 +1883,6 @@
                         "key": "cloud.platform",
                         "value": {
                             "stringValue": "gcp_compute_engine"
-                        }
-                    },
-                    {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
                         }
                     },
                     {
@@ -2458,12 +2422,6 @@
                         }
                     },
                     {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
-                        }
-                    },
-                    {
                         "key": "cloud.availability_zone",
                         "value": {
                             "stringValue": "us-central1-a"
@@ -2745,12 +2703,6 @@
                         "key": "cloud.platform",
                         "value": {
                             "stringValue": "gcp_compute_engine"
-                        }
-                    },
-                    {
-                        "key": "cloud.account.id",
-                        "value": {
-                            "stringValue": "josh-opsagenttester"
                         }
                     },
                     {

--- a/exporter/collector/integrationtest/testdata/fixtures/ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/ops_agent_host_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -3153,6 +3154,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -3438,7 +3440,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -3453,7 +3457,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -3468,7 +3474,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -3483,7 +3491,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -3498,7 +3508,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -3513,7 +3525,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -3531,7 +3545,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -3546,7 +3562,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -3561,7 +3579,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/ops_agent_self_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/ops_agent_self_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -60,6 +61,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -345,7 +347,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -360,7 +364,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -375,7 +381,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -390,7 +398,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -405,7 +415,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -420,7 +432,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -438,7 +452,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -453,7 +469,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -468,7 +486,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/summary_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/summary_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -157,6 +158,7 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_sum",
         "labels": [
@@ -172,6 +174,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary_count",
         "labels": [
@@ -187,6 +190,7 @@
       }
     },
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "type": "workload.googleapis.com/testsummary",
         "labels": [
@@ -209,6 +213,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -751,7 +756,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -766,7 +773,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -781,7 +790,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -796,7 +807,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -811,7 +824,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -826,7 +841,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -844,7 +861,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -859,7 +878,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -874,7 +895,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/unknown_domain_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/unknown_domain_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -37,7 +38,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "testcounter",
         "type": "custom.googleapis.com/foobar.org/testcounter",
         "labels": [
           {
@@ -55,6 +58,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -597,7 +601,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -612,7 +618,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -627,7 +635,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -642,7 +652,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -657,7 +669,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -672,7 +686,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -690,7 +706,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -705,7 +723,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -720,7 +740,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/with_resource_filter_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -43,7 +44,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "testresourcefilter",
         "type": "workload.googleapis.com/testresourcefilter",
         "labels": [
           {
@@ -76,6 +79,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -618,7 +622,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -633,7 +639,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -648,7 +656,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -663,7 +673,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -678,7 +690,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -693,7 +707,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -711,7 +727,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -726,7 +744,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -741,7 +761,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/workload_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/workload_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -6333,6 +6334,7 @@
       ]
     },
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -6406,6 +6408,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -6691,7 +6694,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -6706,7 +6711,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -6721,7 +6728,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -6736,7 +6745,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -6751,7 +6762,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -6766,7 +6779,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -6784,7 +6799,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -6799,7 +6816,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -6814,7 +6833,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {

--- a/exporter/collector/integrationtest/testdata/fixtures/workloadgoogleapis_prefix_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/workloadgoogleapis_prefix_metrics_expect.json
@@ -1,6 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -37,7 +38,9 @@
   ],
   "createMetricDescriptorRequests": [
     {
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
+        "name": "testcounter",
         "type": "workload.googleapis.com/testcounter",
         "labels": [
           {
@@ -55,6 +58,7 @@
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {
+        "name": "projects/myproject",
         "timeSeries": [
           {
             "metric": {
@@ -597,7 +601,9 @@
     ],
     "createMetricDescriptorRequests": [
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_log_records",
           "labels": [
             {
@@ -612,7 +618,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_metric_points",
           "labels": [
             {
@@ -627,7 +635,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "type": "custom.googleapis.com/opencensus/exporter/enqueue_failed_spans",
           "labels": [
             {
@@ -642,7 +652,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/exporter/queue_size",
           "type": "custom.googleapis.com/opencensus/exporter/queue_size",
           "labels": [
             {
@@ -657,7 +669,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
           "labels": [
             {
@@ -672,7 +686,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
           "labels": [
             {
@@ -690,7 +706,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
           "labels": [
             {
@@ -705,7 +723,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
           "labels": [
             {
@@ -720,7 +740,9 @@
         }
       },
       {
+        "name": "projects/myproject",
         "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
           "labels": [
             {


### PR DESCRIPTION
We were previously normalizing the project ID because it was set via an env var for the fixture-based tests.  We can test this by simply setting it to a constant instead, and removing the normalization.  This will make it easier to test multi-project exporting: #402.

This also removes some extra cloud.account.id resource attributes from fixtures.