### PR TITLE
Normalize timestamps in log tests

### DIFF
--- a/exporter/collector/integrationtest/diff.go
+++ b/exporter/collector/integrationtest/diff.go
@@ -34,8 +34,8 @@ var (
 func DiffMetricProtos(t testing.TB, x, y *MetricExpectFixture) string {
 	x = proto.Clone(x).(*MetricExpectFixture)
 	y = proto.Clone(y).(*MetricExpectFixture)
-	normalizeFixture(t, x)
-	normalizeFixture(t, y)
+	normalizeMetricFixture(t, x)
+	normalizeMetricFixture(t, y)
 
 	return cmp.Diff(x, y, cmpOptions...)
 }
@@ -44,6 +44,8 @@ func DiffMetricProtos(t testing.TB, x, y *MetricExpectFixture) string {
 func DiffLogProtos(t testing.TB, x, y *LogExpectFixture) string {
 	x = proto.Clone(x).(*LogExpectFixture)
 	y = proto.Clone(y).(*LogExpectFixture)
+	normalizeLogFixture(t, x)
+	normalizeLogFixture(t, y)
 
 	return cmp.Diff(x, y, cmpOptions...)
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_access_expected.json
@@ -12,7 +12,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -32,7 +32,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/lamp.png",
@@ -52,7 +52,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/favicon.ico",
@@ -72,7 +72,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -92,7 +92,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -112,7 +112,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -132,7 +132,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -152,7 +152,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -172,7 +172,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -192,7 +192,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -212,7 +212,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -232,7 +232,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -252,7 +252,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -272,7 +272,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -292,7 +292,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -312,7 +312,7 @@
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
             "requestUrl": "/",
@@ -332,7 +332,7 @@
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         }
       ],
       "partialSuccess": true

--- a/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs_apache_error_expected.json
@@ -16,7 +16,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.412645 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -32,7 +32,7 @@
             "severity": "warn",
             "time": "Tue Apr 26 00:46:21.457314 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "severity": "WARNING"
         },
         {
@@ -49,7 +49,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.502940 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -65,7 +65,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.503003 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -81,7 +81,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 00:46:38.988423 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -97,7 +97,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:34.466058 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -113,7 +113,7 @@
             "severity": "warn",
             "time": "Tue Apr 26 22:48:34.740290 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z",
+          "timestamp": "1970-01-01T00:00:00Z",
           "severity": "WARNING"
         },
         {
@@ -130,7 +130,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:35.606223 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         },
         {
           "logName": "projects/fakeprojectid/logs/apache-error-fixture",
@@ -146,7 +146,7 @@
             "severity": "notice",
             "time": "Tue Apr 26 22:48:35.606298 2022"
           },
-          "timestamp": "2022-05-25T21:07:00.969486683Z"
+          "timestamp": "1970-01-01T00:00:00Z"
         }
       ],
       "partialSuccess": true


### PR DESCRIPTION
This way the time doesn't change each time the fixtures are regenerated.  This matches what we do in metric tests