### PR TITLE
Remove GKEHostName, since the instance name is not available on GKE

### DIFF
--- a/detectors/gcp/gke.go
+++ b/detectors/gcp/gke.go
@@ -40,11 +40,6 @@ func (d *Detector) GKEHostID() (string, error) {
 	return d.GCEHostID()
 }
 
-// GKEHostName returns the instance name of the instance on which this program is running
-func (d *Detector) GKEHostName() (string, error) {
-	return d.GCEHostName()
-}
-
 // GKEClusterName returns the name if the GKE cluster in which this program is running
 func (d *Detector) GKEClusterName() (string, error) {
 	return d.metadata.InstanceAttributeValue(clusterNameMetadataAttr)

--- a/detectors/gcp/gke_test.go
+++ b/detectors/gcp/gke_test.go
@@ -39,24 +39,6 @@ func TestGKEHostIDErr(t *testing.T) {
 	assert.Equal(t, instanceID, "")
 }
 
-func TestGKEHostName(t *testing.T) {
-	d := NewTestDetector(&FakeMetadataProvider{
-		FakeInstanceName: "my-host-123",
-	}, &FakeOSProvider{})
-	hostName, err := d.GKEHostName()
-	assert.NoError(t, err)
-	assert.Equal(t, hostName, "my-host-123")
-}
-
-func TestGKEHostNameErr(t *testing.T) {
-	d := NewTestDetector(&FakeMetadataProvider{
-		Err: fmt.Errorf("fake error"),
-	}, &FakeOSProvider{})
-	hostName, err := d.GKEHostName()
-	assert.Error(t, err)
-	assert.Equal(t, hostName, "")
-}
-
 func TestGKEClusterName(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		InstanceAttributes: map[string]string{clusterNameMetadataAttr: "my-cluster"},

--- a/e2e-test-server/endtoendserver/server.go
+++ b/e2e-test-server/endtoendserver/server.go
@@ -182,7 +182,6 @@ func (d *testDetector) Detect(ctx context.Context) (*resource.Resource, error) {
 		return detectWithFuncs(attributes, map[attribute.Key]detectionFunc{
 			semconv.K8SClusterNameKey: detector.GKEClusterName,
 			semconv.HostIDKey:         detector.GKEHostID,
-			semconv.HostNameKey:       detector.GKEHostName,
 		})
 	case gcp.CloudRun:
 		attributes = append(attributes, semconv.CloudPlatformGCPCloudRun)


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10486 for more details.