### PR TITLE
Fix GAE region detection

### DIFF
--- a/detectors/gcp/app_engine.go
+++ b/detectors/gcp/app_engine.go
@@ -52,6 +52,22 @@ func (d *Detector) AppEngineServiceInstance() (string, error) {
 }
 
 // AppEngineAvailabilityZoneAndRegion returns the zone and region in which this program is running
+// Deprecated: Use AppEngineAvailabilityZone and AppEngineCloudRegion instead.
 func (d *Detector) AppEngineAvailabilityZoneAndRegion() (string, string, error) {
-	return d.GCEAvailabilityZoneAndRegion()
+	zone, err := d.AppEngineAvailabilityZone()
+	if err != nil {
+		return "", "", err
+	}
+	region, err := d.AppEngineCloudRegion()
+	return zone, region, err
+}
+
+// AppEngineCloudRegion returns the zone the app engine service is running in.
+func (d *Detector) AppEngineAvailabilityZone() (string, error) {
+	return d.metadata.Zone()
+}
+
+// AppEngineCloudRegion returns the region the app engine service is running in.
+func (d *Detector) AppEngineCloudRegion() (string, error) {
+	return d.FaaSCloudRegion()
 }

--- a/detectors/gcp/app_engine_test.go
+++ b/detectors/gcp/app_engine_test.go
@@ -15,6 +15,7 @@
 package gcp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,6 +77,42 @@ func TestAppEngineServiceInstanceErr(t *testing.T) {
 		Vars: map[string]string{},
 	})
 	instance, err := d.AppEngineServiceInstance()
+	assert.Error(t, err)
+	assert.Equal(t, instance, "")
+}
+
+func TestAppEngineAvailabilityZone(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		FakeZone: "us16",
+	}, &FakeOSProvider{})
+	zone, err := d.AppEngineAvailabilityZone()
+	assert.NoError(t, err)
+	assert.Equal(t, zone, "us16")
+}
+
+func TestAppEngineAvailabilityZoneErr(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		Err: fmt.Errorf("fake error"),
+	}, &FakeOSProvider{})
+	zone, err := d.AppEngineAvailabilityZone()
+	assert.Error(t, err)
+	assert.Equal(t, zone, "")
+}
+
+func TestAppEngineCloudRegion(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		Attributes: map[string]string{regionMetadataAttr: "/projects/123/regions/us-central1"},
+	}, &FakeOSProvider{})
+	instance, err := d.AppEngineCloudRegion()
+	assert.NoError(t, err)
+	assert.Equal(t, instance, "us-central1")
+}
+
+func TestAppEngineCloudRegionErr(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		Err: fmt.Errorf("fake error"),
+	}, &FakeOSProvider{})
+	instance, err := d.AppEngineCloudRegion()
 	assert.Error(t, err)
 	assert.Equal(t, instance, "")
 }

--- a/e2e-test-server/endtoendserver/server.go
+++ b/e2e-test-server/endtoendserver/server.go
@@ -201,16 +201,12 @@ func (d *testDetector) Detect(ctx context.Context) (*resource.Resource, error) {
 		})
 	case gcp.AppEngine:
 		attributes = append(attributes, semconv.CloudPlatformGCPAppEngine)
-		zone, region, err := detector.AppEngineAvailabilityZoneAndRegion()
-		if err != nil {
-			return nil, err
-		}
-		attributes = append(attributes, semconv.CloudAvailabilityZoneKey.String(zone))
-		attributes = append(attributes, semconv.CloudRegionKey.String(region))
 		return detectWithFuncs(attributes, map[attribute.Key]detectionFunc{
-			semconv.FaaSNameKey:    detector.AppEngineServiceName,
-			semconv.FaaSVersionKey: detector.AppEngineServiceVersion,
-			semconv.FaaSIDKey:      detector.AppEngineServiceInstance,
+			semconv.FaaSNameKey:              detector.AppEngineServiceName,
+			semconv.FaaSVersionKey:           detector.AppEngineServiceVersion,
+			semconv.FaaSIDKey:                detector.AppEngineServiceInstance,
+			semconv.CloudRegionKey:           detector.AppEngineCloudRegion,
+			semconv.CloudAvailabilityZoneKey: detector.AppEngineAvailabilityZone,
 		})
 	case gcp.GCE:
 		attributes = append(attributes, semconv.CloudPlatformGCPComputeEngine)


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/408.  We can't parse the zone the same way as we do on GCE, so we have to use the zone from "instance/zone" and region from "instance/region" (same as Cloud run and Cloud functions).