### PR TITLE
Fix detection on App engine flex, which is different from standard

### DIFF
--- a/detectors/gcp/app_engine.go
+++ b/detectors/gcp/app_engine.go
@@ -20,7 +20,15 @@ const (
 	gaeServiceEnv  = "GAE_SERVICE"
 	gaeVersionEnv  = "GAE_VERSION"
 	gaeInstanceEnv = "GAE_INSTANCE"
+	gaeEnv         = "GAE_ENV"
+	gaeStandard    = "standard"
 )
+
+func (d *Detector) onAppEngineStandard() bool {
+	// See https://cloud.google.com/appengine/docs/standard/go111/runtime#environment_variables.
+	env, found := d.os.LookupEnv(gaeEnv)
+	return found && env == gaeStandard
+}
 
 func (d *Detector) onAppEngine() bool {
 	_, found := d.os.LookupEnv(gaeServiceEnv)
@@ -51,23 +59,18 @@ func (d *Detector) AppEngineServiceInstance() (string, error) {
 	return "", errEnvVarNotFound
 }
 
-// AppEngineAvailabilityZoneAndRegion returns the zone and region in which this program is running
-// Deprecated: Use AppEngineAvailabilityZone and AppEngineCloudRegion instead.
-func (d *Detector) AppEngineAvailabilityZoneAndRegion() (string, string, error) {
-	zone, err := d.AppEngineAvailabilityZone()
-	if err != nil {
-		return "", "", err
-	}
-	region, err := d.AppEngineCloudRegion()
-	return zone, region, err
+// AppEngineFlexAvailabilityZoneAndRegion returns the zone and region in which this program is running.
+func (d *Detector) AppEngineFlexAvailabilityZoneAndRegion() (string, string, error) {
+	// The GCE metadata server is available on App Engine Flex.
+	return d.GCEAvailabilityZoneAndRegion()
 }
 
-// AppEngineCloudRegion returns the zone the app engine service is running in.
-func (d *Detector) AppEngineAvailabilityZone() (string, error) {
+// AppEngineStandardAvailabilityZone returns the zone the app engine service is running in.
+func (d *Detector) AppEngineStandardAvailabilityZone() (string, error) {
 	return d.metadata.Zone()
 }
 
-// AppEngineCloudRegion returns the region the app engine service is running in.
-func (d *Detector) AppEngineCloudRegion() (string, error) {
+// AppEngineStandardCloudRegion returns the region the app engine service is running in.
+func (d *Detector) AppEngineStandardCloudRegion() (string, error) {
 	return d.FaaSCloudRegion()
 }

--- a/detectors/gcp/app_engine_test.go
+++ b/detectors/gcp/app_engine_test.go
@@ -81,38 +81,78 @@ func TestAppEngineServiceInstanceErr(t *testing.T) {
 	assert.Equal(t, instance, "")
 }
 
-func TestAppEngineAvailabilityZone(t *testing.T) {
+func TestAppEngineStandardAvailabilityZone(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		FakeZone: "us16",
 	}, &FakeOSProvider{})
-	zone, err := d.AppEngineAvailabilityZone()
+	zone, err := d.AppEngineStandardAvailabilityZone()
 	assert.NoError(t, err)
 	assert.Equal(t, zone, "us16")
 }
 
-func TestAppEngineAvailabilityZoneErr(t *testing.T) {
+func TestAppEngineStandardAvailabilityZoneErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		Err: fmt.Errorf("fake error"),
 	}, &FakeOSProvider{})
-	zone, err := d.AppEngineAvailabilityZone()
+	zone, err := d.AppEngineStandardAvailabilityZone()
 	assert.Error(t, err)
 	assert.Equal(t, zone, "")
 }
 
-func TestAppEngineCloudRegion(t *testing.T) {
+func TestAppEngineStandardCloudRegion(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		Attributes: map[string]string{regionMetadataAttr: "/projects/123/regions/us-central1"},
 	}, &FakeOSProvider{})
-	instance, err := d.AppEngineCloudRegion()
+	instance, err := d.AppEngineStandardCloudRegion()
 	assert.NoError(t, err)
 	assert.Equal(t, instance, "us-central1")
 }
 
-func TestAppEngineCloudRegionErr(t *testing.T) {
+func TestAppEngineStandardCloudRegionErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		Err: fmt.Errorf("fake error"),
 	}, &FakeOSProvider{})
-	instance, err := d.AppEngineCloudRegion()
+	instance, err := d.AppEngineStandardCloudRegion()
 	assert.Error(t, err)
 	assert.Equal(t, instance, "")
+}
+
+func TestAppEngineFlexAvailabilityZoneAndRegion(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		FakeZone: "us-central1-c",
+	}, &FakeOSProvider{})
+	zone, region, err := d.AppEngineFlexAvailabilityZoneAndRegion()
+	assert.NoError(t, err)
+	assert.Equal(t, zone, "us-central1-c")
+	assert.Equal(t, region, "us-central1")
+}
+
+func TestAppEngineFlexAvailabilityZoneAndRegionMalformedZone(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		FakeZone: "us-central1",
+	}, &FakeOSProvider{})
+	zone, region, err := d.AppEngineFlexAvailabilityZoneAndRegion()
+	assert.Error(t, err)
+	assert.Equal(t, zone, "")
+	assert.Equal(t, region, "")
+}
+
+func TestAppEngineFlexAvailabilityZoneAndRegionNoZone(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		FakeZone: "",
+	}, &FakeOSProvider{})
+	zone, region, err := d.AppEngineFlexAvailabilityZoneAndRegion()
+	assert.Error(t, err)
+	assert.Equal(t, zone, "")
+	assert.Equal(t, region, "")
+}
+
+func TestAppEngineFlexAvailabilityZoneAndRegionErr(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		Err: fmt.Errorf("fake error"),
+	}, &FakeOSProvider{})
+	zone, region, err := d.AppEngineFlexAvailabilityZoneAndRegion()
+	assert.Error(t, err)
+	assert.Equal(t, zone, "")
+	assert.Equal(t, region, "")
 }

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -36,8 +36,9 @@ const (
 	GKE
 	GCE
 	CloudRun
-	AppEngine
 	CloudFunctions
+	AppEngineStandard
+	AppEngineFlex
 )
 
 // CloudPlatform returns the platform on which this program is running
@@ -49,8 +50,10 @@ func (d *Detector) CloudPlatform() Platform {
 		return CloudRun
 	case d.onCloudFunctions():
 		return CloudFunctions
+	case d.onAppEngineStandard():
+		return AppEngineStandard
 	case d.onAppEngine():
-		return AppEngine
+		return AppEngineFlex
 	case d.onGCE():
 		return GCE
 	}

--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -21,14 +21,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCloudPlatformAppEngine(t *testing.T) {
+func TestCloudPlatformAppEngineFlex(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{
 			gaeServiceEnv: "foo",
 		},
 	})
 	platform := d.CloudPlatform()
-	assert.Equal(t, platform, AppEngine)
+	assert.Equal(t, platform, AppEngineFlex)
+}
+
+func TestCloudPlatformAppEngineStandard(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{
+			gaeServiceEnv: "foo",
+			gaeEnv:        "standard",
+		},
+	})
+	platform := d.CloudPlatform()
+	assert.Equal(t, platform, AppEngineStandard)
 }
 
 func TestCloudPlatformGKE(t *testing.T) {

--- a/e2e-test-server/endtoendserver/server.go
+++ b/e2e-test-server/endtoendserver/server.go
@@ -199,14 +199,27 @@ func (d *testDetector) Detect(ctx context.Context) (*resource.Resource, error) {
 			semconv.FaaSIDKey:      detector.FaaSID,
 			semconv.CloudRegionKey: detector.FaaSCloudRegion,
 		})
-	case gcp.AppEngine:
+	case gcp.AppEngineStandard:
 		attributes = append(attributes, semconv.CloudPlatformGCPAppEngine)
 		return detectWithFuncs(attributes, map[attribute.Key]detectionFunc{
 			semconv.FaaSNameKey:              detector.AppEngineServiceName,
 			semconv.FaaSVersionKey:           detector.AppEngineServiceVersion,
 			semconv.FaaSIDKey:                detector.AppEngineServiceInstance,
-			semconv.CloudRegionKey:           detector.AppEngineCloudRegion,
-			semconv.CloudAvailabilityZoneKey: detector.AppEngineAvailabilityZone,
+			semconv.CloudRegionKey:           detector.AppEngineStandardCloudRegion,
+			semconv.CloudAvailabilityZoneKey: detector.AppEngineStandardAvailabilityZone,
+		})
+	case gcp.AppEngineFlex:
+		attributes = append(attributes, semconv.CloudPlatformGCPAppEngine)
+		zone, region, err := detector.AppEngineFlexAvailabilityZoneAndRegion()
+		if err != nil {
+			return nil, err
+		}
+		attributes = append(attributes, semconv.CloudAvailabilityZoneKey.String(zone))
+		attributes = append(attributes, semconv.CloudRegionKey.String(region))
+		return detectWithFuncs(attributes, map[attribute.Key]detectionFunc{
+			semconv.FaaSNameKey:    detector.AppEngineServiceName,
+			semconv.FaaSVersionKey: detector.AppEngineServiceVersion,
+			semconv.FaaSIDKey:      detector.AppEngineServiceInstance,
 		})
 	case gcp.GCE:
 		attributes = append(attributes, semconv.CloudPlatformGCPComputeEngine)


### PR DESCRIPTION
App engine flex uses the GCE metadata server, but app engine standard has its own metadata server.  So on standard, we can use "instance/region" to get the region, and on flex, we can use the GCE detection of zone/region.

On app engine standard, there is a GAE_ENV environment variable set to "standard".  On app engine flex, it doesn't exist.

This splits AppEngine into AppEngineFlex and AppEngineStandard to allow detecting both platforms.