### PR TITLE
Fix linter for 1.18 and add action to run it in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+# This action runs "make lint" to check go file validity
+
+name: lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+jobs:
+  gotidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for lint failures
+        run: |
+          make lint

--- a/golangci.yml
+++ b/golangci.yml
@@ -3,6 +3,9 @@
 
 # options for analysis running
 run:
+  # https://github.com/golangci/golangci-lint/issues/2664#issuecomment-1073337317
+  go: 1.18
+
   # default concurrency is a available CPU number
   concurrency: 4
 


### PR DESCRIPTION
afaict, we are not calling golangci-lint in our CI anywhere. Going to play with github actions to get it set up