### PR TITLE
exporter/trace: remove batchSpanProcessorOptions from options struct

### DIFF
--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -74,9 +74,6 @@ type options struct {
 	// to the underlying Stackdriver Trace API client.
 	// Optional.
 	traceClientOptions []option.ClientOption
-	// batchSpanProcessorOptions are additional options to be based
-	// to the underlying BatchSpanProcessor when call making a new export pipeline.
-	batchSpanProcessorOptions []sdktrace.BatchSpanProcessorOption
 	// timeout for all API calls. If not set, defaults to 5 seconds.
 	timeout time.Duration
 }


### PR DESCRIPTION
This exporter has removed the `InstallNewPipeline` (and etc) utility with ec949722f3.
Also, in the current architecture where the package user calls `sdktrace.NewTracerProvider`, this option shouldn't have by the exporter.