### PR TITLE
exporter/collector/integrationtest: fix slice order flaky tset

### DIFF
--- a/exporter/collector/integrationtest/diff.go
+++ b/exporter/collector/integrationtest/diff.go
@@ -31,11 +31,16 @@ var (
 )
 
 // Diff uses cmp.Diff(), protocmp, and some custom options to compare two protobuf messages.
-func DiffMetricProtos(t testing.TB, x, y *MetricExpectFixture) string {
+func DiffMetricProtos(t testing.TB, x, y *MetricExpectFixture, lessFunc ...interface{}) string {
 	x = proto.Clone(x).(*MetricExpectFixture)
 	y = proto.Clone(y).(*MetricExpectFixture)
 	normalizeMetricFixture(t, x)
 	normalizeMetricFixture(t, y)
+
+	cmpOptions := cmpOptions // copy
+	for _, lessfn := range lessFunc {
+		cmpOptions = append(cmpOptions, cmpopts.SortSlices(lessfn))
+	}
 
 	return cmp.Diff(x, y, cmpOptions...)
 }

--- a/exporter/collector/integrationtest/metrics_test.go
+++ b/exporter/collector/integrationtest/metrics_test.go
@@ -72,7 +72,7 @@ func TestMetrics(t *testing.T) {
 				fixture,
 				expectFixture,
 				func(i, j int) bool {
-					return fixture.CreateTimeSeriesRequests[i].Name < fixture.CreateTimeSeriesRequests[j].Name
+					return fixture.CreateTimeSeriesRequests[i].Name > fixture.CreateTimeSeriesRequests[j].Name
 				},
 				func(i, j int) bool {
 					return fixture.CreateMetricDescriptorRequests[i].Name < fixture.CreateMetricDescriptorRequests[j].Name


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/421

Fix flaky test caused by slice order.
Also, add lessFunc variadic args to DiffMetricProtos for sort slice using `cmpopts.SortSlices` because diff.go wrap the cmp options.

This flaky test happened on https://app.circleci.com/pipelines/github/GoogleCloudPlatform/opentelemetry-operations-go/1396/workflows/725c989a-9bbe-4b9b-a1a9-02722191e072/jobs/1392.