### PR TITLE
Add unused code check in linter

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -1159,6 +1159,3 @@ func mapMetricPointKind(m pmetric.Metric) (metricpb.MetricDescriptor_MetricKind,
 	}
 	return kind, typ
 }
-
-func (me *MetricsExporter) processItem(ts *monitoringpb.TimeSeries) {
-}

--- a/exporter/collector/observability.go
+++ b/exporter/collector/observability.go
@@ -44,21 +44,6 @@ func MetricViews() []*view.View {
 	return []*view.View{viewPointCount}
 }
 
-func recordPointCount(ctx context.Context, success, dropped int, grpcErr error) {
-	if success > 0 {
-		recordPointCountDataPoint(ctx, success, "OK")
-	}
-
-	if dropped > 0 {
-		st := "UNKNOWN"
-		s, ok := status.FromError(grpcErr)
-		if ok {
-			st = statusCodeToString(s)
-		}
-		recordPointCountDataPoint(ctx, dropped, st)
-	}
-}
-
 func recordExemplarFailure(ctx context.Context, point int) {
 	stats.Record(ctx, exemplarAttachmentDropCount.M(int64(point)))
 }

--- a/golangci.yml
+++ b/golangci.yml
@@ -122,6 +122,12 @@ linters:
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
+    # integrationtests defines constants that are used by _test.go files which
+    # aren't detected as being used (for some reason)
+    - path: testcase.go
+      linters:
+        - unused
+      text: "secondProjectEnv"
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:

--- a/golangci.yml
+++ b/golangci.yml
@@ -117,6 +117,7 @@ linters:
     - staticcheck
     - misspell
     - exportloopref
+    - unused
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/416

This adds a check for unused code. It also updates the `golangci.yml` config to skip a false positive, where the `secondProjectEnv` const defined in `testcase.go` is not detected as being used (it is called in 2 `_test.go` files, which I believe the linter is ignoring and it doesn't have any config option to include them afaict)