### PR TITLE
Added TraceSampled Attribute

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -45,6 +45,7 @@ const (
 	HTTPRequestAttributeKey    = "gcp.http_request"
 	LogNameAttributeKey        = "gcp.log_name"
 	SourceLocationAttributeKey = "gcp.source_location"
+	TraceSampledAttributeKey   = "gcp.trace_sampled"
 )
 
 // severityMapping maps the integer severity level values from OTel [0-24]
@@ -319,6 +320,12 @@ func (l logMapper) logToSplitEntries(
 		}
 		entry.SourceLocation = &logEntrySourceLocation
 		delete(attrsMap, SourceLocationAttributeKey)
+	}
+
+	// parse TraceSampled boolean from OTel attribute
+	if traceSampled, ok := attrsMap[TraceSampledAttributeKey]; ok {
+		entry.TraceSampled = traceSampled.BoolVal()
+		delete(attrsMap, TraceSampledAttributeKey)
 	}
 
 	// parse TraceID and SpanID, if present

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -219,6 +219,27 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with traceSampled (bool)",
+			mr: func() *monitoredres.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Attributes().Insert(
+					TraceSampledAttributeKey,
+					pcommon.NewValueBool(true),
+				)
+				return log
+			},
+			expectedEntries: []logging.Entry{
+				{
+					TraceSampled: true,
+					Timestamp:    testObservedTime,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log with trace and span id",
 			mr: func() *monitoredres.MonitoredResource {
 				return nil


### PR DESCRIPTION
To get the trace details working in gcp logs console traceSampled is required in the logs. So we have added the trace_sampled attribute in the way similar to log_name to get trace details working.