### PR TITLE
exporter/collector/integrationtest: fix lack of sort expectFixture fields

### DIFF
--- a/exporter/collector/integrationtest/diff.go
+++ b/exporter/collector/integrationtest/diff.go
@@ -31,16 +31,11 @@ var (
 )
 
 // Diff uses cmp.Diff(), protocmp, and some custom options to compare two protobuf messages.
-func DiffMetricProtos(t testing.TB, x, y *MetricExpectFixture, lessFunc ...interface{}) string {
+func DiffMetricProtos(t testing.TB, x, y *MetricExpectFixture) string {
 	x = proto.Clone(x).(*MetricExpectFixture)
 	y = proto.Clone(y).(*MetricExpectFixture)
 	normalizeMetricFixture(t, x)
 	normalizeMetricFixture(t, y)
-
-	cmpOptions := cmpOptions // copy
-	for _, lessfn := range lessFunc {
-		cmpOptions = append(cmpOptions, cmpopts.SortSlices(lessfn))
-	}
 
 	return cmp.Diff(x, y, cmpOptions...)
 }

--- a/exporter/collector/integrationtest/metrics_test.go
+++ b/exporter/collector/integrationtest/metrics_test.go
@@ -16,6 +16,7 @@ package integrationtest
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -58,6 +59,15 @@ func TestMetrics(t *testing.T) {
 				startTime,
 				endTime,
 			)
+			sort.Slice(expectFixture.CreateTimeSeriesRequests, func(i, j int) bool {
+				return expectFixture.CreateTimeSeriesRequests[i].Name < expectFixture.CreateTimeSeriesRequests[j].Name
+			})
+			sort.Slice(expectFixture.CreateMetricDescriptorRequests, func(i, j int) bool {
+				return expectFixture.CreateMetricDescriptorRequests[i].Name < expectFixture.CreateMetricDescriptorRequests[j].Name
+			})
+			sort.Slice(expectFixture.CreateServiceTimeSeriesRequests, func(i, j int) bool {
+				return expectFixture.CreateServiceTimeSeriesRequests[i].Name < expectFixture.CreateServiceTimeSeriesRequests[j].Name
+			})
 
 			selfObsMetrics, err := inMemoryOCExporter.Proto(ctx)
 			require.NoError(t, err)
@@ -67,18 +77,36 @@ func TestMetrics(t *testing.T) {
 				CreateServiceTimeSeriesRequests: testServer.CreateServiceTimeSeriesRequests(),
 				SelfObservabilityMetrics:        selfObsMetrics,
 			}
+			sort.Slice(fixture.CreateTimeSeriesRequests, func(i, j int) bool {
+				return fixture.CreateTimeSeriesRequests[i].Name < fixture.CreateTimeSeriesRequests[j].Name
+			})
+			sort.Slice(fixture.CreateMetricDescriptorRequests, func(i, j int) bool {
+				return fixture.CreateMetricDescriptorRequests[i].Name < fixture.CreateMetricDescriptorRequests[j].Name
+			})
+			sort.Slice(fixture.CreateServiceTimeSeriesRequests, func(i, j int) bool {
+				return fixture.CreateServiceTimeSeriesRequests[i].Name < fixture.CreateServiceTimeSeriesRequests[j].Name
+			})
 			diff := DiffMetricProtos(
 				t,
 				fixture,
 				expectFixture,
 				func(i, j int) bool {
-					return fixture.CreateTimeSeriesRequests[i].Name > fixture.CreateTimeSeriesRequests[j].Name
+					return fixture.CreateTimeSeriesRequests[i].Name < fixture.CreateTimeSeriesRequests[j].Name
 				},
 				func(i, j int) bool {
 					return fixture.CreateMetricDescriptorRequests[i].Name < fixture.CreateMetricDescriptorRequests[j].Name
 				},
 				func(i, j int) bool {
 					return fixture.CreateServiceTimeSeriesRequests[i].Name < fixture.CreateServiceTimeSeriesRequests[j].Name
+				},
+				func(i, j int) bool {
+					return expectFixture.CreateTimeSeriesRequests[i].Name < expectFixture.CreateTimeSeriesRequests[j].Name
+				},
+				func(i, j int) bool {
+					return expectFixture.CreateMetricDescriptorRequests[i].Name < expectFixture.CreateMetricDescriptorRequests[j].Name
+				},
+				func(i, j int) bool {
+					return expectFixture.CreateServiceTimeSeriesRequests[i].Name < expectFixture.CreateServiceTimeSeriesRequests[j].Name
 				},
 			)
 			if diff != "" {

--- a/exporter/collector/integrationtest/metrics_test.go
+++ b/exporter/collector/integrationtest/metrics_test.go
@@ -90,24 +90,6 @@ func TestMetrics(t *testing.T) {
 				t,
 				fixture,
 				expectFixture,
-				func(i, j int) bool {
-					return fixture.CreateTimeSeriesRequests[i].Name < fixture.CreateTimeSeriesRequests[j].Name
-				},
-				func(i, j int) bool {
-					return fixture.CreateMetricDescriptorRequests[i].Name < fixture.CreateMetricDescriptorRequests[j].Name
-				},
-				func(i, j int) bool {
-					return fixture.CreateServiceTimeSeriesRequests[i].Name < fixture.CreateServiceTimeSeriesRequests[j].Name
-				},
-				func(i, j int) bool {
-					return expectFixture.CreateTimeSeriesRequests[i].Name < expectFixture.CreateTimeSeriesRequests[j].Name
-				},
-				func(i, j int) bool {
-					return expectFixture.CreateMetricDescriptorRequests[i].Name < expectFixture.CreateMetricDescriptorRequests[j].Name
-				},
-				func(i, j int) bool {
-					return expectFixture.CreateServiceTimeSeriesRequests[i].Name < expectFixture.CreateServiceTimeSeriesRequests[j].Name
-				},
 			)
 			if diff != "" {
 				require.Fail(


### PR DESCRIPTION
exporter/collector/integrationtest: fix lack of sort `expectFixture` fields.

Fix: #421