### PR TITLE
Add client option for GRPC connection pool size

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -51,6 +51,8 @@ type ClientConfig struct {
 	Endpoint string `mapstructure:"endpoint"`
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
+	// GRPCPoolSize sets the size of the connection pool in the GCP client
+	GRPCPoolSize int `mapstructure:"grpcPoolSize"`
 }
 
 type TraceConfig struct {

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -56,11 +56,12 @@ type ClientConfig struct {
 }
 
 type TraceConfig struct {
-	ClientConfig ClientConfig `mapstructure:",squash"`
 	// AttributeMappings determines how to map from OpenTelemetry attribute
 	// keys to Google Cloud Trace keys.  By default, it changes http and
 	// service keys so that they appear more prominently in the UI.
 	AttributeMappings []AttributeMapping `mapstructure:"attribute_mappings"`
+
+	ClientConfig ClientConfig `mapstructure:",squash"`
 }
 
 // AttributeMapping maps from an OpenTelemetry key to a Google Cloud Trace key.
@@ -82,8 +83,7 @@ type MetricConfig struct {
 	// exporter. It allows overriding the function used to map otel resource to
 	// monitored resource.
 	MapMonitoredResource func(pcommon.Resource) *monitoredrespb.MonitoredResource
-	Prefix               string       `mapstructure:"prefix"`
-	ClientConfig         ClientConfig `mapstructure:",squash"`
+	Prefix               string `mapstructure:"prefix"`
 	// KnownDomains contains a list of prefixes. If a metric already has one
 	// of these prefixes, the prefix is not added.
 	KnownDomains []string `mapstructure:"known_domains"`
@@ -92,6 +92,7 @@ type MetricConfig struct {
 	// Defaults to empty, which won't include any additional resource labels. Note that the
 	// service_resource_labels option operates independently from resource_filters.
 	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
+	ClientConfig    ClientConfig     `mapstructure:",squash"`
 	// CreateMetricDescriptorBufferSize is the buffer size for the channel
 	// which asynchronously calls CreateMetricDescriptor. Default is 10.
 	CreateMetricDescriptorBufferSize int  `mapstructure:"create_metric_descriptor_buffer_size"`

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -52,7 +52,7 @@ type ClientConfig struct {
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
 	// GRPCPoolSize sets the size of the connection pool in the GCP client
-	GRPCPoolSize int `mapstructure:"grpcPoolSize"`
+	GRPCPoolSize int `mapstructure:"grpc_pool_size"`
 }
 
 type TraceConfig struct {

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -58,14 +58,16 @@ func TestLoadConfig(t *testing.T) {
 				UserAgent: "opentelemetry-collector-contrib {{version}}",
 				TraceConfig: collector.TraceConfig{
 					ClientConfig: collector.ClientConfig{
-						Endpoint:    "test-trace-endpoint",
-						UseInsecure: true,
+						Endpoint:     "test-trace-endpoint",
+						UseInsecure:  true,
+						GRPCPoolSize: 1,
 					},
 				},
 				MetricConfig: collector.MetricConfig{
 					ClientConfig: collector.ClientConfig{
-						Endpoint:    "test-metric-endpoint",
-						UseInsecure: true,
+						Endpoint:     "test-metric-endpoint",
+						UseInsecure:  true,
+						GRPCPoolSize: 1,
 					},
 					Prefix:                     "prefix",
 					SkipCreateMetricDescriptor: true,
@@ -76,6 +78,12 @@ func TestLoadConfig(t *testing.T) {
 					CreateMetricDescriptorBufferSize: 10,
 					ServiceResourceLabels:            true,
 					CumulativeNormalization:          true,
+				},
+				LogConfig: collector.LogConfig{
+					ClientConfig: collector.ClientConfig{
+						GRPCPoolSize: 1,
+					},
+					DefaultLogName: "foo-log",
 				},
 			},
 		})

--- a/exporter/collector/integrationtest/testdata/config.yaml
+++ b/exporter/collector/integrationtest/testdata/config.yaml
@@ -12,11 +12,16 @@ exporters:
     trace:
       endpoint: test-trace-endpoint
       use_insecure: true
+      grpc_pool_size: 1
     metric:
       endpoint: test-metric-endpoint
       use_insecure: true
       prefix: prefix
       skip_create_descriptor: true
+      grpc_pool_size: 1
+    log:
+      default_log_name: foo-log
+      grpc_pool_size: 1
 
 service:
   pipelines:

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -104,6 +104,9 @@ func generateClientOptions(ctx context.Context, cfg *ClientConfig, userAgent str
 		}
 		copts = append(copts, option.WithTokenSource(tokenSource))
 	}
+	if cfg.GRPCPoolSize > 0 {
+		copts = append(copts, option.WithGRPCConnectionPool(cfg.GRPCPoolSize))
+	}
 	if cfg.GetClientOptions != nil {
 		copts = append(copts, cfg.GetClientOptions()...)
 	}


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/454