### PR TITLE
Add Makefile target to generate test fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(TOOLS_DIR)/protoc: $(TOOLS_DIR)/protoc-gen-go
 	cp bin/protoc $(TOOLS_DIR)/ ; \
 	rm -rf $$tmpdir
 
-precommit: generate build lint test
+precommit: generate build lint test fixtures
 
 .PHONY: test-with-coverage
 test-with-coverage:
@@ -209,3 +209,8 @@ prepare-release:
 .PHONY: release
 release: prepare-release check-clean-work-tree
 	go run tools/release.go tag
+
+.PHONY: fixtures
+fixtures:
+	cd ./exporter/collector/integrationtest && \
+	go run cmd/recordfixtures/main.go

--- a/exporter/collector/integrationtest/testcase.go
+++ b/exporter/collector/integrationtest/testcase.go
@@ -360,6 +360,15 @@ func normalizeMetricFixture(t testing.TB, fixture *MetricExpectFixture) {
 	normalizeTimeSeriesReqs(t, fixture.CreateServiceTimeSeriesRequests...)
 	normalizeMetricDescriptorReqs(t, fixture.CreateMetricDescriptorRequests...)
 	normalizeSelfObs(t, fixture.SelfObservabilityMetrics)
+	sort.Slice(fixture.CreateTimeSeriesRequests, func(i, j int) bool {
+		return fixture.CreateTimeSeriesRequests[i].Name < fixture.CreateTimeSeriesRequests[j].Name
+	})
+	sort.Slice(fixture.CreateMetricDescriptorRequests, func(i, j int) bool {
+		return fixture.CreateMetricDescriptorRequests[i].Name < fixture.CreateMetricDescriptorRequests[j].Name
+	})
+	sort.Slice(fixture.CreateServiceTimeSeriesRequests, func(i, j int) bool {
+		return fixture.CreateServiceTimeSeriesRequests[i].Name < fixture.CreateServiceTimeSeriesRequests[j].Name
+	})
 }
 
 func normalizeTimeSeriesReqs(t testing.TB, reqs ...*monitoringpb.CreateTimeSeriesRequest) {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics_multi_project_expected.json
@@ -1,7 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
-      "name": "projects/fake-other-project",
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -352,7 +352,7 @@
       ]
     },
     {
-      "name": "projects/fakeprojectid",
+      "name": "projects/fake-other-project",
       "timeSeries": [
         {
           "metric": {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics_multi_project_expected.json
@@ -1,7 +1,7 @@
 {
   "createTimeSeriesRequests": [
     {
-      "name": "projects/fakeprojectid",
+      "name": "projects/fake-other-project",
       "timeSeries": [
         {
           "metric": {
@@ -352,7 +352,7 @@
       ]
     },
     {
-      "name": "projects/fake-other-project",
+      "name": "projects/fakeprojectid",
       "timeSeries": [
         {
           "metric": {
@@ -705,7 +705,7 @@
   ],
   "createMetricDescriptorRequests": [
     {
-      "name": "projects/fakeprojectid",
+      "name": "projects/fake-other-project",
       "metricDescriptor": {
         "name": "scrape_series_added",
         "type": "workload.googleapis.com/scrape_series_added",
@@ -724,88 +724,10 @@
       }
     },
     {
-      "name": "projects/fakeprojectid",
+      "name": "projects/fake-other-project",
       "metricDescriptor": {
-        "name": "ex_com_one",
-        "type": "workload.googleapis.com/ex_com_one",
-        "labels": [
-          {
-            "key": "A"
-          },
-          {
-            "key": "B"
-          },
-          {
-            "key": "C"
-          },
-          {
-            "key": "ex_com_lemons"
-          },
-          {
-            "key": "service_instance_id"
-          },
-          {
-            "key": "service_name"
-          },
-          {
-            "key": "telemetry_sdk_language"
-          },
-          {
-            "key": "telemetry_sdk_name"
-          },
-          {
-            "key": "telemetry_sdk_version"
-          }
-        ],
-        "metricKind": "GAUGE",
-        "valueType": "DOUBLE",
-        "displayName": "ex_com_one"
-      }
-    },
-    {
-      "name": "projects/fakeprojectid",
-      "metricDescriptor": {
-        "name": "ex_com_two",
-        "type": "workload.googleapis.com/ex_com_two",
-        "labels": [
-          {
-            "key": "A"
-          },
-          {
-            "key": "B"
-          },
-          {
-            "key": "C"
-          },
-          {
-            "key": "ex_com_lemons"
-          },
-          {
-            "key": "service_instance_id"
-          },
-          {
-            "key": "service_name"
-          },
-          {
-            "key": "telemetry_sdk_language"
-          },
-          {
-            "key": "telemetry_sdk_name"
-          },
-          {
-            "key": "telemetry_sdk_version"
-          }
-        ],
-        "metricKind": "CUMULATIVE",
-        "valueType": "DISTRIBUTION",
-        "displayName": "ex_com_two"
-      }
-    },
-    {
-      "name": "projects/fakeprojectid",
-      "metricDescriptor": {
-        "name": "up",
-        "type": "workload.googleapis.com/up",
+        "name": "scrape_samples_scraped",
+        "type": "workload.googleapis.com/scrape_samples_scraped",
         "labels": [
           {
             "key": "service_instance_id"
@@ -816,12 +738,12 @@
         ],
         "metricKind": "GAUGE",
         "valueType": "DOUBLE",
-        "description": "The scraping was successful",
-        "displayName": "up"
+        "description": "The number of samples the target exposed",
+        "displayName": "scrape_samples_scraped"
       }
     },
     {
-      "name": "projects/fakeprojectid",
+      "name": "projects/fake-other-project",
       "metricDescriptor": {
         "name": "scrape_duration_seconds",
         "type": "workload.googleapis.com/scrape_duration_seconds",
@@ -841,48 +763,10 @@
       }
     },
     {
-      "name": "projects/fakeprojectid",
-      "metricDescriptor": {
-        "name": "scrape_samples_scraped",
-        "type": "workload.googleapis.com/scrape_samples_scraped",
-        "labels": [
-          {
-            "key": "service_instance_id"
-          },
-          {
-            "key": "service_name"
-          }
-        ],
-        "metricKind": "GAUGE",
-        "valueType": "DOUBLE",
-        "description": "The number of samples the target exposed",
-        "displayName": "scrape_samples_scraped"
-      }
-    },
-    {
-      "name": "projects/fakeprojectid",
-      "metricDescriptor": {
-        "name": "scrape_samples_post_metric_relabeling",
-        "type": "workload.googleapis.com/scrape_samples_post_metric_relabeling",
-        "labels": [
-          {
-            "key": "service_instance_id"
-          },
-          {
-            "key": "service_name"
-          }
-        ],
-        "metricKind": "GAUGE",
-        "valueType": "DOUBLE",
-        "description": "The number of samples remaining after metric relabeling was applied",
-        "displayName": "scrape_samples_post_metric_relabeling"
-      }
-    },
-    {
       "name": "projects/fake-other-project",
       "metricDescriptor": {
-        "name": "scrape_series_added",
-        "type": "workload.googleapis.com/scrape_series_added",
+        "name": "up",
+        "type": "workload.googleapis.com/up",
         "labels": [
           {
             "key": "service_instance_id"
@@ -893,47 +777,8 @@
         ],
         "metricKind": "GAUGE",
         "valueType": "DOUBLE",
-        "description": "The approximate number of new series in this scrape",
-        "displayName": "scrape_series_added"
-      }
-    },
-    {
-      "name": "projects/fake-other-project",
-      "metricDescriptor": {
-        "name": "ex_com_one",
-        "type": "workload.googleapis.com/ex_com_one",
-        "labels": [
-          {
-            "key": "A"
-          },
-          {
-            "key": "B"
-          },
-          {
-            "key": "C"
-          },
-          {
-            "key": "ex_com_lemons"
-          },
-          {
-            "key": "service_instance_id"
-          },
-          {
-            "key": "service_name"
-          },
-          {
-            "key": "telemetry_sdk_language"
-          },
-          {
-            "key": "telemetry_sdk_name"
-          },
-          {
-            "key": "telemetry_sdk_version"
-          }
-        ],
-        "metricKind": "GAUGE",
-        "valueType": "DOUBLE",
-        "displayName": "ex_com_one"
+        "description": "The scraping was successful",
+        "displayName": "up"
       }
     },
     {
@@ -978,59 +823,40 @@
     {
       "name": "projects/fake-other-project",
       "metricDescriptor": {
-        "name": "up",
-        "type": "workload.googleapis.com/up",
+        "name": "ex_com_one",
+        "type": "workload.googleapis.com/ex_com_one",
         "labels": [
+          {
+            "key": "A"
+          },
+          {
+            "key": "B"
+          },
+          {
+            "key": "C"
+          },
+          {
+            "key": "ex_com_lemons"
+          },
           {
             "key": "service_instance_id"
           },
           {
             "key": "service_name"
-          }
-        ],
-        "metricKind": "GAUGE",
-        "valueType": "DOUBLE",
-        "description": "The scraping was successful",
-        "displayName": "up"
-      }
-    },
-    {
-      "name": "projects/fake-other-project",
-      "metricDescriptor": {
-        "name": "scrape_duration_seconds",
-        "type": "workload.googleapis.com/scrape_duration_seconds",
-        "labels": [
-          {
-            "key": "service_instance_id"
           },
           {
-            "key": "service_name"
-          }
-        ],
-        "metricKind": "GAUGE",
-        "valueType": "DOUBLE",
-        "unit": "seconds",
-        "description": "Duration of the scrape",
-        "displayName": "scrape_duration_seconds"
-      }
-    },
-    {
-      "name": "projects/fake-other-project",
-      "metricDescriptor": {
-        "name": "scrape_samples_scraped",
-        "type": "workload.googleapis.com/scrape_samples_scraped",
-        "labels": [
-          {
-            "key": "service_instance_id"
+            "key": "telemetry_sdk_language"
           },
           {
-            "key": "service_name"
+            "key": "telemetry_sdk_name"
+          },
+          {
+            "key": "telemetry_sdk_version"
           }
         ],
         "metricKind": "GAUGE",
         "valueType": "DOUBLE",
-        "description": "The number of samples the target exposed",
-        "displayName": "scrape_samples_scraped"
+        "displayName": "ex_com_one"
       }
     },
     {
@@ -1050,6 +876,180 @@
         "valueType": "DOUBLE",
         "description": "The number of samples remaining after metric relabeling was applied",
         "displayName": "scrape_samples_post_metric_relabeling"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_samples_post_metric_relabeling",
+        "type": "workload.googleapis.com/scrape_samples_post_metric_relabeling",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The number of samples remaining after metric relabeling was applied",
+        "displayName": "scrape_samples_post_metric_relabeling"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_samples_scraped",
+        "type": "workload.googleapis.com/scrape_samples_scraped",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The number of samples the target exposed",
+        "displayName": "scrape_samples_scraped"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_duration_seconds",
+        "type": "workload.googleapis.com/scrape_duration_seconds",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "unit": "seconds",
+        "description": "Duration of the scrape",
+        "displayName": "scrape_duration_seconds"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "up",
+        "type": "workload.googleapis.com/up",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The scraping was successful",
+        "displayName": "up"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "ex_com_two",
+        "type": "workload.googleapis.com/ex_com_two",
+        "labels": [
+          {
+            "key": "A"
+          },
+          {
+            "key": "B"
+          },
+          {
+            "key": "C"
+          },
+          {
+            "key": "ex_com_lemons"
+          },
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          },
+          {
+            "key": "telemetry_sdk_language"
+          },
+          {
+            "key": "telemetry_sdk_name"
+          },
+          {
+            "key": "telemetry_sdk_version"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "DISTRIBUTION",
+        "displayName": "ex_com_two"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "ex_com_one",
+        "type": "workload.googleapis.com/ex_com_one",
+        "labels": [
+          {
+            "key": "A"
+          },
+          {
+            "key": "B"
+          },
+          {
+            "key": "C"
+          },
+          {
+            "key": "ex_com_lemons"
+          },
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          },
+          {
+            "key": "telemetry_sdk_language"
+          },
+          {
+            "key": "telemetry_sdk_name"
+          },
+          {
+            "key": "telemetry_sdk_version"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "displayName": "ex_com_one"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_series_added",
+        "type": "workload.googleapis.com/scrape_series_added",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The approximate number of new series in this scrape",
+        "displayName": "scrape_series_added"
       }
     }
   ],

--- a/exporter/collector/integrationtests.md
+++ b/exporter/collector/integrationtests.md
@@ -92,6 +92,11 @@ To add a new test:
     cd integrationtest
     go run cmd/recordfixtures/main.go
     ```
+    
+    or from the repo root:
+    ```sh
+    make fixtures
+    ```
 
     The generated file is a JSON encoded
     [`MetricExpectFixture`](integrationtest/fixtures.proto#L21) protobuf message.


### PR DESCRIPTION
This adds a simple call to generate the fixtures, which will be handy for development but also be [used in CI](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v1.8.0/.circleci/config.yml#L25) to detect missing fixture updates pre-commit