### PR TITLE
Include the status code we compute in the error message

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -242,7 +242,7 @@ func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) e
 			}
 
 			var st string
-			s, _ := status.FromError(err)
+			s := status.Convert(err)
 			st = statusCodeToString(s)
 
 			succeededPoints := len(ts)
@@ -260,7 +260,7 @@ func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) e
 				recordPointCountDataPoint(ctx, failedPoints, st)
 			}
 			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to export time series to GCM: %v", err))
+				errs = append(errs, fmt.Errorf("failed to export time series to GCM: %+v", s))
 			}
 		}
 	}


### PR DESCRIPTION
If the error returned is not a GRPC error, the status gets set to UNKNOWN and is used in metrics.  But since the original error message wasn't from gRPC, it isn't possible to tell where the UNKNOWN errors are coming from.

This makes the error include the gRPC status even when it isn't a gRPC error to match our self-observability metrics.  That will make it easier to link metrics to the resulting log messages.