### PR TITLE
[breaking] Change default metric prefix for SDK exporter to workload.googleapis.com

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	cloudMonitoringMetricDescriptorNameFormat = "custom.googleapis.com/opentelemetry/%s"
+	cloudMonitoringMetricDescriptorNameFormat = "workload.googleapis.com/%s"
 )
 
 // key is used to judge the uniqueness of the record descriptor.
@@ -238,7 +238,7 @@ func (me *metricExporter) exportTimeSeries(ctx context.Context, rm metricdata.Re
 }
 
 // descToMetricType converts descriptor to MetricType proto type.
-// Basically this returns default value ("custom.googleapis.com/opentelemetry/[metric type]")
+// Basically this returns default value ("workload.googleapis.com/[metric type]")
 func (me *metricExporter) descToMetricType(desc metricdata.Metrics) string {
 	if formatter := me.o.metricDescriptorTypeFormatter; formatter != nil {
 		return formatter(desc)

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -187,7 +187,7 @@ func TestDescToMetricType(t *testing.T) {
 	}
 
 	wants := []string{
-		"custom.googleapis.com/opentelemetry/testing",
+		"workload.googleapis.com/testing",
 		"test.googleapis.com/test/of/path",
 	}
 
@@ -221,7 +221,7 @@ func TestRecordToMpb(t *testing.T) {
 		},
 	}
 
-	inputLibrary := instrumentation.Library{Name: "custom.googleapis.com/opentelemetry"}
+	inputLibrary := instrumentation.Library{Name: "workload.googleapis.com"}
 	inputAttributes := attribute.NewSet(
 		attribute.Key("a").String("A"),
 		attribute.Key("b_b").String("B"),
@@ -576,7 +576,7 @@ func TestRecordToMpbUTF8(t *testing.T) {
 		},
 	}
 
-	inputLibrary := instrumentation.Library{Name: "custom.googleapis.com/opentelemetry"}
+	inputLibrary := instrumentation.Library{Name: "workload.googleapis.com"}
 	inputAttributes := attribute.NewSet(
 		attribute.Key("valid_ascii").String("abcdefg"),
 		attribute.Key("valid_utf8").String("שלום"),

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -39,7 +39,7 @@ type options struct {
 	// If unset, context.Background() will be used.
 	context context.Context
 	// metricDescriptorTypeFormatter is the custom formtter for the MetricDescriptor.Type.
-	// By default, the format string is "custom.googleapis.com/opentelemetry/[metric name]".
+	// By default, the format string is "workload.googleapis.com/[metric name]".
 	metricDescriptorTypeFormatter func(metricdata.Metrics) string
 	// projectID is the identifier of the Cloud Monitoring
 	// project the user is uploading the stats data to.
@@ -77,7 +77,7 @@ func WithMonitoringClientOptions(opts ...apioption.ClientOption) func(o *options
 
 // WithMetricDescriptorTypeFormatter sets the custom formatter for MetricDescriptor.
 // Note that the format has to follow the convention defined in the official document.
-// The default is "custom.googleapis.com/[metric name]".
+// The default is "workload.googleapis.com/[metric name]".
 // ref. https://cloud.google.com/monitoring/custom-metrics/creating-metrics#custom_metric_names
 func WithMetricDescriptorTypeFormatter(f func(metricdata.Metrics) string) func(o *options) {
 	return func(o *options) {


### PR DESCRIPTION
This aligns with the collector exporter.  It is one difference found by integration tests.