### PR TITLE
Add display name to metric descriptors for SDK metric exporter

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -947,7 +947,7 @@ func (m *metricMapper) metricTypeToDisplayName(mURL string) string {
 	// TODO - user configuration around display name?
 	// Default: strip domain, keep path after domain.
 	u, err := url.Parse(fmt.Sprintf("metrics://%s", mURL))
-	if err != nil {
+	if err != nil || u.Path == "" {
 		return mURL
 	}
 	return strings.TrimLeft(u.Path, "/")

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -252,6 +252,7 @@ func TestRecordToMdpb(t *testing.T) {
 
 	want := &googlemetricpb.MetricDescriptor{
 		Name:        metricName,
+		DisplayName: metricName,
 		Type:        fmt.Sprintf(cloudMonitoringMetricDescriptorNameFormat, metricName),
 		MetricKind:  googlemetricpb.MetricDescriptor_GAUGE,
 		ValueType:   googlemetricpb.MetricDescriptor_DOUBLE,
@@ -893,4 +894,33 @@ func TestConcurrentExport(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestMetricTypeToDisplayName(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{desc: "empty input"},
+		{
+			desc:     "default prefix",
+			input:    "workload.googleapis.com/MyCoolMetric",
+			expected: "MyCoolMetric",
+		},
+		{
+			desc:     "no prefix",
+			input:    "helloworld",
+			expected: "helloworld",
+		},
+		{
+			desc:     "other prefix",
+			input:    "custom.googleapis.com/MyCoolMetric",
+			expected: "MyCoolMetric",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, metricTypeToDisplayName(tc.input))
+		})
+	}
 }


### PR DESCRIPTION
this fixes an inconsistency between the SDK exporter and the collector exporter discovered by the integration tests.

It is based on the collector implementation (which it fixes a bug in) for non-prefixed metrics.