### PR TITLE
[breaking] Use the resourcemapping package to map SDK metrics to monitored resources

### DIFF
--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -6,6 +6,8 @@ replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metr
 
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock => ../../internal/cloudmock
 
+replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping => ../../internal/resourcemapping
+
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.33.0
 	go.opentelemetry.io/otel v1.10.0
@@ -16,6 +18,7 @@ require (
 require (
 	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/monitoring v1.4.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.33.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -20,6 +20,7 @@ require (
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.33.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.33.0
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/multierr v1.8.0
 )
@@ -42,5 +43,7 @@ require (
 )
 
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock => ../../internal/cloudmock
+
+replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping => ../../internal/resourcemapping
 
 retract v1.0.0-RC1

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -37,6 +37,8 @@ import (
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"
 )
 
 const (
@@ -79,52 +81,6 @@ func (e *metricExporter) Shutdown(ctx context.Context) error {
 		err = multierr.Combine(ctx.Err(), e.client.Close())
 	})
 	return err
-}
-
-// Below are maps with monitored resources fields as keys
-// and OpenTelemetry resources fields as values
-var k8sContainerMap = map[string]string{
-	"location":       CloudKeyZone,
-	"cluster_name":   K8SKeyClusterName,
-	"namespace_name": K8SKeyNamespaceName,
-	"pod_name":       K8SKeyPodName,
-	"container_name": ContainerKeyName,
-}
-
-var k8sNodeMap = map[string]string{
-	"location":     CloudKeyZone,
-	"cluster_name": K8SKeyClusterName,
-	"node_name":    HostKeyName,
-}
-
-var k8sClusterMap = map[string]string{
-	"location":     CloudKeyZone,
-	"cluster_name": K8SKeyClusterName,
-}
-
-var k8sPodMap = map[string]string{
-	"location":       CloudKeyZone,
-	"cluster_name":   K8SKeyClusterName,
-	"namespace_name": K8SKeyNamespaceName,
-	"pod_name":       K8SKeyPodName,
-}
-
-var gceResourceMap = map[string]string{
-	"instance_id": HostKeyID,
-	"zone":        CloudKeyZone,
-}
-
-var awsResourceMap = map[string]string{
-	"instance_id": HostKeyID,
-	"region":      CloudKeyRegion,
-	"aws_account": CloudKeyAccountID,
-}
-
-var cloudRunResourceMap = map[string]string{
-	"task_id":   ServiceKeyInstanceID,
-	"location":  CloudKeyRegion,
-	"namespace": ServiceKeyNamespace,
-	"job":       ServiceKeyName,
 }
 
 // newMetricExporter returns an exporter that uploads OTel metric data to Google Cloud Monitoring.
@@ -325,38 +281,13 @@ func labelDescriptors(metrics metricdata.Metrics) []*label.LabelDescriptor {
 	return labels
 }
 
-// refer to the monitored resources fields
-// https://cloud.google.com/monitoring/api/resources
-func subdivideGCPTypes(labelMap map[string]string) (string, map[string]string) {
-	_, hasLocation := labelMap[CloudKeyZone]
-	_, hasClusterName := labelMap[K8SKeyClusterName]
-	_, hasNamespaceName := labelMap[K8SKeyNamespaceName]
-	_, hasPodName := labelMap[K8SKeyPodName]
-	_, hasContainerName := labelMap[ContainerKeyName]
+type attributes struct {
+	attrs attribute.Set
+}
 
-	if hasLocation && hasClusterName && hasNamespaceName && hasPodName && hasContainerName {
-		return K8SContainer, k8sContainerMap
-	}
-
-	_, hasNodeName := labelMap[HostKeyName]
-
-	if hasLocation && hasClusterName && hasNodeName {
-		return K8SNode, k8sNodeMap
-	}
-
-	if hasLocation && hasClusterName && hasNamespaceName && hasPodName {
-		return K8SPod, k8sPodMap
-	}
-
-	if hasLocation && hasClusterName {
-		return K8SCluster, k8sClusterMap
-	}
-
-	if labelMap[ServiceKeyNamespace] == "cloud-run-managed" {
-		return GenericTask, cloudRunResourceMap
-	}
-
-	return GCEInstance, gceResourceMap
+func (attrs *attributes) GetString(key string) (string, bool) {
+	value, ok := attrs.attrs.Value(attribute.Key(key))
+	return value.AsString(), ok
 }
 
 // resourceToMonitoredResourcepb converts resource in OTel to MonitoredResource
@@ -364,70 +295,18 @@ func subdivideGCPTypes(labelMap map[string]string) (string, map[string]string) {
 //
 // https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.monitoredResourceDescriptors
 func (me *metricExporter) resourceToMonitoredResourcepb(res *resource.Resource) *monitoredrespb.MonitoredResource {
-
-	monitoredRes := &monitoredrespb.MonitoredResource{
-		Type: "global",
-		Labels: map[string]string{
-			"project_id": sanitizeUTF8(me.o.projectID),
-		},
+	gmr := resourcemapping.ResourceAttributesToMonitoredResource(&attributes{
+		attrs: attribute.NewSet(res.Attributes()...),
+	})
+	newLabels := make(map[string]string, len(gmr.Labels))
+	for k, v := range gmr.Labels {
+		newLabels[k] = sanitizeUTF8(v)
 	}
-
-	// Return "global" Monitored resources if the input resource is null or empty
-	// "global" only accepts "project_id" for label.
-	// https://cloud.google.com/monitoring/api/resources#tag_global
-	if res == nil || res.Len() == 0 {
-		return monitoredRes
+	mr := &monitoredrespb.MonitoredResource{
+		Type:   gmr.Type,
+		Labels: newLabels,
 	}
-
-	resLabelMap := generateResLabelMap(res)
-
-	resTypeStr := "global"
-	match := map[string]string{}
-
-	if resType, found := resLabelMap[CloudKeyProvider]; found {
-		switch resType {
-		case CloudProviderGCP:
-			resTypeStr, match = subdivideGCPTypes(resLabelMap)
-		case CloudProviderAWS:
-			resTypeStr = AWSEC2Instance
-			match = awsResourceMap
-		}
-
-		outputMap, isMissing := transformResource(match, resLabelMap)
-		if isMissing {
-			resTypeStr = "global"
-		} else {
-			monitoredRes.Labels = outputMap
-		}
-	}
-
-	monitoredRes.Type = resTypeStr
-	monitoredRes.Labels["project_id"] = sanitizeUTF8(me.o.projectID)
-
-	return monitoredRes
-}
-
-func generateResLabelMap(res *resource.Resource) map[string]string {
-	resLabelMap := make(map[string]string)
-	for _, label := range res.Attributes() {
-		resLabelMap[string(label.Key)] = sanitizeUTF8(label.Value.Emit())
-	}
-	return resLabelMap
-}
-
-// returns transformed label map and false if all labels in match are found
-// in input except optional project_id. It returns true if at least one label
-// other than project_id is missing.
-func transformResource(match, input map[string]string) (map[string]string, bool) {
-	output := make(map[string]string, len(input))
-	for dst, src := range match {
-		if v, ok := input[src]; ok {
-			output[dst] = v
-		} else {
-			return map[string]string{}, true
-		}
-	}
-	return output, false
+	return mr
 }
 
 // recordToMdpbKindType return the mapping from OTel's record descriptor to

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -296,24 +296,25 @@ func TestRecordToMdpb(t *testing.T) {
 
 func TestResourceToMonitoredResourcepb(t *testing.T) {
 	testCases := []struct {
+		desc           string
 		resource       *resource.Resource
 		expectedLabels map[string]string
 		expectedType   string
 	}{
-		// k8s_container
 		{
+			desc: "k8s_container success",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_kubernetes_engine"),
 				attribute.String("cloud.availability_zone", "us-central1-a"),
 				attribute.String("k8s.cluster.name", "opentelemetry-cluster"),
 				attribute.String("k8s.namespace.name", "default"),
 				attribute.String("k8s.pod.name", "opentelemetry-pod-autoconf"),
-				attribute.String("container.name", "opentelemetry"),
+				attribute.String("k8s.container.name", "opentelemetry"),
 			),
 			expectedType: "k8s_container",
 			expectedLabels: map[string]string{
-				"project_id":     "",
 				"location":       "us-central1-a",
 				"cluster_name":   "opentelemetry-cluster",
 				"namespace_name": "default",
@@ -321,28 +322,29 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 				"container_name": "opentelemetry",
 			},
 		},
-		// k8s_node
 		{
+			desc: "k8s_node success",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_kubernetes_engine"),
 				attribute.String("cloud.availability_zone", "us-central1-a"),
 				attribute.String("k8s.cluster.name", "opentelemetry-cluster"),
-				attribute.String("host.name", "opentelemetry-node"),
+				attribute.String("k8s.node.name", "opentelemetry-node"),
 			),
 			expectedType: "k8s_node",
 			expectedLabels: map[string]string{
-				"project_id":   "",
 				"location":     "us-central1-a",
 				"cluster_name": "opentelemetry-cluster",
 				"node_name":    "opentelemetry-node",
 			},
 		},
-		// k8s_pod
 		{
+			desc: "k8s_pod success",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_kubernetes_engine"),
 				attribute.String("cloud.availability_zone", "us-central1-a"),
 				attribute.String("k8s.cluster.name", "opentelemetry-cluster"),
 				attribute.String("k8s.namespace.name", "default"),
@@ -350,94 +352,84 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 			),
 			expectedType: "k8s_pod",
 			expectedLabels: map[string]string{
-				"project_id":     "",
 				"location":       "us-central1-a",
 				"cluster_name":   "opentelemetry-cluster",
 				"namespace_name": "default",
 				"pod_name":       "opentelemetry-pod-autoconf",
 			},
 		},
-		// k8s_cluster
 		{
+			desc: "k8s_cluster success",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_kubernetes_engine"),
 				attribute.String("cloud.availability_zone", "us-central1-a"),
 				attribute.String("k8s.cluster.name", "opentelemetry-cluster"),
 			),
 			expectedType: "k8s_cluster",
 			expectedLabels: map[string]string{
-				"project_id":   "",
 				"location":     "us-central1-a",
 				"cluster_name": "opentelemetry-cluster",
 			},
 		},
-		// k8s_node missing a field
 		{
-			resource: resource.NewWithAttributes(
-				semconv.SchemaURL,
-				attribute.String("cloud.provider", "gcp"),
-				attribute.String("k8s.cluster.name", "opentelemetry-cluster"),
-				attribute.String("host.name", "opentelemetry-node"),
-			),
-			expectedType: "global",
-			expectedLabels: map[string]string{
-				"project_id": "",
-			},
-		},
-		// nonexisting resource types
-		{
+			desc: "nonexisting resource types",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "none"),
+				attribute.String("cloud.platform", "gcp_foobar"),
 				attribute.String("cloud.availability_zone", "us-central1-a"),
 				attribute.String("k8s.cluster.name", "opentelemetry-cluster"),
 				attribute.String("k8s.namespace.name", "default"),
 				attribute.String("k8s.pod.name", "opentelemetry-pod-autoconf"),
-				attribute.String("container.name", "opentelemetry"),
+				attribute.String("k8s.container.name", "opentelemetry"),
 			),
-			expectedType: "global",
+			expectedType: "generic_node",
 			expectedLabels: map[string]string{
-				"project_id": "",
+				"location":  "us-central1-a",
+				"namespace": "",
+				"node_id":   "",
 			},
 		},
-		// GCE resource fields
 		{
+			desc: "GCE instance",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_compute_engine"),
 				attribute.String("host.id", "123"),
 				attribute.String("cloud.availability_zone", "us-central1-a"),
 			),
 			expectedType: "gce_instance",
 			expectedLabels: map[string]string{
-				"project_id":  "",
 				"instance_id": "123",
 				"zone":        "us-central1-a",
 			},
 		},
-		// AWS resources
 		{
+			desc: "AWS resources",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "aws"),
+				attribute.String("cloud.platform", "aws_ec2"),
 				attribute.String("cloud.region", "us-central1-a"),
 				attribute.String("host.id", "123"),
 				attribute.String("cloud.account.id", "fake_account"),
 			),
 			expectedType: "aws_ec2_instance",
 			expectedLabels: map[string]string{
-				"project_id":  "",
 				"instance_id": "123",
 				"region":      "us-central1-a",
 				"aws_account": "fake_account",
 			},
 		},
-		// Cloud Run
 		{
+			desc: "Cloud Run",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_cloud_run"),
 				attribute.String("cloud.region", "utopia"),
 				attribute.String("service.instance.id", "bar"),
 				attribute.String("service.name", "x-service"),
@@ -445,11 +437,25 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 			),
 			expectedType: "generic_task",
 			expectedLabels: map[string]string{
-				"project_id": "",
-				"location":   "utopia",
-				"namespace":  "cloud-run-managed",
-				"job":        "x-service",
-				"task_id":    "bar",
+				"location":  "utopia",
+				"namespace": "cloud-run-managed",
+				"job":       "x-service",
+				"task_id":   "bar",
+			},
+		},
+		{
+			desc: "GCE instance invalid utf8",
+			resource: resource.NewWithAttributes(
+				semconv.SchemaURL,
+				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_compute_engine"),
+				attribute.String("host.id", invalidUtf8SequenceID),
+				attribute.String("cloud.availability_zone", "us-central1-a"),
+			),
+			expectedType: "gce_instance",
+			expectedLabels: map[string]string{
+				"instance_id": "�",
+				"zone":        "us-central1-a",
 			},
 		},
 	}
@@ -475,7 +481,7 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		t.Run(test.resource.String(), func(t *testing.T) {
+		t.Run(test.desc, func(t *testing.T) {
 			got := me.resourceToMonitoredResourcepb(test.resource)
 			if !reflect.DeepEqual(got.GetLabels(), test.expectedLabels) {
 				t.Errorf("expected: %v, actual: %v", test.expectedLabels, got.GetLabels())
@@ -487,113 +493,10 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 	}
 }
 
-func TestGenerateResLabelMap(t *testing.T) {
-	testCases := []struct {
-		resource       *resource.Resource
-		expectedLabels map[string]string
-	}{
-		// Bool attribute
-		{
-			resource.NewWithAttributes(
-				semconv.SchemaURL,
-				attribute.Bool("key", true),
-			),
-			map[string]string{
-				"key": "true",
-			},
-		},
-		// Int attribute
-		{
-			resource.NewWithAttributes(
-				semconv.SchemaURL,
-				attribute.Int("key", 1),
-			),
-			map[string]string{
-				"key": "1",
-			},
-		},
-		// Int64 attribute
-		{
-			resource.NewWithAttributes(
-				semconv.SchemaURL,
-				attribute.Int64("key", 1),
-			),
-			map[string]string{
-				"key": "1",
-			},
-		},
-		// Float64 attribute
-		{
-			resource.NewWithAttributes(
-				semconv.SchemaURL,
-				attribute.Float64("key", 1.3),
-			),
-			map[string]string{
-				"key": "1.3",
-			},
-		},
-		// String attribute
-		{
-			resource.NewWithAttributes(
-				semconv.SchemaURL,
-				attribute.String("key", "str"),
-			),
-			map[string]string{
-				"key": "str",
-			},
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.resource.String(), func(t *testing.T) {
-			got := generateResLabelMap(test.resource)
-			if !reflect.DeepEqual(got, test.expectedLabels) {
-				t.Errorf("expected: %v, actual: %v", test.expectedLabels, got)
-			}
-		})
-	}
-}
-
 var (
 	invalidUtf8TwoOctet   = string([]byte{0xc3, 0x28}) // Invalid 2-octet sequence
 	invalidUtf8SequenceID = string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
 )
-
-func TestGenerateResLabelMapUTF8(t *testing.T) {
-	monResource := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		attribute.String("valid_ascii", "abcdefg"),
-		attribute.String("valid_utf8", "שלום"),
-		attribute.String("invalid_two_octet", invalidUtf8TwoOctet),
-		attribute.String("invalid_sequence_id", invalidUtf8SequenceID),
-	)
-	expectedLabels := map[string]string{
-		"valid_ascii":         "abcdefg",
-		"valid_utf8":          "שלום",
-		"invalid_two_octet":   "�(",
-		"invalid_sequence_id": "�",
-	}
-
-	got := generateResLabelMap(monResource)
-	if !reflect.DeepEqual(got, expectedLabels) {
-		t.Errorf("expected: %v, actual: %v", expectedLabels, got)
-	}
-}
-
-func TestResourceToMonitoredResourcepbProjectIDUTF8(t *testing.T) {
-	expectedProjectID := "�"
-
-	me := &metricExporter{
-		o: &options{
-			projectID: invalidUtf8SequenceID,
-		},
-	}
-
-	got := me.resourceToMonitoredResourcepb(nil)
-	if got.Labels["project_id"] != expectedProjectID {
-		t.Errorf("expected: %v, actual: %v", expectedProjectID, got.Labels["project_id"])
-	}
-}
 
 func TestRecordToMpbUTF8(t *testing.T) {
 	metricName := "testing"

--- a/internal/resourcemapping/resourcemapping.go
+++ b/internal/resourcemapping/resourcemapping.go
@@ -96,7 +96,12 @@ var (
 		},
 		awsEc2Instance: {
 			instanceID: {otelKeys: []string{string(semconv.HostIDKey)}},
-			region:     {otelKeys: []string{string(semconv.CloudAvailabilityZoneKey)}},
+			region: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+			},
 			awsAccount: {otelKeys: []string{string(semconv.CloudAccountIDKey)}},
 		},
 		genericTask: {


### PR DESCRIPTION
This brings the monitored resource conversion in-line with the collector's conversion, and removes another difference between the exporters.

Breaking changes:

* Relies on `k8s.container.name` instead of `container.name` for k8s_container
* Relies on `k8s.node.name` instead of `host.name` for k8s_node
* Defaults to generic_node instead of global if no resource attributes are set.
* Requires `cloud.platform` to be set to map to GCP monitored resources.