### PR TITLE
Convert non-monotonic sums to gauges in the SDK exporter

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -446,15 +446,23 @@ func transformResource(match, input map[string]string) (map[string]string, bool)
 // recordToMdpbKindType return the mapping from OTel's record descriptor to
 // Cloud Monitoring's MetricKind and ValueType.
 func recordToMdpbKindType(a metricdata.Aggregation) (googlemetricpb.MetricDescriptor_MetricKind, googlemetricpb.MetricDescriptor_ValueType) {
-	switch a.(type) {
+	switch agg := a.(type) {
 	case metricdata.Gauge[int64]:
 		return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_INT64
 	case metricdata.Gauge[float64]:
 		return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_DOUBLE
 	case metricdata.Sum[int64]:
-		return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_INT64
+		if agg.IsMonotonic {
+			return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_INT64
+		} else {
+			return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_INT64
+		}
 	case metricdata.Sum[float64]:
-		return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_DOUBLE
+		if agg.IsMonotonic {
+			return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_DOUBLE
+		} else {
+			return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_DOUBLE
+		}
 	case metricdata.Histogram:
 		return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_DISTRIBUTION
 	default:

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -277,7 +277,8 @@ func TestRecordToMdpb(t *testing.T) {
 	inputMetrics := metricdata.Metrics{
 		Name:        metricName,
 		Description: "test",
-		Data: metricdata.Gauge[float64]{
+		Data: metricdata.Sum[float64]{
+			IsMonotonic: false,
 			DataPoints: []metricdata.DataPoint[float64]{
 				{
 					Attributes: attribute.NewSet(


### PR DESCRIPTION
This fixes a difference found by the integration tests between the collector and sdk metrics exporter.