### PR TITLE
Add service labels to GCM metrics exporter

### DIFF
--- a/exporter/metric/cloudmonitoring.go
+++ b/exporter/metric/cloudmonitoring.go
@@ -29,7 +29,10 @@ import (
 
 // New creates a new Exporter thats implements metric.Exporter.
 func New(opts ...Option) (metric.Exporter, error) {
-	o := options{context: context.Background()}
+	o := options{
+		context:                 context.Background(),
+		resourceAttributeFilter: defaultResourceAttributesFilter,
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -29,7 +29,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"go.uber.org/multierr"
@@ -216,14 +215,7 @@ func (me *metricExporter) exportTimeSeries(ctx context.Context, rm metricdata.Re
 }
 
 func (me *metricExporter) extraLabelsFromResource(res *resource.Resource) *attribute.Set {
-	if me.o.disableServiceLabels {
-		return attribute.EmptySet()
-	}
-	set, _ := attribute.NewSetWithFiltered(res.Attributes(), func(kv attribute.KeyValue) bool {
-		return kv.Key == semconv.ServiceNameKey ||
-			kv.Key == semconv.ServiceNamespaceKey ||
-			kv.Key == semconv.ServiceInstanceIDKey
-	})
+	set, _ := attribute.NewSetWithFiltered(res.Attributes(), me.o.resourceAttributeFilter)
 	return &set
 }
 

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -54,6 +54,12 @@ type options struct {
 	// to the underlying Stackdriver Monitoring API client.
 	// Optional.
 	monitoringClientOptions []apioption.ClientOption
+	// disableServiceLabels, if false, causes the exporter to copy
+	// OTel's service.name, service.namespace, and service.instance.id resource
+	// attributes into the GCM timeseries metric labels. This option is
+	// recommended to avoid writing duplicate timeseries against the same
+	// monitored resource. Default is false (not disabled).
+	disableServiceLabels bool
 }
 
 // WithProjectID sets Google Cloud Platform project as projectID.
@@ -82,5 +88,16 @@ func WithMonitoringClientOptions(opts ...apioption.ClientOption) func(o *options
 func WithMetricDescriptorTypeFormatter(f func(metricdata.Metrics) string) func(o *options) {
 	return func(o *options) {
 		o.metricDescriptorTypeFormatter = f
+	}
+}
+
+// WithServiceLabelsDisabled disables the addition of service labels to GCM
+// timeseries. If this option is not provided, the exporter to copies OTel's
+// service.name, service.namespace, and service.instance.id resource attributes
+// into the GCM timeseries metric labels. This option is recommended to avoid
+// writing duplicate timeseries against the same monitored resource.
+func WithServiceLabelsDisabled() func(o *options) {
+	return func(o *options) {
+		o.disableServiceLabels = true
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/506

### Design

This adds a new Option: `WithFilteredResourceAttributes(filter attribute.Filter)`, which allows users to specify which resource attributes should be added to the metric as metric labels.

It changes the default behavior of the exporter by adding service.name, service.namespace, and service.instance.id as metric labels by default.  This matches the default behavior of the collector exporter.

It also provides a helper function for disabling this functionality entirely: `NoAttributes()`, which can be used with: `WithFilteredResourceAttributes(NoAttributes())`.

### Alternative

Instead of `WithFilteredResourceAttributes(NoAttributes())`, we could just add `WithServiceLabelsDisabled()` (the first commit only).  This would make it simpler to disable the functionality, but with less configurability for users.  Since the collector exporter allows specifying prefixes of resource attributes to promote, allowing a filter seems useful.