### PR TITLE
Dont attempt to create metric descriptors for metrics without an aggregation or data points

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -1081,6 +1081,14 @@ func (m *metricMapper) metricDescriptor(
 		return m.summaryMetricDescriptors(pm, extraLabels)
 	}
 	kind, typ := mapMetricPointKind(pm)
+	if kind == metricpb.MetricDescriptor_METRIC_KIND_UNSPECIFIED {
+		m.obs.log.Debug("Failed to get metric kind (i.e. aggregation) for metric descriptor. Dropping the metric descriptor.", zap.Any("metric", pm))
+		return nil
+	}
+	if typ == metricpb.MetricDescriptor_VALUE_TYPE_UNSPECIFIED {
+		m.obs.log.Debug("Failed to get metric type (int / double) for metric descriptor. Dropping the metric descriptor.", zap.Any("metric", pm))
+		return nil
+	}
 	metricType, err := m.metricNameToType(pm.Name(), pm)
 	if err != nil {
 		m.obs.log.Debug("Failed to get metric type (i.e. name) for metric descriptor. Dropping the metric descriptor.", zap.Error(err), zap.Any("metric", pm))

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -1835,6 +1835,27 @@ func TestMetricDescriptorMapping(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "No data points",
+			metricCreator: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("custom.googleapis.com/test.metric")
+				metric.SetDescription("Description")
+				metric.SetUnit("1")
+				metric.SetEmptyGauge()
+				return metric
+			},
+		},
+		{
+			name: "No aggregation",
+			metricCreator: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("custom.googleapis.com/test.metric")
+				metric.SetDescription("Description")
+				metric.SetUnit("1")
+				return metric
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/529

This adds debug-level logging when that occurs, instead of the error-level logging from the request failing.