### PR TITLE
Allow extra resource attributes to be parsed to LogEntry labels

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -143,8 +143,12 @@ type ResourceFilter struct {
 type LogConfig struct {
 	// DefaultLogName sets the fallback log name to use when one isn't explicitly set
 	// for a log entry. If unset, logs without a log name will raise an error.
-	DefaultLogName string       `mapstructure:"default_log_name"`
-	ClientConfig   ClientConfig `mapstructure:",squash"`
+	DefaultLogName string `mapstructure:"default_log_name"`
+	// ResourceFilters, if provided, provides a list of resource filters.
+	// Resource attributes matching any filter will be included in LogEntry labels.
+	// Defaults to empty, which won't include any additional resource labels.
+	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
+	ClientConfig    ClientConfig     `mapstructure:",squash"`
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.

--- a/exporter/collector/integrationtest/testcases/testcases_logs.go
+++ b/exporter/collector/integrationtest/testcases/testcases_logs.go
@@ -14,6 +14,8 @@
 
 package testcases
 
+import "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+
 var LogsTestCases = []TestCase{
 	{
 		Name:                 "Apache access log with HTTPRequest",
@@ -39,5 +41,15 @@ var LogsTestCases = []TestCase{
 		Name:                 "Logs with trace/span info",
 		OTLPInputFixturePath: "testdata/fixtures/logs/logs_span_trace_id.json",
 		ExpectFixturePath:    "testdata/fixtures/logs/logs_span_trace_id_expected.json",
+	},
+	{
+		Name:                 "Logs with additional resource attributes",
+		OTLPInputFixturePath: "testdata/fixtures/logs/logs_apache_access_resource_attributes.json",
+		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.LogConfig.ResourceFilters = []collector.ResourceFilter{
+				{Prefix: "custom."},
+			}
+		},
 	},
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes.json
@@ -1,0 +1,1678 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "cloud.platform",
+            "value": {
+              "stringValue": "gcp_compute_engine"
+            }
+          },
+          {
+            "key": "custom.foobar",
+            "value": {
+              "stringValue": "baz"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1650984816000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:36 +0800"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984817000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:37 +0800"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/lamp.png"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "51164"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984817000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/favicon.ico"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "3990"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:37 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984831000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:51 +0800"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984832000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:52 +0800"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984833000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:53 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984833000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:53 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984833000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:53 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984833000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:53 +0800"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984834000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "1247"
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:53:54 +0800"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984878000000000",
+              "body": {
+                "stringValue": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "200"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:54:38 +0800"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": "/"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": "HTTP/1.1"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.2"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "GET"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "4429"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "timeUnixNano": "1650984883000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -"
+              },
+              "attributes": [
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "test.log"
+                  }
+                },
+                {
+                  "key": "gcp.http_request",
+                  "value": {
+                    "kvlistValue": {
+                      "values": [
+                        {
+                          "key": "userAgent",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "user",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "time",
+                          "value": {
+                            "stringValue": "26/Apr/2022:22:54:43 +0800"
+                          }
+                        },
+                        {
+                          "key": "responseSize",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "remoteIp",
+                          "value": {
+                            "stringValue": "127.0.0.1"
+                          }
+                        },
+                        {
+                          "key": "requestMethod",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "protocol",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "status",
+                          "value": {
+                            "stringValue": "408"
+                          }
+                        },
+                        {
+                          "key": "host",
+                          "value": {
+                            "stringValue": "-"
+                          }
+                        },
+                        {
+                          "key": "requestUrl",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        },
+                        {
+                          "key": "referer",
+                          "value": {
+                            "stringValue": ""
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -1,0 +1,409 @@
+{
+  "writeLogEntriesRequests": [
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/lamp.png",
+            "status": 200,
+            "responseSize": "51164",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/favicon.ico",
+            "status": 200,
+            "responseSize": "3990",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "custom_foobar": "baz",
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    }
+  ]
+}

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -315,8 +315,7 @@ func TestLogMapping(t *testing.T) {
 			entries, err := mapper.logToSplitEntries(
 				log,
 				mr,
-				"",
-				"",
+				nil,
 				testObservedTime,
 				logName,
 				"fakeprojectid",

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -174,7 +174,7 @@ func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) e
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 		monitoredResource := me.cfg.MetricConfig.MapMonitoredResource(rm.Resource())
-		extraResourceLabels := me.mapper.resourceToMetricLabels(rm.Resource())
+		extraResourceLabels := resourceToLabels(rm.Resource(), me.cfg.MetricConfig.ServiceResourceLabels, me.cfg.MetricConfig.ResourceFilters)
 		projectID := me.cfg.ProjectID
 		// override project ID with gcp.project.id, if present
 		if projectFromResource, found := rm.Resource().Attributes().Get(resourcemapping.ProjectIDAttributeKey); found {

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -53,15 +53,16 @@ func defaultResourceToMonitoredResource(resource pcommon.Resource) *monitoredres
 	return mr
 }
 
-// resourceToMetricLabels converts the Resource into metric labels needed to uniquely identify
-// the timeseries.
-func (m *metricMapper) resourceToMetricLabels(
+// resourceToLabels converts the Resource attributes into labels.
+func resourceToLabels(
 	resource pcommon.Resource,
+	serviceResourceLabels bool,
+	resourceFilters []ResourceFilter,
 ) labels {
 	attrs := pcommon.NewMap()
 	resource.Attributes().Range(func(k string, v pcommon.Value) bool {
 		// Is a service attribute and should be included
-		if m.cfg.MetricConfig.ServiceResourceLabels &&
+		if serviceResourceLabels &&
 			(k == semconv.AttributeServiceName ||
 				k == semconv.AttributeServiceNamespace ||
 				k == semconv.AttributeServiceInstanceID) {
@@ -69,7 +70,7 @@ func (m *metricMapper) resourceToMetricLabels(
 			return true
 		}
 		// Matches one of the resource filters
-		for _, resourceFilter := range m.cfg.MetricConfig.ResourceFilters {
+		for _, resourceFilter := range resourceFilters {
 			if strings.HasPrefix(k, resourceFilter.Prefix) {
 				v.CopyTo(attrs.PutEmpty(k))
 				return true

--- a/exporter/collector/monitoredresource_test.go
+++ b/exporter/collector/monitoredresource_test.go
@@ -468,7 +468,7 @@ func TestResourceToMetricLabels(t *testing.T) {
 			for k, v := range test.resourceLabels {
 				r.Attributes().PutStr(k, v)
 			}
-			extraLabels := mapper.resourceToMetricLabels(r)
+			extraLabels := resourceToLabels(r, mapper.cfg.MetricConfig.ServiceResourceLabels, mapper.cfg.MetricConfig.ResourceFilters)
 			assert.Equal(t, test.expectExtraLabels, extraLabels)
 		})
 	}
@@ -516,6 +516,6 @@ func TestResourceMetricsToMonitoredResourceUTF8(t *testing.T) {
 	}
 	mr := defaultResourceToMonitoredResource(r)
 	assert.Equal(t, expectMr, mr)
-	extraLabels := mapper.resourceToMetricLabels(r)
+	extraLabels := resourceToLabels(r, mapper.cfg.MetricConfig.ServiceResourceLabels, mapper.cfg.MetricConfig.ResourceFilters)
 	assert.Equal(t, expectExtraLabels, extraLabels)
 }


### PR DESCRIPTION
Ref https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16270

This copies functionality from metrics to allow defining a custom attribute prefix, which will parse matching resource attributes to LogEntry labels.