### PR TITLE
Update linters to match upstream settings

### DIFF
--- a/detectors/gcp/app_engine.go
+++ b/detectors/gcp/app_engine.go
@@ -16,7 +16,7 @@ package gcp
 
 const (
 	// See https://cloud.google.com/appengine/docs/flexible/python/migrating#modules
-	// for the environment variables available in GAE environments
+	// for the environment variables available in GAE environments.
 	gaeServiceEnv  = "GAE_SERVICE"
 	gaeVersionEnv  = "GAE_VERSION"
 	gaeInstanceEnv = "GAE_INSTANCE"

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -41,7 +41,7 @@ const (
 	AppEngineFlex
 )
 
-// CloudPlatform returns the platform on which this program is running
+// CloudPlatform returns the platform on which this program is running.
 func (d *Detector) CloudPlatform() Platform {
 	switch {
 	case d.onGKE():
@@ -60,12 +60,12 @@ func (d *Detector) CloudPlatform() Platform {
 	return UnknownPlatform
 }
 
-// ProjectID returns the ID of the project in which this program is running
+// ProjectID returns the ID of the project in which this program is running.
 func (d *Detector) ProjectID() (string, error) {
 	return d.metadata.ProjectID()
 }
 
-// Detector collects resource information for all GCP platforms
+// Detector collects resource information for all GCP platforms.
 type Detector struct {
 	metadata metadataProvider
 	os       osProvider
@@ -82,12 +82,12 @@ type metadataProvider interface {
 	InstanceAttributeValue(string) (string, error)
 }
 
-// osProvider contains the subset of the os package functions used by
+// osProvider contains the subset of the os package functions used by.
 type osProvider interface {
 	LookupEnv(string) (string, bool)
 }
 
-// realOSProvider uses the os package to lookup env vars
+// realOSProvider uses the os package to lookup env vars.
 type realOSProvider struct{}
 
 func (realOSProvider) LookupEnv(env string) (string, bool) {

--- a/detectors/gcp/faas.go
+++ b/detectors/gcp/faas.go
@@ -48,7 +48,7 @@ func (d *Detector) FaaSName() (string, error) {
 	return "", errEnvVarNotFound
 }
 
-// FaaSVersion returns the revision of the cloud run or cloud functions service
+// FaaSVersion returns the revision of the cloud run or cloud functions service.
 func (d *Detector) FaaSVersion() (string, error) {
 	if version, found := d.os.LookupEnv(faasRevisionEnv); found {
 		return version, nil
@@ -56,7 +56,7 @@ func (d *Detector) FaaSVersion() (string, error) {
 	return "", errEnvVarNotFound
 }
 
-// FaaSID returns the instance id of the cloud run instance or cloud function
+// FaaSID returns the instance id of the cloud run instance or cloud function.
 func (d *Detector) FaaSID() (string, error) {
 	return d.metadata.InstanceID()
 }

--- a/detectors/gcp/gce.go
+++ b/detectors/gcp/gce.go
@@ -28,22 +28,22 @@ func (d *Detector) onGCE() bool {
 	return err == nil
 }
 
-// GCEHostType returns the machine type of the instance on which this program is running
+// GCEHostType returns the machine type of the instance on which this program is running.
 func (d *Detector) GCEHostType() (string, error) {
 	return d.metadata.Get(machineTypeMetadataAttr)
 }
 
-// GCEHostID returns the instance ID of the instance on which this program is running
+// GCEHostID returns the instance ID of the instance on which this program is running.
 func (d *Detector) GCEHostID() (string, error) {
 	return d.metadata.InstanceID()
 }
 
-// GCEHostName returns the instance name of the instance on which this program is running
+// GCEHostName returns the instance name of the instance on which this program is running.
 func (d *Detector) GCEHostName() (string, error) {
 	return d.metadata.InstanceName()
 }
 
-// GCEAvailabilityZoneAndRegion returns the zone and region in which this program is running
+// GCEAvailabilityZoneAndRegion returns the zone and region in which this program is running.
 func (d *Detector) GCEAvailabilityZoneAndRegion() (string, string, error) {
 	zone, err := d.metadata.Zone()
 	if err != nil {

--- a/detectors/gcp/gke.go
+++ b/detectors/gcp/gke.go
@@ -35,12 +35,12 @@ func (d *Detector) onGKE() bool {
 	return found
 }
 
-// GKEHostID returns the instance ID of the instance on which this program is running
+// GKEHostID returns the instance ID of the instance on which this program is running.
 func (d *Detector) GKEHostID() (string, error) {
 	return d.GCEHostID()
 }
 
-// GKEClusterName returns the name if the GKE cluster in which this program is running
+// GKEClusterName returns the name if the GKE cluster in which this program is running.
 func (d *Detector) GKEClusterName() (string, error) {
 	return d.metadata.InstanceAttributeValue(clusterNameMetadataAttr)
 }
@@ -53,7 +53,7 @@ const (
 	Region
 )
 
-// GKEAvailabilityZoneOrRegion returns the location of the cluster and whether the cluster is zonal or regional
+// GKEAvailabilityZoneOrRegion returns the location of the cluster and whether the cluster is zonal or regional.
 func (d *Detector) GKEAvailabilityZoneOrRegion() (string, LocationType, error) {
 	clusterLocation, err := d.metadata.InstanceAttributeValue(clusterLocationMetadataAttr)
 	if err != nil {

--- a/e2e-test-server/endtoendserver/constants.go
+++ b/e2e-test-server/endtoendserver/constants.go
@@ -32,16 +32,27 @@ const (
 )
 
 var (
-	subscriptionMode        = mustGetenv("SUBSCRIPTION_MODE")
-	projectID               = mustGetenv("PROJECT_ID")
-	requestSubscriptionName = mustGetenv("REQUEST_SUBSCRIPTION_NAME")
-	responseTopicName       = mustGetenv("RESPONSE_TOPIC_NAME")
+	subscriptionMode        string
+	projectID               string
+	requestSubscriptionName string
+	responseTopicName       string
 )
 
-func mustGetenv(key string) string {
-	v := os.Getenv(key)
-	if v == "" {
-		log.Fatalf("environment variable %q must be set", key)
+func init() {
+	subscriptionMode = os.Getenv("SUBSCRIPTION_MODE")
+	if subscriptionMode == "" {
+		log.Fatalf("environment variable SUBSCRIPTION_MODE must be set")
 	}
-	return v
+	projectID = os.Getenv("PROJECT_ID")
+	if projectID == "" {
+		log.Fatalf("environment variable PROJECT_ID must be set")
+	}
+	requestSubscriptionName = os.Getenv("REQUEST_SUBSCRIPTION_NAME")
+	if requestSubscriptionName == "" {
+		log.Fatalf("environment variable REQUEST_SUBSCRIPTION_NAME must be set")
+	}
+	responseTopicName = os.Getenv("RESPONSE_TOPIC_NAME")
+	if responseTopicName == "" {
+		log.Fatalf("environment variable RESPONSE_TOPIC_NAME must be set")
+	}
 }

--- a/e2e-test-server/endtoendserver/server.go
+++ b/e2e-test-server/endtoendserver/server.go
@@ -105,10 +105,12 @@ func (s *Server) onReceive(ctx context.Context, m *pubsub.Message) {
 
 	if err := shutdownTraceProvider(ctx, tracerProvider); err != nil {
 		log.Printf("could not shutdown tracer-provider: %v", err)
-		s.respond(ctx, testID, &response{
+		if respondErr := s.respond(ctx, testID, &response{
 			statusCode: code.Code_INTERNAL,
 			data:       []byte(fmt.Sprintf("could not shutdown tracer-provider: %v", err)),
-		})
+		}); respondErr != nil {
+			log.Printf("could not publish response: %v", respondErr)
+		}
 		return
 	}
 

--- a/example/trace/http/client/client.go
+++ b/example/trace/http/client/client.go
@@ -36,14 +36,14 @@ import (
 	gcppropagator "github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator"
 )
 
-func initTracer() func() {
+func initTracer() (func(), error) {
 	projectID := os.Getenv("PROJECT_ID")
 
 	// Create Google Cloud Trace exporter to be able to retrieve
 	// the collected spans.
 	exporter, err := texporter.New(texporter.WithProjectID(projectID))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	tp := sdktrace.NewTracerProvider(
 		// For this example code we use sdktrace.AlwaysSample sampler to sample all traces.
@@ -52,7 +52,12 @@ func initTracer() func() {
 		sdktrace.WithBatcher(exporter))
 
 	otel.SetTracerProvider(tp)
-	return func() { tp.Shutdown(context.Background()) }
+	return func() {
+		err := tp.Shutdown(context.Background())
+		if err != nil {
+			fmt.Printf("error shutting down trace provider: %+v", err)
+		}
+	}, nil
 }
 
 func installPropagators() {
@@ -68,7 +73,10 @@ func installPropagators() {
 
 func main() {
 	installPropagators()
-	shutdown := initTracer()
+	shutdown, err := initTracer()
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer shutdown()
 	tr := otel.Tracer("cloudtrace/example/client")
 

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -129,7 +129,7 @@ type MetricConfig struct {
 	EnableSumOfSquaredDeviation bool `mapstructure:"sum_of_squared_deviation"`
 }
 
-// ImpersonateConfig defines configuration for service account impersonation
+// ImpersonateConfig defines configuration for service account impersonation.
 type ImpersonateConfig struct {
 	TargetPrincipal string   `mapstructure:"target_principal"`
 	Subject         string   `mapstructure:"subject"`
@@ -174,7 +174,7 @@ func DefaultConfig() Config {
 	}
 }
 
-// ValidateConfig returns an error if the provided configuration is invalid
+// ValidateConfig returns an error if the provided configuration is invalid.
 func ValidateConfig(cfg Config) error {
 	seenKeys := make(map[string]struct{}, len(cfg.TraceConfig.AttributeMappings))
 	seenReplacements := make(map[string]struct{}, len(cfg.TraceConfig.AttributeMappings))

--- a/exporter/collector/googlemanagedprometheus/monitoredresource.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource.go
@@ -52,7 +52,7 @@ func MapToPrometheusTarget(res pcommon.Resource) *monitoredrespb.MonitoredResour
 	}
 }
 
-// getStringOrEmpty returns the value of the first key found, or the empty string
+// getStringOrEmpty returns the value of the first key found, or the empty string.
 func getStringOrEmpty(attributes pcommon.Map, keys ...string) string {
 	for _, k := range keys {
 		if val, ok := attributes.Get(k); ok {

--- a/exporter/collector/integrationtest/cmd/recordfixtures/main.go
+++ b/exporter/collector/integrationtest/cmd/recordfixtures/main.go
@@ -64,6 +64,7 @@ func recordTraces(ctx context.Context, t *FakeTesting, startTime, endTime time.T
 	if err != nil {
 		panic(err)
 	}
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 
@@ -121,6 +122,7 @@ func recordMetrics(ctx context.Context, t *FakeTesting, startTime, endTime time.
 	if err != nil {
 		panic(err)
 	}
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 
@@ -133,6 +135,7 @@ func recordMetrics(ctx context.Context, t *FakeTesting, startTime, endTime time.
 			testServerExporter := integrationtest.NewMetricTestExporter(ctx, t, testServer, test.CreateCollectorMetricConfig())
 			inMemoryOCExporter, err := integrationtest.NewInMemoryOCViewExporter()
 			require.NoError(t, err)
+			//nolint:errcheck
 			defer inMemoryOCExporter.Shutdown(ctx)
 
 			err = testServerExporter.PushMetrics(ctx, metrics)

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -102,7 +102,7 @@ func newFactory() component.ExporterFactory {
 	)
 }
 
-// testExporterConfig implements exporter.Config so we can test parsing of configuration
+// testExporterConfig implements exporter.Config so we can test parsing of configuration.
 type testExporterConfig struct {
 	config.ExporterSettings `mapstructure:",squash"`
 	collector.Config        `mapstructure:",squash"`

--- a/exporter/collector/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/integrationtest/inmemoryocexporter.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock"
 )
 
-// OC stats/metrics exporter used to capture self observability metrics
+// OC stats/metrics exporter used to capture self observability metrics.
 type InMemoryOCExporter struct {
 	testServer          *cloudmock.MetricsTestServer
 	reader              *metricexport.Reader
@@ -74,7 +74,7 @@ func (i *InMemoryOCExporter) Proto(ctx context.Context) (*protos.SelfObservabili
 		nil
 }
 
-// Shutdown unregisters the global OpenCensus views to reset state for the next test
+// Shutdown unregisters the global OpenCensus views to reset state for the next test.
 func (i *InMemoryOCExporter) Shutdown(ctx context.Context) error {
 	i.stackdriverExporter.StopMetricsExporter()
 	err := i.stackdriverExporter.Close()
@@ -90,12 +90,16 @@ func NewInMemoryOCViewExporter() (*InMemoryOCExporter, error) {
 	// Reset our views in case any tests ran before this
 	views := getViews()
 	view.Unregister(views...)
-	view.Register(views...)
+	err := view.Register(views...)
+	if err != nil {
+		return nil, err
+	}
 
 	testServer, err := cloudmock.NewMetricTestServer()
 	if err != nil {
 		return nil, err
 	}
+	//nolint:errcheck
 	go testServer.Serve()
 	conn, err := grpc.Dial(testServer.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -127,7 +131,6 @@ func NewTraceTestExporter(
 	s *cloudmock.TracesTestServer,
 	cfg collector.Config,
 ) *collector.TraceExporter {
-
 	cfg.TraceConfig.ClientConfig.Endpoint = s.Endpoint
 	cfg.TraceConfig.ClientConfig.UseInsecure = true
 	cfg.ProjectID = "fakeprojectid"
@@ -172,7 +175,6 @@ func NewLogTestExporter(
 	l *cloudmock.LogsTestServer,
 	cfg collector.Config,
 ) *collector.LogsExporter {
-
 	cfg.LogConfig.ClientConfig.Endpoint = l.Endpoint
 	cfg.LogConfig.ClientConfig.UseInsecure = true
 	cfg.ProjectID = "fakeprojectid"

--- a/exporter/collector/integrationtest/logs_test.go
+++ b/exporter/collector/integrationtest/logs_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestLogs(t *testing.T) {
-
 	ctx := context.Background()
 	timestamp := time.Now()
 
@@ -72,5 +71,4 @@ func TestLogs(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/exporter/collector/integrationtest/metrics_test.go
+++ b/exporter/collector/integrationtest/metrics_test.go
@@ -46,12 +46,14 @@ func TestCollectorMetrics(t *testing.T) {
 
 			testServer, err := cloudmock.NewMetricTestServer()
 			require.NoError(t, err)
+			//nolint:errcheck
 			go testServer.Serve()
 			defer testServer.Shutdown()
 			testServerExporter := NewMetricTestExporter(ctx, t, testServer, test.CreateCollectorMetricConfig())
 			// For collecting self observability metrics
 			inMemoryOCExporter, err := NewInMemoryOCViewExporter()
 			require.NoError(t, err)
+			//nolint:errcheck
 			defer inMemoryOCExporter.Shutdown(ctx)
 
 			err = testServerExporter.PushMetrics(ctx, metrics)
@@ -131,6 +133,7 @@ func TestSDKMetrics(t *testing.T) {
 
 			testServer, err := cloudmock.NewMetricTestServer()
 			require.NoError(t, err)
+			//nolint:errcheck
 			go testServer.Serve()
 			defer testServer.Shutdown()
 			opts := append([]metric.Option{

--- a/exporter/collector/integrationtest/testcases/testcase.go
+++ b/exporter/collector/integrationtest/testcases/testcase.go
@@ -79,10 +79,10 @@ func (tc *TestCase) LoadOTLPTracesInput(
 	startTimestamp time.Time,
 	endTimestamp time.Time,
 ) ptrace.Traces {
-	bytes, err := os.ReadFile(tc.OTLPInputFixturePath)
+	fixtureBytes, err := os.ReadFile(tc.OTLPInputFixturePath)
 	require.NoError(t, err)
 	unmarshaler := &ptrace.JSONUnmarshaler{}
-	traces, err := unmarshaler.UnmarshalTraces(bytes)
+	traces, err := unmarshaler.UnmarshalTraces(fixtureBytes)
 	require.NoError(t, err)
 
 	for i := 0; i < traces.ResourceSpans().Len(); i++ {
@@ -108,10 +108,10 @@ func (tc *TestCase) LoadTraceExpectFixture(
 	startTimestamp time.Time,
 	endTimestamp time.Time,
 ) *protos.TraceExpectFixture {
-	bytes, err := os.ReadFile(tc.ExpectFixturePath)
+	fixtureBytes, err := os.ReadFile(tc.ExpectFixturePath)
 	require.NoError(t, err)
 	fixture := &protos.TraceExpectFixture{}
-	require.NoError(t, protojson.Unmarshal(bytes, fixture))
+	require.NoError(t, protojson.Unmarshal(fixtureBytes, fixture))
 
 	for _, request := range fixture.BatchWriteSpansRequest {
 		for _, span := range request.Spans {
@@ -133,7 +133,8 @@ func (tc *TestCase) SaveRecordedTraceFixtures(
 	require.NoError(t, err)
 	formatted := bytes.Buffer{}
 	require.NoError(t, json.Indent(&formatted, jsonBytes, "", "  "))
-	formatted.WriteString("\n")
+	_, err = formatted.WriteString("\n")
+	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(tc.ExpectFixturePath, formatted.Bytes(), 0640))
 	t.Logf("Updated fixture %v", tc.ExpectFixturePath)
 }
@@ -166,10 +167,10 @@ func (tc *TestCase) LoadOTLPLogsInput(
 	t testing.TB,
 	timestamp time.Time,
 ) plog.Logs {
-	bytes, err := os.ReadFile(tc.OTLPInputFixturePath)
+	fixtureBytes, err := os.ReadFile(tc.OTLPInputFixturePath)
 	require.NoError(t, err)
 	unmarshaler := &plog.JSONUnmarshaler{}
-	logs, err := unmarshaler.UnmarshalLogs(bytes)
+	logs, err := unmarshaler.UnmarshalLogs(fixtureBytes)
 	require.NoError(t, err)
 
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
@@ -202,10 +203,10 @@ func (tc *TestCase) LoadLogExpectFixture(
 	t testing.TB,
 	timestamp time.Time,
 ) *protos.LogExpectFixture {
-	bytes, err := os.ReadFile(tc.ExpectFixturePath)
+	fixtureBytes, err := os.ReadFile(tc.ExpectFixturePath)
 	require.NoError(t, err)
 	fixture := &protos.LogExpectFixture{}
-	require.NoError(t, protojson.Unmarshal(bytes, fixture))
+	require.NoError(t, protojson.Unmarshal(fixtureBytes, fixture))
 
 	for _, request := range fixture.WriteLogEntriesRequests {
 		for _, entry := range request.Entries {
@@ -226,13 +227,14 @@ func (tc *TestCase) SaveRecordedLogFixtures(
 	require.NoError(t, err)
 	formatted := bytes.Buffer{}
 	require.NoError(t, json.Indent(&formatted, jsonBytes, "", "  "))
-	formatted.WriteString("\n")
+	_, err = formatted.WriteString("\n")
+	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(tc.ExpectFixturePath, formatted.Bytes(), 0640))
 	t.Logf("Updated fixture %v", tc.ExpectFixturePath)
 }
 
 // Normalizes timestamps which create noise in the fixture because they can
-// vary each test run
+// vary each test run.
 func NormalizeLogFixture(t testing.TB, fixture *protos.LogExpectFixture) {
 	for _, req := range fixture.WriteLogEntriesRequests {
 		for _, entry := range req.Entries {
@@ -251,10 +253,10 @@ func (tc *TestCase) LoadOTLPMetricsInput(
 	startTime time.Time,
 	endTime time.Time,
 ) pmetric.Metrics {
-	bytes, err := os.ReadFile(tc.OTLPInputFixturePath)
+	fixtureBytes, err := os.ReadFile(tc.OTLPInputFixturePath)
 	require.NoError(t, err)
 	unmarshaler := &pmetric.JSONUnmarshaler{}
-	metrics, err := unmarshaler.UnmarshalMetrics(bytes)
+	metrics, err := unmarshaler.UnmarshalMetrics(fixtureBytes)
 	require.NoError(t, err)
 
 	// Interface with common fields that pdata metric points have
@@ -314,10 +316,10 @@ func (tc *TestCase) LoadMetricExpectFixture(
 	startTime time.Time,
 	endTime time.Time,
 ) *protos.MetricExpectFixture {
-	bytes, err := os.ReadFile(tc.ExpectFixturePath)
+	fixtureBytes, err := os.ReadFile(tc.ExpectFixturePath)
 	require.NoError(t, err)
 	fixture := &protos.MetricExpectFixture{}
-	require.NoError(t, protojson.Unmarshal(bytes, fixture))
+	require.NoError(t, protojson.Unmarshal(fixtureBytes, fixture))
 	tc.updateMetricExpectFixture(t, startTime, endTime, fixture)
 
 	return fixture
@@ -344,7 +346,6 @@ func (tc *TestCase) updateMetricExpectFixture(
 				}
 			}
 		}
-
 	}
 }
 
@@ -358,13 +359,14 @@ func (tc *TestCase) SaveRecordedMetricFixtures(
 	require.NoError(t, err)
 	formatted := bytes.Buffer{}
 	require.NoError(t, json.Indent(&formatted, jsonBytes, "", "  "))
-	formatted.WriteString("\n")
+	_, err = formatted.WriteString("\n")
+	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(tc.ExpectFixturePath, formatted.Bytes(), 0640))
 	t.Logf("Updated fixture %v", tc.ExpectFixturePath)
 }
 
 // Normalizes timestamps which create noise in the fixture because they can
-// vary each test run
+// vary each test run.
 func NormalizeMetricFixture(t testing.TB, fixture *protos.MetricExpectFixture) {
 	normalizeTimeSeriesReqs(t, fixture.CreateTimeSeriesRequests...)
 	normalizeTimeSeriesReqs(t, fixture.CreateServiceTimeSeriesRequests...)

--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -59,7 +59,7 @@ type usedExponentialHistogramPoint struct {
 	used  *atomic.Bool
 }
 
-// NewCache instantiates a cache and starts background processes
+// NewCache instantiates a cache and starts background processes.
 func NewCache(shutdown <-chan struct{}) *Cache {
 	c := &Cache{
 		numberCache:               make(map[string]usedNumberPoint),
@@ -76,7 +76,7 @@ func NewCache(shutdown <-chan struct{}) *Cache {
 }
 
 // GetNumberDataPoint retrieves the point associated with the identifier, and whether
-// or not it was found
+// or not it was found.
 func (c *Cache) GetNumberDataPoint(identifier string) (pmetric.NumberDataPoint, bool) {
 	c.numberLock.RLock()
 	defer c.numberLock.RUnlock()
@@ -87,7 +87,7 @@ func (c *Cache) GetNumberDataPoint(identifier string) (pmetric.NumberDataPoint, 
 	return point.point, found
 }
 
-// SetNumberDataPoint assigns the point to the identifier in the cache
+// SetNumberDataPoint assigns the point to the identifier in the cache.
 func (c *Cache) SetNumberDataPoint(identifier string, point pmetric.NumberDataPoint) {
 	c.numberLock.Lock()
 	defer c.numberLock.Unlock()
@@ -95,7 +95,7 @@ func (c *Cache) SetNumberDataPoint(identifier string, point pmetric.NumberDataPo
 }
 
 // GetSummaryDataPoint retrieves the point associated with the identifier, and whether
-// or not it was found
+// or not it was found.
 func (c *Cache) GetSummaryDataPoint(identifier string) (pmetric.SummaryDataPoint, bool) {
 	c.summaryLock.RLock()
 	defer c.summaryLock.RUnlock()
@@ -106,7 +106,7 @@ func (c *Cache) GetSummaryDataPoint(identifier string) (pmetric.SummaryDataPoint
 	return point.point, found
 }
 
-// SetSummaryDataPoint assigns the point to the identifier in the cache
+// SetSummaryDataPoint assigns the point to the identifier in the cache.
 func (c *Cache) SetSummaryDataPoint(identifier string, point pmetric.SummaryDataPoint) {
 	c.summaryLock.Lock()
 	defer c.summaryLock.Unlock()
@@ -114,7 +114,7 @@ func (c *Cache) SetSummaryDataPoint(identifier string, point pmetric.SummaryData
 }
 
 // GetHistogramDataPoint retrieves the point associated with the identifier, and whether
-// or not it was found
+// or not it was found.
 func (c *Cache) GetHistogramDataPoint(identifier string) (pmetric.HistogramDataPoint, bool) {
 	c.histogramLock.RLock()
 	defer c.histogramLock.RUnlock()
@@ -125,7 +125,7 @@ func (c *Cache) GetHistogramDataPoint(identifier string) (pmetric.HistogramDataP
 	return point.point, found
 }
 
-// SetHistogramDataPoint assigns the point to the identifier in the cache
+// SetHistogramDataPoint assigns the point to the identifier in the cache.
 func (c *Cache) SetHistogramDataPoint(identifier string, point pmetric.HistogramDataPoint) {
 	c.histogramLock.Lock()
 	defer c.histogramLock.Unlock()
@@ -133,7 +133,7 @@ func (c *Cache) SetHistogramDataPoint(identifier string, point pmetric.Histogram
 }
 
 // GetExponentialHistogramDataPoint retrieves the point associated with the identifier, and whether
-// or not it was found
+// or not it was found.
 func (c *Cache) GetExponentialHistogramDataPoint(identifier string) (pmetric.ExponentialHistogramDataPoint, bool) {
 	c.exponentialHistogramLock.RLock()
 	defer c.exponentialHistogramLock.RUnlock()
@@ -144,14 +144,14 @@ func (c *Cache) GetExponentialHistogramDataPoint(identifier string) (pmetric.Exp
 	return point.point, found
 }
 
-// SetExponentialHistogramDataPoint assigns the point to the identifier in the cache
+// SetExponentialHistogramDataPoint assigns the point to the identifier in the cache.
 func (c *Cache) SetExponentialHistogramDataPoint(identifier string, point pmetric.ExponentialHistogramDataPoint) {
 	c.exponentialHistogramLock.Lock()
 	defer c.exponentialHistogramLock.Unlock()
 	c.exponentialHistogramCache[identifier] = usedExponentialHistogramPoint{point, atomic.NewBool(true)}
 }
 
-// gc garbage collects the cache after the ticker ticks
+// gc garbage collects the cache after the ticker ticks.
 func (c *Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
 	select {
 	case <-shutdown:
@@ -209,7 +209,7 @@ func (c *Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
 	return true
 }
 
-// Identifier returns the unique string identifier for a metric
+// Identifier returns the unique string identifier for a metric.
 func Identifier(resource *monitoredrespb.MonitoredResource, extraLabels map[string]string, metric pmetric.Metric, attributes pcommon.Map) string {
 	var b strings.Builder
 

--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -69,6 +69,7 @@ func NewCache(shutdown <-chan struct{}) *Cache {
 	}
 	go func() {
 		ticker := time.NewTicker(gcInterval)
+		//nolint:revive
 		for c.gc(shutdown, ticker.C) {
 		}
 	}()

--- a/exporter/collector/internal/normalization/standard_normalizer.go
+++ b/exporter/collector/internal/normalization/standard_normalizer.go
@@ -114,12 +114,12 @@ func (s *standardNormalizer) NormalizeExponentialHistogramDataPoint(point pmetri
 	return newPoint, true
 }
 
-// lessThanExponentialHistogramDataPoint returns a < b
+// lessThanExponentialHistogramDataPoint returns a < b.
 func lessThanExponentialHistogramDataPoint(a, b pmetric.ExponentialHistogramDataPoint) bool {
 	return a.Count() < b.Count() || a.Sum() < b.Sum()
 }
 
-// subtractExponentialHistogramDataPoint returns a - b
+// subtractExponentialHistogramDataPoint returns a - b.
 func subtractExponentialHistogramDataPoint(a, b pmetric.ExponentialHistogramDataPoint) pmetric.ExponentialHistogramDataPoint {
 	// Make a copy so we don't mutate underlying data
 	newPoint := pmetric.NewExponentialHistogramDataPoint()
@@ -136,7 +136,7 @@ func subtractExponentialHistogramDataPoint(a, b pmetric.ExponentialHistogramData
 	return newPoint
 }
 
-// subtractExponentialBuckets returns a - b
+// subtractExponentialBuckets returns a - b.
 func subtractExponentialBuckets(a, b pmetric.ExponentialHistogramDataPointBuckets) []uint64 {
 	newBuckets := make([]uint64, a.BucketCounts().Len())
 	offsetDiff := int(a.Offset() - b.Offset())
@@ -218,12 +218,12 @@ func (s *standardNormalizer) NormalizeHistogramDataPoint(point pmetric.Histogram
 	return newPoint, true
 }
 
-// lessThanHistogramDataPoint returns a < b
+// lessThanHistogramDataPoint returns a < b.
 func lessThanHistogramDataPoint(a, b pmetric.HistogramDataPoint) bool {
 	return a.Count() < b.Count() || a.Sum() < b.Sum()
 }
 
-// subtractHistogramDataPoint returns a - b
+// subtractHistogramDataPoint returns a - b.
 func subtractHistogramDataPoint(a, b pmetric.HistogramDataPoint) pmetric.HistogramDataPoint {
 	// Make a copy so we don't mutate underlying data
 	newPoint := pmetric.NewHistogramDataPoint()
@@ -313,7 +313,7 @@ func (s *standardNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPo
 	return newPoint, true
 }
 
-// lessThanNumberDataPoint returns a < b
+// lessThanNumberDataPoint returns a < b.
 func lessThanNumberDataPoint(a, b pmetric.NumberDataPoint) bool {
 	switch a.ValueType() {
 	case pmetric.NumberDataPointValueTypeInt:
@@ -324,7 +324,7 @@ func lessThanNumberDataPoint(a, b pmetric.NumberDataPoint) bool {
 	return false
 }
 
-// subtractNumberDataPoint returns a - b
+// subtractNumberDataPoint returns a - b.
 func subtractNumberDataPoint(a, b pmetric.NumberDataPoint) pmetric.NumberDataPoint {
 	// Make a copy so we don't mutate underlying data
 	newPoint := pmetric.NewNumberDataPoint()
@@ -396,12 +396,12 @@ func (s *standardNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryData
 	return newPoint, true
 }
 
-// lessThanSummaryDataPoint returns a < b
+// lessThanSummaryDataPoint returns a < b.
 func lessThanSummaryDataPoint(a, b pmetric.SummaryDataPoint) bool {
 	return a.Count() < b.Count() || a.Sum() < b.Sum()
 }
 
-// subtractSummaryDataPoint returns a - b
+// subtractSummaryDataPoint returns a - b.
 func subtractSummaryDataPoint(a, b pmetric.SummaryDataPoint) pmetric.SummaryDataPoint {
 	// Make a copy so we don't mutate underlying data.
 	newPoint := pmetric.NewSummaryDataPoint()

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -50,7 +50,7 @@ const (
 )
 
 // severityMapping maps the integer severity level values from OTel [0-24]
-// to matching Cloud Logging severity levels
+// to matching Cloud Logging severity levels.
 var severityMapping = []logging.Severity{
 	logging.Default,   // Default, 0
 	logging.Debug,     //

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -208,7 +208,7 @@ func (l *LogsExporter) PushLogs(ctx context.Context, ld plog.Logs) error {
 
 func (l logMapper) createEntries(ld plog.Logs) ([]*logpb.LogEntry, error) {
 	errors := []error{}
-	entries := make([]*logpb.LogEntry, 0, 0)
+	entries := make([]*logpb.LogEntry, 0)
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
 		mr := defaultResourceToMonitoredResource(rl.Resource())
@@ -283,7 +283,6 @@ func (l logMapper) logEntryToInternal(
 	splits int,
 	splitIndex int,
 ) (*logpb.LogEntry, error) {
-
 	internalLogEntry, err := logging.ToLogEntry(entry, fmt.Sprintf("projects/%s", projectID))
 	if err != nil {
 		return nil, err
@@ -386,7 +385,7 @@ func (l logMapper) logToSplitEntries(
 	}
 
 	if log.SeverityNumber() < 0 || int(log.SeverityNumber()) > len(severityMapping)-1 {
-		return []logging.Entry{entry}, fmt.Errorf("Unknown SeverityNumber %v", log.SeverityNumber())
+		return []logging.Entry{entry}, fmt.Errorf("unknown SeverityNumber %v", log.SeverityNumber())
 	}
 	severityNumber := log.SeverityNumber()
 	// Log severity levels are based on numerical values defined by Otel/GCP, which are informally mapped to generic text values such as "ALERT", "Debug", etc.

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -120,14 +120,11 @@ func NewGoogleCloudMetricsExporter(
 	version string,
 	timeout time.Duration,
 ) (*MetricsExporter, error) {
-	err := view.Register(MetricViews()...)
-	if err != nil {
-		return nil, err
-	}
-	err = view.Register(ocgrpc.DefaultClientViews...)
-	if err != nil {
-		return nil, err
-	}
+	// TODO: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/537#discussion_r1038290097
+	//nolint:errcheck
+	view.Register(MetricViews()...)
+	//nolint:errcheck
+	view.Register(ocgrpc.DefaultClientViews...)
 	setVersionInUserAgent(&cfg, version)
 
 	clientOpts, err := generateClientOptions(ctx, &cfg.MetricConfig.ClientConfig, &cfg, monitoring.DefaultAuthScopes())

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -57,7 +57,7 @@ type selfObservability struct {
 	log *zap.Logger
 }
 
-// MetricsExporter is the GCM exporter that uses pdata directly
+// MetricsExporter is the GCM exporter that uses pdata directly.
 type MetricsExporter struct {
 	mapper metricMapper
 	// A channel that receives metric descriptor and sends them to GCM once
@@ -165,7 +165,7 @@ func NewGoogleCloudMetricsExporter(
 	return mExp, nil
 }
 
-// PushMetrics calls pushes pdata metrics to GCM, creating metric descriptors if necessary
+// PushMetrics calls pushes pdata metrics to GCM, creating metric descriptors if necessary.
 func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) error {
 	// map from project -> []timeseries. This groups timeseries by the project
 	// they need to be sent to. Each project's timeseries are sent in a
@@ -865,7 +865,7 @@ func (m *metricMapper) getMetricNamePrefix(name string) string {
 	return m.cfg.MetricConfig.Prefix
 }
 
-// metricNameToType maps OTLP metric name to GCM metric type (aka name)
+// metricNameToType maps OTLP metric name to GCM metric type (aka name).
 func (m *metricMapper) metricNameToType(name string, metric pmetric.Metric) (string, error) {
 	metricName, err := m.cfg.MetricConfig.GetMetricName(name, metric)
 	if err != nil {
@@ -874,7 +874,7 @@ func (m *metricMapper) metricNameToType(name string, metric pmetric.Metric) (str
 	return path.Join(m.getMetricNamePrefix(name), metricName), nil
 }
 
-// defaultGetMetricName does not (further) customize the baseName
+// defaultGetMetricName does not (further) customize the baseName.
 func defaultGetMetricName(baseName string, _ pmetric.Metric) (string, error) {
 	return baseName, nil
 }
@@ -921,7 +921,7 @@ func sanitizeKey(s string) string {
 	return s
 }
 
-// converts anything that is not a letter or digit to an underscore
+// converts anything that is not a letter or digit to an underscore.
 func sanitizeRune(r rune) rune {
 	if unicode.IsLetter(r) || unicode.IsDigit(r) {
 		return r

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -1406,6 +1406,7 @@ func TestMetricNameToType(t *testing.T) {
 
 func TestAttributesToLabels(t *testing.T) {
 	attr := pcommon.NewMap()
+	//nolint:errcheck
 	attr.FromRaw(map[string]interface{}{
 		"foo": "bar",
 		"bar": "baz",
@@ -1418,6 +1419,7 @@ func TestAttributesToLabels(t *testing.T) {
 	)
 
 	// various key special cases
+	//nolint:errcheck
 	attr.FromRaw(map[string]interface{}{
 		"foo.bar":   "bar",
 		"_foo":      "bar",
@@ -1436,6 +1438,7 @@ func TestAttributesToLabels(t *testing.T) {
 	)
 
 	// value special cases
+	//nolint:errcheck
 	attr.FromRaw(map[string]interface{}{
 		"a": true,
 		"b": false,
@@ -1981,6 +1984,7 @@ var (
 
 func TestAttributesToLabelsUTF8(t *testing.T) {
 	attributes := pcommon.NewMap()
+	//nolint:errcheck
 	attributes.FromRaw(map[string]interface{}{
 		"valid_ascii":         "abcdefg",
 		"valid_utf8":          "שלום",

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -57,6 +57,8 @@ func defaultResourceToMonitoredResource(resource pcommon.Resource) *monitoredres
 }
 
 // resourceToLabels converts the Resource attributes into labels.
+//nolint:revive
+// TODO(@damemi): Refactor to pass control-coupling lint check.
 func resourceToLabels(
 	resource pcommon.Resource,
 	serviceResourceLabels bool,

--- a/exporter/collector/observability.go
+++ b/exporter/collector/observability.go
@@ -48,8 +48,8 @@ func recordExemplarFailure(ctx context.Context, point int) {
 	stats.Record(ctx, exemplarAttachmentDropCount.M(int64(point)))
 }
 
-func recordPointCountDataPoint(ctx context.Context, points int, status string) {
-	ctx, err := tag.New(ctx, tag.Insert(statusKey, status))
+func recordPointCountDataPoint(ctx context.Context, points int, statusValue string) {
+	ctx, err := tag.New(ctx, tag.Insert(statusKey, statusValue))
 	if err != nil {
 		return
 	}

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -41,10 +41,9 @@ func (te *TraceExporter) Shutdown(ctx context.Context) error {
 }
 
 func NewGoogleCloudTracesExporter(ctx context.Context, cfg Config, version string, timeout time.Duration) (*TraceExporter, error) {
-	err := view.Register(ocgrpc.DefaultClientViews...)
-	if err != nil {
-		return nil, err
-	}
+	// TODO: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/537#discussion_r1038290097
+	//nolint:errcheck
+	view.Register(ocgrpc.DefaultClientViews...)
 	setVersionInUserAgent(&cfg, version)
 
 	topts := []cloudtrace.Option{

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -41,7 +41,10 @@ func (te *TraceExporter) Shutdown(ctx context.Context) error {
 }
 
 func NewGoogleCloudTracesExporter(ctx context.Context, cfg Config, version string, timeout time.Duration) (*TraceExporter, error) {
-	view.Register(ocgrpc.DefaultClientViews...)
+	err := view.Register(ocgrpc.DefaultClientViews...)
+	if err != nil {
+		return nil, err
+	}
 	setVersionInUserAgent(&cfg, version)
 
 	topts := []cloudtrace.Option{

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -31,7 +31,7 @@ import (
 	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 )
 
-// TraceExporter is a wrapper struct of OT cloud trace exporter
+// TraceExporter is a wrapper struct of OT cloud trace exporter.
 type TraceExporter struct {
 	texporter *cloudtrace.Exporter
 }
@@ -82,7 +82,7 @@ func mappingFuncFromAKM(akm []AttributeMapping) func(attribute.Key) attribute.Ke
 	}
 }
 
-// PushTraces calls texporter.ExportSpan for each span in the given traces
+// PushTraces calls texporter.ExportSpan for each span in the given traces.
 func (te *TraceExporter) PushTraces(ctx context.Context, td ptrace.Traces) error {
 	resourceSpans := td.ResourceSpans()
 	spans := make([]sdktrace.ReadOnlySpan, 0, td.SpanCount())

--- a/exporter/collector/traces_test.go
+++ b/exporter/collector/traces_test.go
@@ -93,6 +93,7 @@ func TestGoogleCloudTraceExport(t *testing.T) {
 			require.NoError(t, err)
 			defer lis.Close()
 
+			//nolint:errcheck
 			go srv.Serve(lis)
 			sde, err := NewGoogleCloudTracesExporter(ctx, test.cfg, "latest", DefaultTimeout)
 			if test.expectedErr != "" {

--- a/exporter/metric/constants.go
+++ b/exporter/metric/constants.go
@@ -23,75 +23,75 @@ package metric
 // set to any meaningful value within the environment. For example,
 // GKE clusters have a name which can be used for this label.
 const (
-	// Deprecated: use semconv.CloudProviderKey instead
+	// Deprecated: use semconv.CloudProviderKey instead.
 	CloudKeyProvider = "cloud.provider"
-	// Deprecated: use semconv.CloudAccountIDKey instead
+	// Deprecated: use semconv.CloudAccountIDKey instead.
 	CloudKeyAccountID = "cloud.account.id"
-	// Deprecated: use semconv.CloudRegionKey instead
+	// Deprecated: use semconv.CloudRegionKey instead.
 	CloudKeyRegion = "cloud.region"
-	// Deprecated: use semconv.CloudAvailabilityZoneKey instead
+	// Deprecated: use semconv.CloudAvailabilityZoneKey instead.
 	CloudKeyZone = "cloud.availability_zone"
 
-	// Deprecated: use semconv.ServiceNamespaceKey instead
+	// Deprecated: use semconv.ServiceNamespaceKey instead.
 	ServiceKeyNamespace = "service.namespace"
-	// Deprecated: use semconv.ServiceInstanceIDKey instead
+	// Deprecated: use semconv.ServiceInstanceIDKey instead.
 	ServiceKeyInstanceID = "service.instance.id"
-	// Deprecated: use semconv.ServiceNameKey instead
+	// Deprecated: use semconv.ServiceNameKey instead.
 	ServiceKeyName = "service.name"
 
 	// Deprecated: HostType is not needed.
 	HostType = "host"
 	// A uniquely identifying name for the host.
-	// Deprecated: use semconv.HostNameKey instead
+	// Deprecated: use semconv.HostNameKey instead.
 	HostKeyName = "host.name"
 	// A hostname as returned by the 'hostname' command on host machine.
 	// Deprecated: HostKeyHostName is not needed.
 	HostKeyHostName = "host.hostname"
-	// Deprecated: use semconv.HostIDKey instead
+	// Deprecated: use semconv.HostIDKey instead.
 	HostKeyID = "host.id"
-	// Deprecated: use semconv.HostTypeKey instead
+	// Deprecated: use semconv.HostTypeKey instead.
 	HostKeyType = "host.type"
 
 	// A uniquely identifying name for the Container.
-	// Deprecated: use semconv.ContainerNameKey instead
+	// Deprecated: use semconv.ContainerNameKey instead.
 	ContainerKeyName = "container.name"
-	// Deprecated: use semconv.ContainerImageNameKey instead
+	// Deprecated: use semconv.ContainerImageNameKey instead.
 	ContainerKeyImageName = "container.image.name"
-	// Deprecated: use semconv.ContainerImageTagKey instead
+	// Deprecated: use semconv.ContainerImageTagKey instead.
 	ContainerKeyImageTag = "container.image.tag"
 
 	// Cloud Providers
-	// Deprecated: use semconv.CloudProviderAWS instead
+	// Deprecated: use semconv.CloudProviderAWS instead.
 	CloudProviderAWS = "aws"
-	// Deprecated: use semconv.CloudProviderGCP instead
+	// Deprecated: use semconv.CloudProviderGCP instead.
 	CloudProviderGCP = "gcp"
-	// Deprecated: use semconv.CloudProviderAzure instead
+	// Deprecated: use semconv.CloudProviderAzure instead.
 	CloudProviderAZURE = "azure"
 
-	// Deprecated: Use "k8s" instead. This should not be needed
+	// Deprecated: Use "k8s" instead. This should not be needed.
 	K8S = "k8s"
-	// Deprecated: use semconv.K8SClusterNameKey instead
+	// Deprecated: use semconv.K8SClusterNameKey instead.
 	K8SKeyClusterName = "k8s.cluster.name"
-	// Deprecated: use semconv.K8SNamespaceNameKey instead
+	// Deprecated: use semconv.K8SNamespaceNameKey instead.
 	K8SKeyNamespaceName = "k8s.namespace.name"
-	// Deprecated: use semconv.K8SPodNameKey instead
+	// Deprecated: use semconv.K8SPodNameKey instead.
 	K8SKeyPodName = "k8s.pod.name"
-	// Deprecated: use semconv.K8SDeploymentNameKey instead
+	// Deprecated: use semconv.K8SDeploymentNameKey instead.
 	K8SKeyDeploymentName = "k8s.deployment.name"
 
 	// Monitored Resources types
-	// Deprecated: Use "k8s_container" instead
+	// Deprecated: Use "k8s_container" instead.
 	K8SContainer = "k8s_container"
-	// Deprecated: Use "k8s_node" instead
+	// Deprecated: Use "k8s_node" instead.
 	K8SNode = "k8s_node"
-	// Deprecated: Use "k8s_pod" instead
+	// Deprecated: Use "k8s_pod" instead.
 	K8SPod = "k8s_pod"
-	// Deprecated: Use "k8s_cluster" instead
+	// Deprecated: Use "k8s_cluster" instead.
 	K8SCluster = "k8s_cluster"
-	// Deprecated: Use "gce_instance" instead
+	// Deprecated: Use "gce_instance" instead.
 	GCEInstance = "gce_instance"
-	// Deprecated: Use "aws_ec2_instance" instead
+	// Deprecated: Use "aws_ec2_instance" instead.
 	AWSEC2Instance = "aws_ec2_instance"
-	// Deprecated: Use "generic_task" instead
+	// Deprecated: Use "generic_task" instead.
 	GenericTask = "generic_task"
 )

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -75,7 +75,7 @@ type metricExporter struct {
 // ForceFlush does nothing, the exporter holds no state.
 func (e *metricExporter) ForceFlush(ctx context.Context) error { return ctx.Err() }
 
-// Shutdown shuts down the client connections
+// Shutdown shuts down the client connections.
 func (e *metricExporter) Shutdown(ctx context.Context) error {
 	err := errShutdown
 	e.shutdownOnce.Do(func() {
@@ -224,7 +224,7 @@ func (me *metricExporter) extraLabelsFromResource(res *resource.Resource) *attri
 }
 
 // descToMetricType converts descriptor to MetricType proto type.
-// Basically this returns default value ("workload.googleapis.com/[metric type]")
+// Basically this returns default value ("workload.googleapis.com/[metric type]").
 func (me *metricExporter) descToMetricType(desc metricdata.Metrics) string {
 	if formatter := me.o.metricDescriptorTypeFormatter; formatter != nil {
 		return formatter(desc)
@@ -345,15 +345,13 @@ func recordToMdpbKindType(a metricdata.Aggregation) (googlemetricpb.MetricDescri
 	case metricdata.Sum[int64]:
 		if agg.IsMonotonic {
 			return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_INT64
-		} else {
-			return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_INT64
 		}
+		return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_INT64
 	case metricdata.Sum[float64]:
 		if agg.IsMonotonic {
 			return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_DOUBLE
-		} else {
-			return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_DOUBLE
 		}
+		return googlemetricpb.MetricDescriptor_GAUGE, googlemetricpb.MetricDescriptor_DOUBLE
 	case metricdata.Histogram:
 		return googlemetricpb.MetricDescriptor_CUMULATIVE, googlemetricpb.MetricDescriptor_DISTRIBUTION
 	default:
@@ -617,7 +615,7 @@ func normalizeLabelKey(s string) string {
 	return s
 }
 
-// converts anything that is not a letter or digit to an underscore
+// converts anything that is not a letter or digit to an underscore.
 func sanitizeRune(r rune) rune {
 	if unicode.IsLetter(r) || unicode.IsDigit(r) {
 		return r

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -53,6 +53,7 @@ var (
 func TestExportMetrics(t *testing.T) {
 	ctx := context.Background()
 	testServer, err := cloudmock.NewMetricTestServer()
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 	assert.NoError(t, err)
@@ -89,6 +90,7 @@ func TestExportMetrics(t *testing.T) {
 
 func TestExportCounter(t *testing.T) {
 	testServer, err := cloudmock.NewMetricTestServer()
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 	assert.NoError(t, err)
@@ -115,6 +117,7 @@ func TestExportCounter(t *testing.T) {
 	)
 
 	ctx := context.Background()
+	//nolint:errcheck
 	defer provider.Shutdown(ctx)
 
 	// Start meter
@@ -129,6 +132,7 @@ func TestExportCounter(t *testing.T) {
 
 func TestExportHistogram(t *testing.T) {
 	testServer, err := cloudmock.NewMetricTestServer()
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 	assert.NoError(t, err)
@@ -157,6 +161,7 @@ func TestExportHistogram(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
+	//nolint:errcheck
 	defer provider.Shutdown(ctx)
 
 	// Start meter
@@ -332,7 +337,6 @@ func TestExtraLabelsFromResource(t *testing.T) {
 			if !tc.expected.Equals(actual) {
 				t.Errorf("expected: %v, actual: %v", tc.expected, actual)
 			}
-
 		})
 	}
 }
@@ -743,6 +747,7 @@ func TestExportWithDisableCreateMetricDescriptors(t *testing.T) {
 
 			lis, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
+			//nolint:errcheck
 			go server.Serve(lis)
 
 			clientOpts := []option.ClientOption{
@@ -832,6 +837,7 @@ func TestExportMetricsWithUserAgent(t *testing.T) {
 
 			lis, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
+			//nolint:errcheck
 			go server.Serve(lis)
 
 			clientOpts := []option.ClientOption{
@@ -865,7 +871,6 @@ func TestExportMetricsWithUserAgent(t *testing.T) {
 
 			counter.Add(ctx, 1)
 			require.NoError(t, provider.ForceFlush(ctx))
-
 			// User agent checking happens above in parallel to this flow.
 		})
 	}
@@ -873,6 +878,7 @@ func TestExportMetricsWithUserAgent(t *testing.T) {
 
 func TestConcurrentCallsAfterShutdown(t *testing.T) {
 	testServer, err := cloudmock.NewMetricTestServer()
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 	assert.NoError(t, err)
@@ -918,6 +924,7 @@ func TestConcurrentCallsAfterShutdown(t *testing.T) {
 
 func TestConcurrentExport(t *testing.T) {
 	testServer, err := cloudmock.NewMetricTestServer()
+	//nolint:errcheck
 	go testServer.Serve()
 	defer testServer.Shutdown()
 	assert.NoError(t, err)

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -77,7 +77,7 @@ func WithProjectID(id string) func(o *options) {
 }
 
 // WithMonitoringClientOptions add the options for Cloud Monitoring client instance.
-// Available options are defined in
+// Available options are defined in.
 func WithMonitoringClientOptions(opts ...apioption.ClientOption) func(o *options) {
 	return func(o *options) {
 		o.monitoringClientOptions = append(o.monitoringClientOptions, opts...)

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -90,7 +90,6 @@ func (e *traceExporter) Shutdown(ctx context.Context) error {
 
 // uploadSpans sends a set of spans to Stackdriver.
 func (e *traceExporter) uploadSpans(ctx context.Context, req *tracepb.BatchWriteSpansRequest) error {
-
 	var cancel func()
 	ctx, cancel = newContextWithTimeout(ctx, e.o.timeout)
 	defer cancel()

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -41,7 +41,7 @@ import (
 const (
 	maxAnnotationEventsPerSpan = 32
 	// TODO(ymotongpoo): uncomment this after gRPC trace get supported.
-	// maxMessageEventsPerSpan    = 128
+	// maxMessageEventsPerSpan    = 128.
 	maxAttributeStringValue = 256
 	maxNumLinks             = 128
 	agentLabel              = "g.co/agent"
@@ -62,7 +62,7 @@ const (
 	labelHTTPPath       = `/http/path`
 	labelHTTPUserAgent  = `/http/user_agent`
 	// This is prefixed for google app engine, but translates to the service
-	// in the trace UI
+	// in the trace UI.
 	labelService = `g.co/gae/app/module`
 
 	instrumentationScopeNameAttribute    = "otel.scope.name"
@@ -71,7 +71,7 @@ const (
 
 var userAgent = fmt.Sprintf("opentelemetry-go %s; google-cloud-trace-exporter %s", otel.Version(), Version())
 
-// Adapters for using resourcemapping library
+// Adapters for using resourcemapping library.
 type attrs struct {
 	Attrs []attribute.KeyValue
 }

--- a/golangci.yml
+++ b/golangci.yml
@@ -254,7 +254,7 @@ linters-settings:
         disabled: false
         arguments:
           - ["ID"] # AllowList
-          - ["Otel", "Aws", "Gcp"] # DenyList
+          - ["Otel", "Gcp"] # DenyList
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
       - name: var-declaration
         disabled: false

--- a/golangci.yml
+++ b/golangci.yml
@@ -92,7 +92,8 @@ linters-settings:
         ignore-file-rules:
           - "**/*_test.go"
           - "**/*test/*.go"
-          - "**/internal/matchers/*.go"
+          - "**/testcase.go"
+          - "**/recordfixtures/*.go"
   godot:
     exclude:
       # Exclude sentence fragments for lists.

--- a/golangci.yml
+++ b/golangci.yml
@@ -70,6 +70,36 @@ output:
 
 # all available settings of specific linters
 linters-settings:
+  depguard:
+    # Check the list against standard lib.
+    # Default: false
+    include-go-root: true
+    # A list of packages for the list type specified.
+    # Default: []
+    packages:
+      - "crypto/md5"
+      - "crypto/sha1"
+      - "crypto/**/pkix"
+    ignore-file-rules:
+      - "**/*_test.go"
+    additional-guards:
+      # Do not allow testing packages in non-test files.
+      - list-type: denylist
+        include-go-root: true
+        packages:
+          - testing
+          - github.com/stretchr/testify
+        ignore-file-rules:
+          - "**/*_test.go"
+          - "**/*test/*.go"
+          - "**/internal/matchers/*.go"
+  godot:
+    exclude:
+      # Exclude sentence fragments for lists.
+      - '^[ ]*[-•]'
+      # Exclude sentences prefixing a list.
+      - ':$'
+
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
@@ -107,19 +137,168 @@ linters-settings:
     - kilometre
     - kilometres
   revive:
+    # Sets the default failure confidence.
+    # This means that linting errors with less than 0.8 confidence will be ignored.
+    # Default: 0.8
+    confidence: 0.01
     rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
+      - name: blank-imports
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      - name: bool-literal-in-expr
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
+      - name: constant-logical-expr
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        disabled: false
+        arguments:
+          allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
+      - name: context-keys-type
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
+      - name: deep-exit
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
+      - name: defer
+        disabled: false
+        arguments:
+          - ["call-chain", "loop"]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
+      - name: dot-imports
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
       - name: duplicated-imports
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
+      - name: empty-block
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+      - name: empty-lines
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
+      - name: error-naming
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
+      - name: error-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      - name: error-strings
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
+      - name: errorf
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+      - name: exported
+        disabled: false
+        arguments:
+          - "sayRepetitiveInsteadOfStutters"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
+      - name: flag-parameter
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
+      - name: identical-branches
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      - name: if-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
+      - name: increment-decrement
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+      - name: indent-error-flow
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      - name: import-shadowing
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
+      - name: package-comments
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
+      - name: range
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
+      - name: range-val-in-closure
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
+      - name: range-val-address
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
+      - name: redefines-builtin-id
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
+      - name: string-format
+        disabled: false
+        arguments:
+          - - panic
+            - '/^[^\n]*$/'
+            - must not contain line breaks
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      - name: struct-tag
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+      - name: superfluous-else
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
+      - name: time-equal
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      - name: var-naming
+        disabled: false
+        arguments:
+          - ["ID"] # AllowList
+          - ["Otel", "Aws", "Gcp"] # DenyList
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
+      - name: var-declaration
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
+      - name: unconditional-recursion
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+      - name: unexported-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      - name: unhandled-error
+        disabled: false
+        arguments:
+          - "fmt.Fprint"
+          - "fmt.Fprintf"
+          - "fmt.Fprintln"
+          - "fmt.Print"
+          - "fmt.Printf"
+          - "fmt.Println"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt
+      - name: unnecessary-stmt
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      - name: useless-break
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
+      - name: waitgroup-by-value
+        disabled: false
 
 linters:
   disable-all: true
   enable:
+    - depguard
+    - errcheck
+    - exportloopref
+    - godot
     - gofmt
     - goimports
-    - revive
+    - gosimple
     - govet
-    - staticcheck
+    - ineffassign
     - misspell
-    - exportloopref
+    - revive
+    - staticcheck
+    - typecheck
     - unused
 
 issues:

--- a/internal/cloudmock/logs.go
+++ b/internal/cloudmock/logs.go
@@ -37,6 +37,7 @@ func (l *LogsTestServer) Shutdown() {
 }
 
 func (l *LogsTestServer) Serve() {
+	//nolint:errcheck
 	l.srv.Serve(l.lis)
 }
 

--- a/internal/cloudmock/metrics.go
+++ b/internal/cloudmock/metrics.go
@@ -43,7 +43,7 @@ func (m *MetricsTestServer) Shutdown() {
 	m.srv.GracefulStop()
 }
 
-// Pops out the CreateMetricDescriptorRequests which the test server has received so far
+// Pops out the CreateMetricDescriptorRequests which the test server has received so far.
 func (m *MetricsTestServer) CreateMetricDescriptorRequests() []*monitoringpb.CreateMetricDescriptorRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -52,7 +52,7 @@ func (m *MetricsTestServer) CreateMetricDescriptorRequests() []*monitoringpb.Cre
 	return reqs
 }
 
-// Pops out the CreateTimeSeriesRequests which the test server has received so far
+// Pops out the CreateTimeSeriesRequests which the test server has received so far.
 func (m *MetricsTestServer) CreateTimeSeriesRequests() []*monitoringpb.CreateTimeSeriesRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -61,7 +61,7 @@ func (m *MetricsTestServer) CreateTimeSeriesRequests() []*monitoringpb.CreateTim
 	return reqs
 }
 
-// Pops out the CreateServiceTimeSeriesRequests which the test server has received so far
+// Pops out the CreateServiceTimeSeriesRequests which the test server has received so far.
 func (m *MetricsTestServer) CreateServiceTimeSeriesRequests() []*monitoringpb.CreateTimeSeriesRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/cloudmock/traces.go
+++ b/internal/cloudmock/traces.go
@@ -39,6 +39,7 @@ func (t *TracesTestServer) Shutdown() {
 }
 
 func (t *TracesTestServer) Serve() {
+	//nolint:errcheck
 	t.srv.Serve(t.lis)
 }
 
@@ -108,7 +109,7 @@ func (fn optionFunc) apply(cfg config) config {
 	return fn(cfg)
 }
 
-// WithDelay sets a delay on the test server before it responds
+// WithDelay sets a delay on the test server before it responds.
 func WithDelay(t time.Duration) TraceServerOption {
 	return optionFunc(func(cfg config) config {
 		cfg.delay = t

--- a/propagator/propagator.go
+++ b/propagator/propagator.go
@@ -32,7 +32,7 @@ import (
 // https://cloud.google.com/trace/docs/setup#force-trace
 const TraceContextHeaderName = "x-cloud-trace-context"
 
-// traceContextHeaderFormat is the regular expression pattern for valid Cloud Trace header value
+// traceContextHeaderFormat is the regular expression pattern for valid Cloud Trace header value.
 const traceContextHeaderFormat = "^(?P<trace_id>[0-9a-f]{32})/(?P<span_id>[0-9]{1,20})(;o=(?P<trace_flags>[0-9]))?$"
 
 // traceContextHeaderRe is a regular expression object of TraceContextHeaderFormat.
@@ -64,11 +64,11 @@ type CloudTraceOneWayPropagator struct {
 	CloudTraceFormatPropagator
 }
 
-// Inject does not inject anything for the oneway propagator
+// Inject does not inject anything for the oneway propagator.
 func (p CloudTraceOneWayPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {}
 
 // Fields returns an empty list of fields, since the one way propagator does
-// not inject any fields
+// not inject any fields.
 func (p CloudTraceOneWayPropagator) Fields() []string {
 	return oneWayContextHeaders
 }


### PR DESCRIPTION
Fixes #524 
This updates our linter settings to match [upstream](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/2aae3a65934017de3c5b65de95a7f1a2ddad84f8/.golangci.yml)