### PR TITLE
Fix propagator package in release.go

### DIFF
--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -14,7 +14,7 @@ replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/clou
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.10.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.0.0-00010101000000-000000000000
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.34.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4
 	go.opentelemetry.io/otel v1.11.1
 	go.opentelemetry.io/otel/sdk v1.11.1

--- a/tools/release.go
+++ b/tools/release.go
@@ -49,7 +49,7 @@ var versions = map[string]string{
 
 	"detectors/gcp/": unstable,
 
-	"propagator": unstable,
+	"propagator/": unstable,
 }
 
 type module string


### PR DESCRIPTION
Got a little hot on the merge button in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/539 and didn't notice the weird changes in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/539/files#diff-5e69ba298fd881f2cf26d39a12cf8ac7f4df5900cb66971179941ad33582f93e

Luckily, `make release` failed with the following:
```
go run tools/release.go prepare
go: errors parsing example/trace/http/go.mod:
example/trace/http/go.mod:17:2: require github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator: version "v" invalid: must be of the form v1.2.3
2022/11/29 16:25:36 running "/usr/lib/google-golang/bin/go mod edit -require=github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping@v0.34.2 example/trace/http/go.mod": exit status 1
exit status 1
make: *** [Makefile:207: prepare-release] Error 1
```

I don't know exactly how adding the `/` fixes this, but I noticed the other modules all had a trailing slash so I assume there is some text manipulation in the script that depends on it.