### PR TITLE
Do not mutate incoming metrics

### DIFF
--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -16,6 +16,7 @@ package datapointstorage
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -223,9 +224,14 @@ func Identifier(resource *monitoredrespb.MonitoredResource, extraLabels map[stri
 
 	// Metric identifiers
 	fmt.Fprintf(&b, " - %s -", metric.Name())
-	attributes.Sort().Range(func(k string, v pcommon.Value) bool {
-		fmt.Fprintf(&b, " %s=%s", k, v.AsString())
+	attrsIds := make([]string, 0, attributes.Len())
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		attrsIds = append(attrsIds, k+"="+v.AsString())
 		return true
 	})
+	if len(attrsIds) > 0 {
+		sort.Strings(attrsIds)
+		fmt.Fprint(&b, " "+strings.Join(attrsIds, " "))
+	}
 	return b.String()
 }

--- a/exporter/collector/internal/datapointstorage/datapointcache_test.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache_test.go
@@ -318,10 +318,13 @@ func TestIdentifier(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			origLabels := pcommon.NewMap()
+			tc.labels.CopyTo(origLabels)
 			got := Identifier(tc.resource, tc.extraLabels, tc.metric, tc.labels)
 			if tc.want != got {
 				t.Errorf("Identifier() = %q; want %q", got, tc.want)
 			}
+			assert.Equal(t, origLabels, tc.labels) // Make sure the labels are not mutated
 		})
 	}
 }


### PR DESCRIPTION
The method Sort mutates the incoming data which can lead to subtle bugs like https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16499 given that googlecloudexporter marked as not mutating