### PR TITLE
Support multi-project quota usage

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -137,6 +137,7 @@ The following configuration options are supported:
     User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
+- `destination_project_quota` (optional): Enables [multi-project quota usage](#multi-project-exporting) for traces and metrics.
 
 Note: These `retry_on_failure` and `sending_queue` are provided (and documented) by the [Exporter Helper](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper#configuration)
 
@@ -316,6 +317,13 @@ additional flexibility in parsing log severity from incoming entries.
 ## Multi-Project exporting
 
 By default, the exporter sends telemetry to the project specified by `project` in the configuration. This can be overridden on a per-metrics basis using the `gcp.project.id` resource attribute. For example, if a metric has a label `project`, you could use the `groupbyattrs` processor to promote it to a resource label, and the `resource` processor to rename the attribute from `project` to `gcp.project.id`.
+
+### Multi-Project quota usage
+
+The `gcp.project.id` label can be combined with the `destination_project_quota` option to attribute quota usage to the project parsed by the label. This feature is currently only available
+for traces and metrics.
+
+Note that this option will not work  if a quota project is already defined in your Collector's GCP credentials. In this case, the telemetry will fail to export with a "project not found" error.
 
 ## Recommendations
 

--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -137,7 +137,7 @@ The following configuration options are supported:
     User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
-- `destination_project_quota` (optional): Enables [multi-project quota usage](#multi-project-exporting) for traces and metrics.
+- `destination_project_quota` (optional): Counts quota for traces and metrics against the project to which the data is sent (as opposed to the project associated with the Collector's service account. For example, when setting `project_id` or using [multi-project export](#multi-project-exporting). (default = false)
 
 Note: These `retry_on_failure` and `sending_queue` are provided (and documented) by the [Exporter Helper](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper#configuration)
 
@@ -321,9 +321,10 @@ By default, the exporter sends telemetry to the project specified by `project` i
 ### Multi-Project quota usage
 
 The `gcp.project.id` label can be combined with the `destination_project_quota` option to attribute quota usage to the project parsed by the label. This feature is currently only available
-for traces and metrics.
+for traces and metrics. The Collector's default service account will need `roles/serviceusage.serviceUsageConsumer` IAM permissions in the destination quota project.
 
 Note that this option will not work  if a quota project is already defined in your Collector's GCP credentials. In this case, the telemetry will fail to export with a "project not found" error.
+This can be done by manually editing your [ADC file](https://cloud.google.com/docs/authentication/application-default-credentials#personal) (if it exists) to remove the `quota_project_id` entry line.
 
 ## Recommendations
 

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -39,15 +39,16 @@ const (
 
 // Config defines configuration for Google Cloud exporter.
 type Config struct {
-	ImpersonateConfig ImpersonateConfig `mapstructure:"impersonate"`
 	// ProjectID is the project telemetry is sent to if the gcp.project.id
 	// resource attribute is not set. If unspecified, this is determined using
 	// application default credentials.
-	ProjectID    string       `mapstructure:"project"`
-	UserAgent    string       `mapstructure:"user_agent"`
-	TraceConfig  TraceConfig  `mapstructure:"trace"`
-	LogConfig    LogConfig    `mapstructure:"log"`
-	MetricConfig MetricConfig `mapstructure:"metric"`
+	ProjectID               string            `mapstructure:"project"`
+	UserAgent               string            `mapstructure:"user_agent"`
+	ImpersonateConfig       ImpersonateConfig `mapstructure:"impersonate"`
+	LogConfig               LogConfig         `mapstructure:"log"`
+	TraceConfig             TraceConfig       `mapstructure:"trace"`
+	MetricConfig            MetricConfig      `mapstructure:"metric"`
+	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
 }
 
 type ClientConfig struct {

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -42,6 +42,7 @@ import (
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -59,7 +60,6 @@ type selfObservability struct {
 
 // MetricsExporter is the GCM exporter that uses pdata directly.
 type MetricsExporter struct {
-	mapper metricMapper
 	// A channel that receives metric descriptor and sends them to GCM once
 	metricDescriptorC chan *monitoringpb.CreateMetricDescriptorRequest
 	client            *monitoring.MetricClient
@@ -68,10 +68,19 @@ type MetricsExporter struct {
 	shutdownC chan struct{}
 	// mdCache tracks the metric descriptors that have already been sent to GCM
 	mdCache map[string]*monitoringpb.CreateMetricDescriptorRequest
-	cfg     Config
+	// requestOpts applies options to the context for requests, such as additional headers.
+	requestOpts []func(*context.Context, requestInfo)
+	mapper      metricMapper
+	cfg         Config
 	// goroutines tracks the currently running child tasks
 	goroutines sync.WaitGroup
 	timeout    time.Duration
+}
+
+// requestInfo is meant to abstract info from CreateMetricsDescriptorRequests and
+// CreateTimeSeriesRequests that is shared by requestOpts functions.
+type requestInfo struct {
+	name string
 }
 
 // metricMapper is the part that transforms metrics. Separate from MetricsExporter since it has
@@ -159,6 +168,13 @@ func NewGoogleCloudMetricsExporter(
 		mdCache:           make(map[string]*monitoringpb.CreateMetricDescriptorRequest),
 		shutdownC:         shutdown,
 		timeout:           timeout,
+	}
+
+	mExp.requestOpts = make([]func(*context.Context, requestInfo), 0)
+	if cfg.DestinationProjectQuota {
+		mExp.requestOpts = append(mExp.requestOpts, func(ctx *context.Context, ri requestInfo) {
+			*ctx = metadata.NewOutgoingContext(*ctx, metadata.New(map[string]string{"x-goog-user-project": strings.TrimPrefix(ri.name, "projects/")}))
+		})
 	}
 
 	// Fire up the metric descriptor exporter.
@@ -313,6 +329,10 @@ func (me *MetricsExporter) exportMetricDescriptor(req *monitoringpb.CreateMetric
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), me.timeout)
 	defer cancel()
+
+	for _, opt := range me.requestOpts {
+		opt(&ctx, requestInfo{name: req.Name})
+	}
 	_, err := me.client.CreateMetricDescriptor(ctx, req)
 	if err != nil {
 		// TODO: Log-once on error, per metric descriptor?
@@ -328,6 +348,9 @@ func (me *MetricsExporter) exportMetricDescriptor(req *monitoringpb.CreateMetric
 func (me *MetricsExporter) createTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest) error {
 	ctx, cancel := context.WithTimeout(ctx, me.timeout)
 	defer cancel()
+	for _, opt := range me.requestOpts {
+		opt(&ctx, requestInfo{name: req.Name})
+	}
 	return me.client.CreateTimeSeries(ctx, req)
 }
 
@@ -335,6 +358,9 @@ func (me *MetricsExporter) createTimeSeries(ctx context.Context, req *monitoring
 func (me *MetricsExporter) createServiceTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest) error {
 	ctx, cancel := context.WithTimeout(ctx, me.timeout)
 	defer cancel()
+	for _, opt := range me.requestOpts {
+		opt(&ctx, requestInfo{name: req.Name})
+	}
 	return me.client.CreateServiceTimeSeries(ctx, req)
 }
 

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -50,6 +50,9 @@ func NewGoogleCloudTracesExporter(ctx context.Context, cfg Config, version strin
 		cloudtrace.WithProjectID(cfg.ProjectID),
 		cloudtrace.WithTimeout(timeout),
 	}
+	if cfg.DestinationProjectQuota {
+		topts = append(topts, cloudtrace.WithDestinationProjectQuota())
+	}
 	if cfg.TraceConfig.AttributeMappings != nil {
 		topts = append(topts, cloudtrace.WithAttributeMapping(mappingFuncFromAKM(cfg.TraceConfig.AttributeMappings)))
 	}

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -38,6 +38,7 @@ import (
 	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"
@@ -119,6 +120,10 @@ func (me *metricExporter) Export(ctx context.Context, rm metricdata.ResourceMetr
 	case <-me.shutdown:
 		return errShutdown
 	default:
+	}
+
+	if me.o.destinationProjectQuota {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"x-goog-user-project": strings.TrimPrefix(me.o.projectID, "projects/")}))
 	}
 	return multierr.Combine(
 		me.exportMetricDescriptor(ctx, rm),

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -60,6 +60,9 @@ type options struct {
 	// to the underlying Stackdriver Monitoring API client.
 	// Optional.
 	monitoringClientOptions []apioption.ClientOption
+	// destinationProjectQuota sets whether the request should use quota from
+	// the destination project for the request.
+	destinationProjectQuota bool
 
 	// disableCreateMetricDescriptors disables automatic MetricDescriptor creation
 	disableCreateMetricDescriptors bool
@@ -73,6 +76,14 @@ type options struct {
 func WithProjectID(id string) func(o *options) {
 	return func(o *options) {
 		o.projectID = id
+	}
+}
+
+// WithDestinationProjectQuota enables per-request usage of the destination
+// project's quota. For example, when setting gcp.project.id on a metric.
+func WithDestinationProjectQuota() func(o *options) {
+	return func(o *options) {
+		o.destinationProjectQuota = true
 	}
 }
 

--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -85,7 +85,7 @@ func WithProjectID(projectID string) func(o *options) {
 }
 
 // WithDestinationProjectQuota enables per-request usage of the destination
-// project's quota. For example, when setting gcp.project.id on a span.
+// project's quota. For example, when setting the gcp.project.id resource attribute.
 func WithDestinationProjectQuota() func(o *options) {
 	return func(o *options) {
 		o.destinationProjectQuota = true

--- a/exporter/trace/cloudtrace.go
+++ b/exporter/trace/cloudtrace.go
@@ -68,6 +68,9 @@ type options struct {
 	traceClientOptions []option.ClientOption
 	// timeout for all API calls. If not set, defaults to 12 seconds.
 	timeout time.Duration
+	// destinationProjectQuota sets whether the request should use quota from
+	// the destination project for the request.
+	destinationProjectQuota bool
 }
 
 // WithProjectID sets Google Cloud Platform project as projectID.
@@ -78,6 +81,14 @@ type options struct {
 func WithProjectID(projectID string) func(o *options) {
 	return func(o *options) {
 		o.projectID = projectID
+	}
+}
+
+// WithDestinationProjectQuota enables per-request usage of the destination
+// project's quota. For example, when setting gcp.project.id on a span.
+func WithDestinationProjectQuota() func(o *options) {
+	return func(o *options) {
+		o.destinationProjectQuota = true
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/411

Need to figure out a way to add a test for this (only done manually so far). But ultimately it's just setting the header on requests.

Note that this will not work if the collector's credentials already define a quota project. We could probably automatically parse that out when this feature is enabled, but it feels hacky so for a first release of this I think documenting the requirement, allowing it to explicitly fail, and alerting the user is good enough.

The logs collector exporter will need to be refactored to use this, because we currently batch requests of logs from potentially multiple projects into a single request.