### PR TITLE
Add github actions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,146 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+env:
+  # Path to where test results will be saved.
+  TEST_RESULTS: /tmp/test-results
+  # Default minimum version of Go to support.
+  DEFAULT_GO_VERSION: 1.18
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Module cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+      - name: Tools cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-tools-cache
+        with:
+          path: ~/.tools
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('./internal/tools/**') }}
+      - name: Generate
+        run: make generate
+      - name: Build
+        run: make build
+      - name: Run linters
+        run: make lint
+      - name: Fixtures
+        run: make fixtures
+      - name: Check clean repository
+        run: make check-clean-work-tree
+
+  test-race:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Module cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+      - name: Run tests with race detector
+        run: make test
+
+  test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Module cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+      - name: Run coverage tests
+        run: |
+          make test-with-coverage
+          mkdir $TEST_RESULTS
+          cp coverage.out $TEST_RESULTS
+          cp coverage.txt $TEST_RESULTS
+          cp coverage.html $TEST_RESULTS
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: true
+          verbose: true
+      - name: Store coverage test output
+        uses: actions/upload-artifact@v3
+        with:
+          name: opentelemetry-go-test-output
+          path: ${{ env.TEST_RESULTS }}
+
+  compatibility-test:
+    strategy:
+      matrix:
+        go-version: [1.19, 1.18]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: ["386", amd64]
+        exclude:
+          # Not a supported Go OS/architecture.
+          - os: macos-latest
+            arch: "386"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
+      - name: Module cache
+        uses: actions/cache@v3
+        env:
+          cache-name: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+      - name: Run tests
+        env:
+          GOARCH: ${{ matrix.arch }}
+        run: make test-short


### PR DESCRIPTION
Part of https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/554

This keeps all of the individual steps the same, but instead of running `make ci`, like we do in circleci, it runs each step (generate, build, lint, fixtures, check-clean-work-tree) as a separate step.

It also expands the compatibility matrix we test against to match what the opentelemetry-go repo uses to include testing against two go versions (1.19 and 1.18), testing on linux, windows, and mac.

Tests are based on the github actions tests in opentelemetry-go.