### PR TITLE
Add resource mappings for cloud run, cloud functions, and GAE

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -342,9 +342,7 @@ func (me *metricExporter) resourceToMonitoredResourcepb(res *resource.Resource) 
 	cloudPlatform, _ := attrs.GetString(string(semconv.CloudPlatformKey))
 	var gmr *resourcemapping.GceResource
 	switch cloudPlatform {
-	case semconv.CloudPlatformGCPCloudRun.Value.AsString():
-		fallthrough
-	case semconv.CloudPlatformGCPCloudFunctions.Value.AsString():
+	case semconv.CloudPlatformGCPCloudRun.Value.AsString(), semconv.CloudPlatformGCPCloudFunctions.Value.AsString():
 		// On Cloud Run and Cloud Functions, we can't write to their monitored resources.
 		// Fall-back to generic monitored resources in that case.
 		gmr = resourcemapping.ResourceAttributesToGenericMonitoredResource(attrs)

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -529,7 +529,7 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 			},
 		},
 		{
-			desc: "Cloud Run",
+			desc: "Cloud Run Via Service",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "gcp"),
@@ -545,6 +545,63 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 				"namespace": "cloud-run-managed",
 				"job":       "x-service",
 				"task_id":   "bar",
+			},
+		},
+		{
+			desc: "Cloud Run From Detector",
+			resource: resource.NewWithAttributes(
+				semconv.SchemaURL,
+				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_cloud_run"),
+				attribute.String("cloud.region", "utopia"),
+				attribute.String("faas.id", "bar"),
+				attribute.String("faas.name", "x-service"),
+				attribute.String("faas.version", "v1"),
+			),
+			expectedType: "generic_task",
+			expectedLabels: map[string]string{
+				"location":  "utopia",
+				"namespace": "",
+				"job":       "x-service",
+				"task_id":   "bar",
+			},
+		},
+		{
+			desc: "Cloud Functions",
+			resource: resource.NewWithAttributes(
+				semconv.SchemaURL,
+				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_cloud_functions"),
+				attribute.String("cloud.region", "utopia"),
+				attribute.String("faas.id", "bar"),
+				attribute.String("faas.name", "x-service"),
+				attribute.String("faas.version", "v1"),
+			),
+			expectedType: "generic_task",
+			expectedLabels: map[string]string{
+				"location":  "utopia",
+				"namespace": "",
+				"job":       "x-service",
+				"task_id":   "bar",
+			},
+		},
+		{
+			desc: "AppEngine",
+			resource: resource.NewWithAttributes(
+				semconv.SchemaURL,
+				attribute.String("cloud.provider", "gcp"),
+				attribute.String("cloud.platform", "gcp_app_engine"),
+				attribute.String("cloud.availability_zone", "utopia"),
+				attribute.String("faas.id", "bar"),
+				attribute.String("faas.name", "x-service"),
+				attribute.String("faas.version", "v1"),
+			),
+			expectedType: "gae_instance",
+			expectedLabels: map[string]string{
+				"location":    "utopia",
+				"instance_id": "bar",
+				"module_id":   "x-service",
+				"version_id":  "v1",
 			},
 		},
 		{


### PR DESCRIPTION
Adds support for gae_instance, cloud_run_revision, and cloud_function monitored resources, but disallow their use for monitoring since those resources are not writable.  This is required to add e2e tests on those platforms.

This maintains the mappings if using the service.* labels (e.g. for cloud run).