### PR TITLE
Implement push scenario for test server

### DIFF
--- a/e2e-test-server/app.go
+++ b/e2e-test-server/app.go
@@ -41,13 +41,14 @@ func main() {
 		log.Fatalf("Could not initialize server: %v", err)
 	}
 
-	err = server.Run(runCtx)
-	if err != nil {
+	if err = server.Run(runCtx); err != nil {
 		log.Printf("Unexpected error occurred: %v", err)
 	}
 
 	log.Print("Shutting down")
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelShutdown()
-	server.Shutdown(shutdownCtx)
+	if err = server.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Unexpected error occurred: %v", err)
+	}
 }

--- a/e2e-test-server/endtoendserver/constants.go
+++ b/e2e-test-server/endtoendserver/constants.go
@@ -36,6 +36,7 @@ var (
 	projectID               string
 	requestSubscriptionName string
 	responseTopicName       string
+	port                    string
 )
 
 func init() {
@@ -54,5 +55,9 @@ func init() {
 	responseTopicName = os.Getenv("RESPONSE_TOPIC_NAME")
 	if responseTopicName == "" {
 		log.Fatalf("environment variable RESPONSE_TOPIC_NAME must be set")
+	}
+	port = os.Getenv("PORT")
+	if port == "" && subscriptionMode == "push" {
+		log.Fatalf("environment variable PORT must be set for push subscription")
 	}
 }

--- a/e2e-test-server/endtoendserver/pull_server.go
+++ b/e2e-test-server/endtoendserver/pull_server.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endtoendserver
+
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/pubsub"
+)
+
+// pullServer is an end-to-end test service.
+type pullServer struct {
+	pubsubClient *pubsub.Client
+}
+
+// New instantiates a new end-to-end test service.
+func NewPullServer() (Server, error) {
+	pubsubClient, err := pubsub.NewClient(context.Background(), projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pullServer{
+		pubsubClient: pubsubClient,
+	}, nil
+}
+
+// Run the end-to-end test service. This method will block until the context is
+// cancel, or an unrecoverable error is encountered.
+func (s *pullServer) Run(ctx context.Context) error {
+	sub := s.pubsubClient.Subscription(requestSubscriptionName)
+	log.Printf("End-to-end test service listening on %s", sub)
+	return sub.Receive(ctx, func(ctx context.Context, m *pubsub.Message) { s.onReceive(ctx, m) })
+}
+
+// Shutdown gracefully shuts down the service, flushing and closing resources as
+// appropriate.
+func (s *pullServer) Shutdown(ctx context.Context) error {
+	return s.pubsubClient.Close()
+}
+
+// onReceive executes a scenario based on the incoming message from the test runner.
+func (s *pullServer) onReceive(ctx context.Context, m *pubsub.Message) {
+	defer m.Ack()
+	handleMessage(ctx, s.pubsubClient, m)
+}

--- a/e2e-test-server/endtoendserver/push_server.go
+++ b/e2e-test-server/endtoendserver/push_server.go
@@ -1,0 +1,112 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endtoendserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"cloud.google.com/go/pubsub"
+)
+
+// pushServer is an end-to-end test service.
+type pushServer struct {
+	pubsubClient *pubsub.Client
+	srv          http.Server
+}
+
+// New instantiates a new push end-to-end test service.
+func NewPushServer() (Server, error) {
+	pubsubClient, err := pubsub.NewClient(context.Background(), projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pushServer{
+		srv:          http.Server{Addr: ":" + port},
+		pubsubClient: pubsubClient,
+	}, nil
+}
+
+// Run the end-to-end test service. This method will block until the context is
+// cancel, or an unrecoverable error is encountered.
+func (s *pushServer) Run(ctx context.Context) error {
+	http.HandleFunc("/", s.handle)
+	http.HandleFunc("/ready", handleReady)
+	http.HandleFunc("/alive", handleAlive)
+	go func() {
+		if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			// Error starting or closing listener:
+			log.Printf("HTTP server ListenAndServe: %v", err)
+		}
+	}()
+	<-ctx.Done()
+	return nil
+}
+
+// Shutdown gracefully shuts down the service, flushing and closing resources as
+// appropriate.
+func (s *pushServer) Shutdown(ctx context.Context) error {
+	pubsubErr := s.pubsubClient.Close()
+	if err := s.srv.Shutdown(ctx); err != nil {
+		return err
+	}
+	return pubsubErr
+}
+
+// pubSubMessage is the payload of a Pub/Sub event.
+type PubSubMessage struct {
+	Message struct {
+		Attributes map[string]string `json:"attributes,omitempty"`
+	} `json:"message"`
+}
+
+func (p *PubSubMessage) toPubSubMessage() *pubsub.Message {
+	return &pubsub.Message{Attributes: p.Message.Attributes}
+}
+
+// handle receives and processes a Pub/Sub push message.
+func (s *pushServer) handle(w http.ResponseWriter, r *http.Request) {
+	var m PubSubMessage
+	if r.Method == "POST" {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("io.ReadAll: %v", err)
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+		// byte slice unmarshalling handles base64 decoding.
+		if err := json.Unmarshal(body, &m); err != nil {
+			log.Printf("json.Unmarshal: %v", err)
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+		handleMessage(r.Context(), s.pubsubClient, m.toPubSubMessage())
+	}
+	// Ack the message
+	fmt.Fprint(w, "OK")
+}
+
+func handleReady(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Server Ready")
+}
+
+func handleAlive(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Server Alive")
+}


### PR DESCRIPTION
This is based on [the java implementation](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/blob/main/e2e-test-server/src/main/java/com/google/cloud/opentelemetry/endtoend/PubSubPushServer.java#L64).  It listens on a server for incoming requests, rather than waiting for messages to be pushed to a topic.

It is a prerequisite for adding tests for GAE, Cloud Run and Cloud Functions.