### PR TITLE
Include service attributes in logs exporter by default

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -159,6 +159,10 @@ type LogConfig struct {
 	// Defaults to empty, which won't include any additional resource labels.
 	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
 	ClientConfig    ClientConfig     `mapstructure:",squash"`
+	// ServiceResourceLabels, if true, causes the exporter to copy OTel's
+	// service.name, service.namespace, and service.instance.id resource attributes into the Cloud Logging LogEntry labels.
+	// Disabling this option does not prevent resource_filters from adding those labels. Default is true.
+	ServiceResourceLabels bool `mapstructure:"service_resource_labels"`
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.
@@ -168,6 +172,9 @@ var domains = []string{"googleapis.com", "kubernetes.io", "istio.io", "knative.d
 func DefaultConfig() Config {
 	return Config{
 		UserAgent: "opentelemetry-collector-contrib {{version}}",
+		LogConfig: LogConfig{
+			ServiceResourceLabels: true,
+		},
 		MetricConfig: MetricConfig{
 			KnownDomains:                     domains,
 			Prefix:                           "workload.googleapis.com",

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -82,7 +82,8 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: collector.ClientConfig{
 						GRPCPoolSize: 1,
 					},
-					DefaultLogName: "foo-log",
+					DefaultLogName:        "foo-log",
+					ServiceResourceLabels: true,
 				},
 			},
 		})

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes.json
@@ -14,6 +14,24 @@
             "value": {
               "stringValue": "baz"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my_service_name"
+            }
+          },
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "my_service_namespace"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "my_service_instance_id"
+            }
           }
         ]
       },

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -23,7 +23,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -47,7 +50,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -71,7 +77,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -95,7 +104,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -119,7 +131,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -143,7 +158,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -167,7 +185,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -191,7 +212,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -215,7 +239,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -239,7 +266,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -263,7 +293,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -287,7 +320,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -311,7 +347,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -335,7 +374,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -359,7 +401,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -383,7 +428,10 @@
           },
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         },
         {
@@ -399,7 +447,10 @@
           "timestamp": "1970-01-01T00:00:00Z",
           "labels": {
             "custom_foobar": "baz",
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "service_instance_id": "my_service_instance_id",
+            "service_name": "my_service_name",
+            "service_namespace": "my_service_namespace"
           }
         }
       ],

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -212,7 +212,7 @@ func (l logMapper) createEntries(ld plog.Logs) ([]*logpb.LogEntry, error) {
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
 		mr := defaultResourceToMonitoredResource(rl.Resource())
-		extraResourceLabels := resourceToLabels(rl.Resource(), false, l.cfg.LogConfig.ResourceFilters, l.obs.log)
+		extraResourceLabels := resourceToLabels(rl.Resource(), l.cfg.LogConfig.ServiceResourceLabels, l.cfg.LogConfig.ResourceFilters, l.obs.log)
 		projectID := l.cfg.ProjectID
 		// override project ID with gcp.project.id, if present
 		if projectFromResource, found := rl.Resource().Attributes().Get(resourcemapping.ProjectIDAttributeKey); found {


### PR DESCRIPTION
This copies the flow from metrics to include service resource attributes as LogEntry labels