### PR TITLE
Mark gcp resource detector stable

### DIFF
--- a/tools/release.go
+++ b/tools/release.go
@@ -47,7 +47,7 @@ var versions = map[string]string{
 	"internal/resourcemapping/": unstable,
 	"internal/cloudmock/":       unstable,
 
-	"detectors/gcp/": unstable,
+	"detectors/gcp/": stable,
 
 	"propagator/": unstable,
 }


### PR DESCRIPTION
This graduates the gcp resource detector library to stable in the next release.