### PR TITLE
 Remove monitored resource mappings for Cloud run and cloud functions

### DIFF
--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.15.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -33,5 +33,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.11.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.11.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.11.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -31,7 +31,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"go.uber.org/multierr"
@@ -338,17 +337,9 @@ func (attrs *attributes) GetString(key string) (string, bool) {
 //
 // https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.monitoredResourceDescriptors
 func (me *metricExporter) resourceToMonitoredResourcepb(res *resource.Resource) *monitoredrespb.MonitoredResource {
-	attrs := &attributes{attrs: attribute.NewSet(res.Attributes()...)}
-	cloudPlatform, _ := attrs.GetString(string(semconv.CloudPlatformKey))
-	var gmr *resourcemapping.GceResource
-	switch cloudPlatform {
-	case semconv.CloudPlatformGCPCloudRun.Value.AsString(), semconv.CloudPlatformGCPCloudFunctions.Value.AsString():
-		// On Cloud Run and Cloud Functions, we can't write to their monitored resources.
-		// Fall-back to generic monitored resources in that case.
-		gmr = resourcemapping.ResourceAttributesToGenericMonitoredResource(attrs)
-	default:
-		gmr = resourcemapping.ResourceAttributesToMonitoredResource(attrs)
-	}
+	gmr := resourcemapping.ResourceAttributesToMonitoredResource(&attributes{
+		attrs: attribute.NewSet(res.Attributes()...),
+	})
 	newLabels := make(map[string]string, len(gmr.Labels))
 	for k, v := range gmr.Labels {
 		newLabels[k] = sanitizeUTF8(v)


### PR DESCRIPTION
Partial revert of #562.

It removes MR mappings for cloud run and cloud functions.  It keeps the GAE mappings, since that is useful when writing metrics.

This should break e2e tests until we switch to checking otel resource attributes.