### PR TITLE
Add otel_scope_info metric to GMP exporter

### DIFF
--- a/exporter/collector/googlemanagedprometheus/extra_metrics.go
+++ b/exporter/collector/googlemanagedprometheus/extra_metrics.go
@@ -58,8 +58,7 @@ func AddScopeInfoMetric(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
 	resourceMetricSlice := pmetric.NewResourceMetricsSlice()
 	rms := m.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
-		rm := rms.At(i)
-		rm.Resource().CopyTo(resourceMetricSlice.AppendEmpty().Resource())
+		resourceMetricSlice.AppendEmpty()
 
 		sms := rms.At(i).ScopeMetrics()
 		for j := 0; j < sms.Len(); j++ {

--- a/exporter/collector/googlemanagedprometheus/extra_metrics_test.go
+++ b/exporter/collector/googlemanagedprometheus/extra_metrics_test.go
@@ -21,14 +21,16 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func TestAddTargetInfo(t *testing.T) {
+func TestAddExtraMetrics(t *testing.T) {
 	for _, tc := range []struct {
+		testFunc func(pmetric.Metrics) pmetric.ResourceMetricsSlice
 		input    pmetric.Metrics
 		expected pmetric.ResourceMetricsSlice
 		name     string
 	}{
 		{
-			name: "add target info from resource metric",
+			name:     "add target info from resource metric",
+			testFunc: AddTargetInfoMetric,
 			input: func() pmetric.Metrics {
 				metrics := pmetric.NewMetrics()
 				rm := metrics.ResourceMetrics().AppendEmpty()
@@ -40,6 +42,7 @@ func TestAddTargetInfo(t *testing.T) {
 				// scope should not be copied to target_info
 				sm := rm.ScopeMetrics().AppendEmpty()
 				sm.Scope().SetName("myscope")
+				sm.Scope().SetVersion("v0.0.1")
 
 				// other metrics should not be copied to target_info
 				metric := sm.Metrics().AppendEmpty()
@@ -63,9 +66,103 @@ func TestAddTargetInfo(t *testing.T) {
 				return rms
 			}(),
 		},
+		{
+			name:     "add scope info from scope metrics",
+			testFunc: AddScopeInfoMetric,
+			input: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+
+				// foo-label should be copied to target_info, not locationLabel
+				rm.Resource().Attributes().PutStr(locationLabel, "us-east")
+				rm.Resource().Attributes().PutStr("foo-label", "bar")
+
+				// scope should not be copied to target_info
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("myscope")
+				sm.Scope().SetVersion("v0.0.1")
+
+				// other metrics should not be copied to target_info
+				metric := sm.Metrics().AppendEmpty()
+				metric.SetName("baz-metric")
+				metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(2112)
+				return metrics
+			}(),
+			expected: func() pmetric.ResourceMetricsSlice {
+				rms := pmetric.NewResourceMetricsSlice()
+				rm := rms.AppendEmpty()
+
+				// resource attributes will be changed to a MonitoredResource on export, not in AddTargetInfo
+				// therefore they should still be present here
+				rm.Resource().Attributes().PutStr(locationLabel, "us-east")
+				rm.Resource().Attributes().PutStr("foo-label", "bar")
+
+				scopeInfo := rm.ScopeMetrics().AppendEmpty()
+				scopeInfoMetric := scopeInfo.Metrics().AppendEmpty()
+				scopeInfoMetric.SetName("otel_scope_info")
+				scopeInfoMetric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+				scopeInfoMetric.Gauge().DataPoints().At(0).Attributes().PutStr("otel_scope_name", "myscope")
+				scopeInfoMetric.Gauge().DataPoints().At(0).Attributes().PutStr("otel_scope_version", "v0.0.1")
+				return rms
+			}(),
+		},
+		{
+			name: "add both scope info and target info",
+			testFunc: func(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
+				extraMetrics := AddTargetInfoMetric(m)
+				AddScopeInfoMetric(m).MoveAndAppendTo(extraMetrics)
+				return extraMetrics
+			},
+			input: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+
+				// foo-label should be copied to target_info, not locationLabel
+				rm.Resource().Attributes().PutStr(locationLabel, "us-east")
+				rm.Resource().Attributes().PutStr("foo-label", "bar")
+
+				// scope should not be copied to target_info
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("myscope")
+				sm.Scope().SetVersion("v0.0.1")
+
+				// other metrics should not be copied to target_info
+				metric := sm.Metrics().AppendEmpty()
+				metric.SetName("baz-metric")
+				metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(2112)
+				return metrics
+			}(),
+			expected: func() pmetric.ResourceMetricsSlice {
+				rms := pmetric.NewResourceMetricsSlice()
+				rm := rms.AppendEmpty()
+
+				// resource attributes will be changed to a MonitoredResource on export, not in AddTargetInfo
+				// therefore they should still be present here
+				rm.Resource().Attributes().PutStr(locationLabel, "us-east")
+				rm.Resource().Attributes().PutStr("foo-label", "bar")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				metric := sm.Metrics().AppendEmpty()
+				metric.SetName("target_info")
+				metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("foo-label", "bar")
+
+				rm2 := rms.AppendEmpty()
+				rm2.Resource().Attributes().PutStr(locationLabel, "us-east")
+				rm2.Resource().Attributes().PutStr("foo-label", "bar")
+
+				scopeInfo := rm2.ScopeMetrics().AppendEmpty()
+				scopeInfoMetric := scopeInfo.Metrics().AppendEmpty()
+				scopeInfoMetric.SetName("otel_scope_info")
+				scopeInfoMetric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+				scopeInfoMetric.Gauge().DataPoints().At(0).Attributes().PutStr("otel_scope_name", "myscope")
+				scopeInfoMetric.Gauge().DataPoints().At(0).Attributes().PutStr("otel_scope_version", "v0.0.1")
+				return rms
+			}(),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rms := AddTargetInfo(tc.input)
+			rms := tc.testFunc(tc.input)
 			assert.EqualValues(t, tc.expected, rms)
 		})
 	}

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -136,7 +136,10 @@ var MetricsTestCases = []TestCase{
 			cfg.MetricConfig.MapMonitoredResource = googlemanagedprometheus.MapToPrometheusTarget
 			cfg.MetricConfig.ExtraMetrics = func(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
 				extraMetrics := googlemanagedprometheus.AddTargetInfoMetric(m)
-				googlemanagedprometheus.AddScopeInfoMetric(m).MoveAndAppendTo(extraMetrics)
+				scopeInfoMetrics := googlemanagedprometheus.AddScopeInfoMetric(m)
+				for i := 0; i < scopeInfoMetrics.Len(); i++ {
+					scopeInfoMetrics.At(i).ScopeMetrics().MoveAndAppendTo(extraMetrics.At(i).ScopeMetrics())
+				}
 				return extraMetrics
 			}
 			cfg.MetricConfig.InstrumentationLibraryLabels = false

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -17,6 +17,7 @@ package testcases
 import (
 	"strings"
 
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -133,7 +134,11 @@ var MetricsTestCases = []TestCase{
 			cfg.MetricConfig.SkipCreateMetricDescriptor = true
 			cfg.MetricConfig.GetMetricName = googlemanagedprometheus.GetMetricName
 			cfg.MetricConfig.MapMonitoredResource = googlemanagedprometheus.MapToPrometheusTarget
-			cfg.MetricConfig.ExtraMetrics = googlemanagedprometheus.AddTargetInfo
+			cfg.MetricConfig.ExtraMetrics = func(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
+				extraMetrics := googlemanagedprometheus.AddTargetInfoMetric(m)
+				googlemanagedprometheus.AddScopeInfoMetric(m).MoveAndAppendTo(extraMetrics)
+				return extraMetrics
+			}
 			cfg.MetricConfig.InstrumentationLibraryLabels = false
 			cfg.MetricConfig.ServiceResourceLabels = false
 			cfg.MetricConfig.EnableSumOfSquaredDeviation = true

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -677,6 +677,37 @@
               }
             }
           ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/otel_scope_info/gauge",
+            "labels": {
+              "otel_scope_name": "",
+              "otel_scope_version": ""
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1"
+              }
+            }
+          ]
         }
       ]
     }
@@ -703,7 +734,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "20"
+                  "int64Value": "21"
                 }
               }
             ]


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/543

Following the spec at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.16.0/specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1, this adds an `otel_scope_info` metric:

* `otel_scope_name` and `otel_scope_version` are populated if present on the scope
* additional scope attributes are added as labels
* this is broken into its own function so that it can be optionally configurable through the exporter