### PR TITLE
(logs exporter) Use a copy of shared log labels to prevent interference between LogRecords

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access.json
@@ -28,6 +28,12 @@
                   }
                 },
                 {
+                  "key": "single-attribute",
+                  "value": {
+                    "stringValue": "foobar"
+                  }
+                },
+                {
                   "key": "gcp.http_request",
                   "value": {
                     "kvlistValue": {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
@@ -22,7 +22,8 @@
             "protocol": "HTTP/1.1"
           },
           "labels": {
-            "log.file.name": "test.log"
+            "log.file.name": "test.log",
+            "single-attribute": "foobar"
           }
         },
         {

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -224,6 +224,12 @@ func (l logMapper) createEntries(ld plog.Logs) ([]*logpb.LogEntry, error) {
 			logLabels := mergeLogLabels(sl.Scope().Name(), sl.Scope().Version(), extraResourceLabels)
 
 			for k := 0; k < sl.LogRecords().Len(); k++ {
+				// make a copy of logLabels so that shared attributes (scope/resource) are copied across LogRecords,
+				// but that individual LogRecord attributes don't copy over to other Records via map reference.
+				entryLabels := make(map[string]string)
+				for k, v := range logLabels {
+					entryLabels[k] = v
+				}
 				log := sl.LogRecords().At(k)
 
 				// We can't just set logName on these entries otherwise the conversion to internal will fail
@@ -238,7 +244,7 @@ func (l logMapper) createEntries(ld plog.Logs) ([]*logpb.LogEntry, error) {
 				splitEntries, err := l.logToSplitEntries(
 					log,
 					mr,
-					logLabels,
+					entryLabels,
 					time.Now(),
 					logName,
 					projectID,


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/572

Reproduced the original issue by adding a unique attribute to an entry in the test fixtures (saw that attribute copied to every output entry). Code changes fixed this, and fixtures work as expected now.