### PR TITLE
Add scope_info labels to all GMP metrics where available

### DIFF
--- a/exporter/collector/googlemanagedprometheus/extra_metrics.go
+++ b/exporter/collector/googlemanagedprometheus/extra_metrics.go
@@ -52,7 +52,6 @@ func AddTargetInfoMetric(m pmetric.Metrics) {
 func AddScopeInfoMetric(m pmetric.Metrics) {
 	rms := m.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
-
 		sms := rms.At(i).ScopeMetrics()
 		for j := 0; j < sms.Len(); j++ {
 			sm := sms.At(j)

--- a/exporter/collector/googlemanagedprometheus/extra_metrics.go
+++ b/exporter/collector/googlemanagedprometheus/extra_metrics.go
@@ -21,21 +21,16 @@ import (
 
 // AddTargetInfoMetric inserts target_info for each resource.
 // First, it extracts the target_info metric from each ResourceMetric associated with the input pmetric.Metrics
-// and inserts it into each ScopeMetric for that resource, as specified in
+// and inserts it into a new ScopeMetric for that resource, as specified in
 // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.16.0/specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1
-func AddTargetInfoMetric(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
-	// initialize a new ResourceMetricSlice, which will hold our target_info metrics for each RM/Scope
-	resourceMetricSlice := pmetric.NewResourceMetricsSlice()
+func AddTargetInfoMetric(m pmetric.Metrics) {
 	rms := m.ResourceMetrics()
 	// loop over input (original) resource metrics
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 
-		// copy the Resource to a new ResourceMetric in our target_info slice, so we don't lose its attributes
-		rm.Resource().CopyTo(resourceMetricSlice.AppendEmpty().Resource())
-
 		// create the target_info metric as a Gauge with value 1
-		targetInfoMetric := resourceMetricSlice.At(i).ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		targetInfoMetric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		targetInfoMetric.SetName("target_info")
 
 		dataPoint := targetInfoMetric.SetEmptyGauge().DataPoints().AppendEmpty()
@@ -49,36 +44,80 @@ func AddTargetInfoMetric(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
 			return true
 		})
 	}
-	return resourceMetricSlice
 }
 
 // AddScopeInfoMetric adds the otel_scope_info metric to a Metrics slice as specified in
 // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.16.0/specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1
-func AddScopeInfoMetric(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
-	resourceMetricSlice := pmetric.NewResourceMetricsSlice()
+// It also updates all other metrics with the corresponding scope_name and scope_version attributes, if they are present.
+func AddScopeInfoMetric(m pmetric.Metrics) {
 	rms := m.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
-		resourceMetricSlice.AppendEmpty()
 
 		sms := rms.At(i).ScopeMetrics()
 		for j := 0; j < sms.Len(); j++ {
 			sm := sms.At(j)
 
-			scopeInfoMetric := resourceMetricSlice.At(i).ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			// Add otel_scope_info metric
+			scopeInfoMetric := sm.Metrics().AppendEmpty()
 			scopeInfoMetric.SetName("otel_scope_info")
-
 			dataPoint := scopeInfoMetric.SetEmptyGauge().DataPoints().AppendEmpty()
 			dataPoint.SetIntValue(1)
-
-			dataPoint.Attributes().PutStr("otel_scope_name", sm.Scope().Name())
-			dataPoint.Attributes().PutStr("otel_scope_version", sm.Scope().Version())
 			sm.Scope().Attributes().Range(func(k string, v pcommon.Value) bool {
 				dataPoint.Attributes().PutStr(k, v.AsString())
 				return true
 			})
+
+			// If present, add scope_name and scope_version attributes to each datapoint (including otel_scope_info)
+			if len(sm.Scope().Name()) == 0 && len(sm.Scope().Version()) == 0 {
+				continue
+			}
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				metric := sm.Metrics().At(k)
+				switch metric.Type() {
+				case pmetric.MetricTypeSum:
+					sum := metric.Sum()
+					points := sum.DataPoints()
+					for x := 0; x < points.Len(); x++ {
+						point := points.At(x)
+						point.Attributes().PutStr("otel_scope_name", sm.Scope().Name())
+						point.Attributes().PutStr("otel_scope_version", sm.Scope().Version())
+					}
+				case pmetric.MetricTypeGauge:
+					gauge := metric.Gauge()
+					points := gauge.DataPoints()
+					for x := 0; x < points.Len(); x++ {
+						point := points.At(x)
+						point.Attributes().PutStr("otel_scope_name", sm.Scope().Name())
+						point.Attributes().PutStr("otel_scope_version", sm.Scope().Version())
+					}
+				case pmetric.MetricTypeSummary:
+					summary := metric.Summary()
+					points := summary.DataPoints()
+					for x := 0; x < points.Len(); x++ {
+						point := points.At(x)
+						point.Attributes().PutStr("otel_scope_name", sm.Scope().Name())
+						point.Attributes().PutStr("otel_scope_version", sm.Scope().Version())
+					}
+				case pmetric.MetricTypeHistogram:
+					hist := metric.Histogram()
+					points := hist.DataPoints()
+					for x := 0; x < points.Len(); x++ {
+						point := points.At(x)
+						point.Attributes().PutStr("otel_scope_name", sm.Scope().Name())
+						point.Attributes().PutStr("otel_scope_version", sm.Scope().Version())
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					eh := metric.ExponentialHistogram()
+					points := eh.DataPoints()
+					for x := 0; x < points.Len(); x++ {
+						point := points.At(x)
+						point.Attributes().PutStr("otel_scope_name", sm.Scope().Name())
+						point.Attributes().PutStr("otel_scope_version", sm.Scope().Version())
+					}
+				}
+			}
 		}
 	}
-	return resourceMetricSlice
 }
 
 func isSpecialAttribute(attributeKey string) bool {

--- a/exporter/collector/googlemanagedprometheus/extra_metrics.go
+++ b/exporter/collector/googlemanagedprometheus/extra_metrics.go
@@ -56,6 +56,10 @@ func AddScopeInfoMetric(m pmetric.Metrics) {
 		sms := rms.At(i).ScopeMetrics()
 		for j := 0; j < sms.Len(); j++ {
 			sm := sms.At(j)
+			// If not present, skip this scope
+			if len(sm.Scope().Name()) == 0 && len(sm.Scope().Version()) == 0 {
+				continue
+			}
 
 			// Add otel_scope_info metric
 			scopeInfoMetric := sm.Metrics().AppendEmpty()
@@ -67,10 +71,6 @@ func AddScopeInfoMetric(m pmetric.Metrics) {
 				return true
 			})
 
-			// If present, add scope_name and scope_version attributes to each datapoint (including otel_scope_info)
-			if len(sm.Scope().Name()) == 0 && len(sm.Scope().Version()) == 0 {
-				continue
-			}
 			for k := 0; k < sm.Metrics().Len(); k++ {
 				metric := sm.Metrics().At(k)
 				switch metric.Type() {

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -135,12 +135,9 @@ var MetricsTestCases = []TestCase{
 			cfg.MetricConfig.GetMetricName = googlemanagedprometheus.GetMetricName
 			cfg.MetricConfig.MapMonitoredResource = googlemanagedprometheus.MapToPrometheusTarget
 			cfg.MetricConfig.ExtraMetrics = func(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
-				extraMetrics := googlemanagedprometheus.AddTargetInfoMetric(m)
-				scopeInfoMetrics := googlemanagedprometheus.AddScopeInfoMetric(m)
-				for i := 0; i < scopeInfoMetrics.Len(); i++ {
-					scopeInfoMetrics.At(i).ScopeMetrics().MoveAndAppendTo(extraMetrics.At(i).ScopeMetrics())
-				}
-				return extraMetrics
+				googlemanagedprometheus.AddScopeInfoMetric(m)
+				googlemanagedprometheus.AddTargetInfoMetric(m)
+				return m.ResourceMetrics()
 			}
 			cfg.MetricConfig.InstrumentationLibraryLabels = false
 			cfg.MetricConfig.ServiceResourceLabels = false

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
@@ -79,6 +79,26 @@
          },
          "scopeMetrics":[
             {
+               "scope":{
+                  "name":"very_real_scope",
+                  "version":"0.0.2"
+               },
+               "metrics":[
+                  {
+                     "name":"metric_with_a_scope",
+                     "description":"This metric was added to the fixture manually to test that scope attributes are applied when present",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":2112
+                           }
+                        ]
+                     }
+                  }
+               ]
+            },
+            {
                "scope":{},
                "metrics":[
                   {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -5,6 +5,68 @@
       "timeSeries": [
         {
           "metric": {
+            "type": "prometheus.googleapis.com/metric_with_a_scope/gauge",
+            "labels": {
+              "otel_scope_name": "very_real_scope",
+              "otel_scope_version": "0.0.2"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 2112
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/otel_scope_info/gauge",
+            "labels": {
+              "otel_scope_name": "very_real_scope",
+              "otel_scope_version": "0.0.2"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
             "type": "prometheus.googleapis.com/scrape_series_added/gauge"
           },
           "resource": {
@@ -644,33 +706,6 @@
         },
         {
           "metric": {
-            "type": "prometheus.googleapis.com/otel_scope_info/gauge"
-          },
-          "resource": {
-            "type": "prometheus_target",
-            "labels": {
-              "cluster": "rabbitmq-test-dev",
-              "instance": "10.92.5.2:15692",
-              "job": "demo",
-              "location": "us-central1-c",
-              "namespace": "default"
-            }
-          },
-          "metricKind": "GAUGE",
-          "valueType": "INT64",
-          "points": [
-            {
-              "interval": {
-                "endTime": "1970-01-01T00:00:00Z"
-              },
-              "value": {
-                "int64Value": "1"
-              }
-            }
-          ]
-        },
-        {
-          "metric": {
             "type": "prometheus.googleapis.com/target_info/gauge",
             "labels": {
               "cloud_platform": "gcp_kubernetes_engine",
@@ -730,7 +765,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "21"
+                  "int64Value": "22"
                 }
               }
             ]

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -644,16 +644,7 @@
         },
         {
           "metric": {
-            "type": "prometheus.googleapis.com/target_info/gauge",
-            "labels": {
-              "cloud_platform": "gcp_kubernetes_engine",
-              "http_scheme": "http",
-              "k8s_container_name": "rabbitmq",
-              "k8s_node_name": "10.92.5.2",
-              "k8s_pod_name": "rabbitmq-server-0",
-              "net_host_ip": "10.92.5.2",
-              "net_host_port": "15692"
-            }
+            "type": "prometheus.googleapis.com/otel_scope_info/gauge"
           },
           "resource": {
             "type": "prometheus_target",
@@ -680,10 +671,15 @@
         },
         {
           "metric": {
-            "type": "prometheus.googleapis.com/otel_scope_info/gauge",
+            "type": "prometheus.googleapis.com/target_info/gauge",
             "labels": {
-              "otel_scope_name": "",
-              "otel_scope_version": ""
+              "cloud_platform": "gcp_kubernetes_engine",
+              "http_scheme": "http",
+              "k8s_container_name": "rabbitmq",
+              "k8s_node_name": "10.92.5.2",
+              "k8s_pod_name": "rabbitmq-server-0",
+              "net_host_ip": "10.92.5.2",
+              "net_host_port": "15692"
             }
           },
           "resource": {

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -194,9 +194,9 @@ func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) e
 
 	// add extra metrics from the ExtraMetrics() extension point, combine into a new copy
 	if me.cfg.MetricConfig.ExtraMetrics != nil {
-		copy := pmetric.NewMetrics()
-		m.ResourceMetrics().CopyTo(copy.ResourceMetrics())
-		rms = me.cfg.MetricConfig.ExtraMetrics(copy)
+		metricsCopy := pmetric.NewMetrics()
+		m.ResourceMetrics().CopyTo(metricsCopy.ResourceMetrics())
+		rms = me.cfg.MetricConfig.ExtraMetrics(metricsCopy)
 	}
 
 	for i := 0; i < rms.Len(); i++ {

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -194,10 +194,9 @@ func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) e
 
 	// add extra metrics from the ExtraMetrics() extension point, combine into a new copy
 	if me.cfg.MetricConfig.ExtraMetrics != nil {
-		extraResourceMetrics := me.cfg.MetricConfig.ExtraMetrics(m)
-		rms = pmetric.NewResourceMetricsSlice()
-		m.ResourceMetrics().CopyTo(rms)
-		extraResourceMetrics.MoveAndAppendTo(rms)
+		copy := pmetric.NewMetrics()
+		m.ResourceMetrics().CopyTo(copy.ResourceMetrics())
+		rms = me.cfg.MetricConfig.ExtraMetrics(copy)
 	}
 
 	for i := 0; i < rms.Len(); i++ {


### PR DESCRIPTION
Follow up https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/571, due to misinterpreting the spec. `otel_scope_` labels should be applied to all metric data points in a given scope, not just metric data points for the `otel_scope_info` metric.

Previously, the ExtraMetrics extension point would just return a list of *new* metrics, to be merged into the existing list. Since we now want to modify metrics from the original list to add these labels, this had to be changed.

This changes the `AddTargetInfoMetric` and `AddScopeInfoMetric` functions to directly modify the input `pmetric.Metrics` object. To ensure original metrics aren't modified, the ExtraMetrics extension point in `metrics.go` has been updated to handle copying the input metrics and passing that copy to the ExtraMetrics function.

Ref https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/543