### PR TITLE
Add gzip compression option to metrics and logs

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -123,6 +123,7 @@ The following configuration options are supported:
 - `user_agent` (optional): Override the user agent string sent on requests to Cloud Monitoring (currently only applies to metrics). Specify `{{version}}` to include the application version number. Defaults to `opentelemetry-collector-contrib {{version}}`.
 - `use_insecure` (optional): If true. use gRPC as their communication transport. Only has effect if Endpoint is not "".
 - `timeout` (optional): Timeout for all API calls. If not set, defaults to 12 seconds.
+- `compression` (optional): Enable gzip compression on gRPC calls for Metrics or Logs. Valid values: `gzip`.
 - `resource_mappings` (optional): ResourceMapping defines mapping of resources from source (OpenCensus) to target (Google Cloud).
   - `label_mappings` (optional): Optional flag signals whether we can proceed with transformation if a label is missing in the resource.
 - `retry_on_failure` (optional): Configuration for how to handle retries when sending data to Google Cloud fails.
@@ -185,6 +186,7 @@ exporters:
     metric:
       prefix: prefix
       skip_create_descriptor: true
+      compression: gzip
 
     log:
       default_log_name: my-app

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -31,12 +31,11 @@ import (
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding/gzip"
 )
 
 const (
 	DefaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
-
-	CompressionGzip = "gzip"
 )
 
 // Config defines configuration for Google Cloud exporter.
@@ -217,11 +216,14 @@ func ValidateConfig(cfg Config) error {
 		}
 	}
 
-	if len(cfg.LogConfig.ClientConfig.Compression) > 0 && cfg.LogConfig.ClientConfig.Compression != CompressionGzip {
-		return fmt.Errorf("unknown compression option '%s', allowed values: '', 'gzip'")
+	if len(cfg.LogConfig.ClientConfig.Compression) > 0 && cfg.LogConfig.ClientConfig.Compression != gzip.Name {
+		return fmt.Errorf("unknown compression option '%s', allowed values: '', 'gzip'", cfg.LogConfig.ClientConfig.Compression)
 	}
-	if len(cfg.MetricConfig.ClientConfig.Compression) > 0 && cfg.MetricConfig.ClientConfig.Compression != CompressionGzip {
-		return fmt.Errorf("unknown compression option '%s', allowed values: '', 'gzip'")
+	if len(cfg.MetricConfig.ClientConfig.Compression) > 0 && cfg.MetricConfig.ClientConfig.Compression != gzip.Name {
+		return fmt.Errorf("unknown compression option '%s', allowed values: '', 'gzip'", cfg.MetricConfig.ClientConfig.Compression)
+	}
+	if len(cfg.TraceConfig.ClientConfig.Compression) > 0 {
+		return fmt.Errorf("traces.compression invalid: compression is only available for logs and metrics")
 	}
 
 	return nil

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -35,6 +35,8 @@ import (
 
 const (
 	DefaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
+
+	CompressionGzip = "gzip"
 )
 
 // Config defines configuration for Google Cloud exporter.
@@ -62,6 +64,9 @@ type ClientConfig struct {
 	GetClientOptions func() []option.ClientOption
 
 	Endpoint string `mapstructure:"endpoint"`
+	// Compression specifies the compression format for Metrics and Logging gRPC requests.
+	// Supported values: gzip.
+	Compression string `mapstructure:"compression"`
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
 	// GRPCPoolSize sets the size of the connection pool in the GCP client
@@ -211,6 +216,14 @@ func ValidateConfig(cfg Config) error {
 			return fmt.Errorf("unable to parse resource filter regex: %s", err.Error())
 		}
 	}
+
+	if len(cfg.LogConfig.ClientConfig.Compression) > 0 && cfg.LogConfig.ClientConfig.Compression != CompressionGzip {
+		return fmt.Errorf("unknown compression option '%s', allowed values: '', 'gzip'")
+	}
+	if len(cfg.MetricConfig.ClientConfig.Compression) > 0 && cfg.MetricConfig.ClientConfig.Compression != CompressionGzip {
+		return fmt.Errorf("unknown compression option '%s', allowed values: '', 'gzip'")
+	}
+
 	return nil
 }
 

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.34.2
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/google/go-cmp v0.5.9
-	github.com/googleapis/gax-go/v2 v2.6.0
+	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rc2
@@ -41,7 +41,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
-	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.34.2
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/google/go-cmp v0.5.9
+	github.com/googleapis/gax-go/v2 v2.6.0
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rc2

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -218,5 +218,13 @@ var MetricsTestCases = []TestCase{
 		ExpectFixturePath:    "testdata/fixtures/metrics/prometheus_empty_buckets_expected.json",
 		SkipForSDK:           true,
 	},
+	{
+		Name:                 "Basic Counter with gzip compression",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/basic_counter_metrics.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/basic_counter_metrics_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.MetricConfig.ClientConfig.Compression = "gzip"
+		},
+	},
 	// TODO: Add integration tests for workload.googleapis.com metrics from the ops agent
 }

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -29,7 +29,11 @@ import (
 	loggingv2 "cloud.google.com/go/logging/apiv2"
 	logpb "cloud.google.com/go/logging/apiv2/loggingpb"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/googleapis/gax-go/v2"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"
 
@@ -138,6 +142,11 @@ func NewGoogleCloudLogsExporter(
 	loggingClient, err := loggingv2.NewClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.LogConfig.ClientConfig.Compression == CompressionGzip {
+		loggingClient.CallOptions.WriteLogEntries = append(loggingClient.CallOptions.WriteLogEntries,
+			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
 	}
 
 	obs := selfObservability{

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -144,7 +144,7 @@ func NewGoogleCloudLogsExporter(
 		return nil, err
 	}
 
-	if cfg.LogConfig.ClientConfig.Compression == CompressionGzip {
+	if cfg.LogConfig.ClientConfig.Compression == gzip.Name {
 		loggingClient.CallOptions.WriteLogEntries = append(loggingClient.CallOptions.WriteLogEntries,
 			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
 	}

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -150,7 +150,7 @@ func NewGoogleCloudMetricsExporter(
 		return nil, err
 	}
 
-	if cfg.MetricConfig.ClientConfig.Compression == CompressionGzip {
+	if cfg.MetricConfig.ClientConfig.Compression == gzip.Name {
 		client.CallOptions.CreateMetricDescriptor = append(client.CallOptions.CreateMetricDescriptor,
 			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
 		client.CallOptions.CreateTimeSeries = append(client.CallOptions.CreateTimeSeries,

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -42,10 +42,14 @@ import (
 	"google.golang.org/genproto/googleapis/api/label"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/googleapis/gax-go/v2"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/datapointstorage"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization"
@@ -145,6 +149,16 @@ func NewGoogleCloudMetricsExporter(
 	if err != nil {
 		return nil, err
 	}
+
+	if cfg.MetricConfig.ClientConfig.Compression == CompressionGzip {
+		client.CallOptions.CreateMetricDescriptor = append(client.CallOptions.CreateMetricDescriptor,
+			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+		client.CallOptions.CreateTimeSeries = append(client.CallOptions.CreateTimeSeries,
+			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+		client.CallOptions.CreateServiceTimeSeries = append(client.CallOptions.CreateServiceTimeSeries,
+			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+	}
+
 	obs := selfObservability{log: log}
 	shutdown := make(chan struct{})
 	normalizer := normalization.NewDisabledNormalizer()

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -21,6 +21,7 @@ require (
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.34.2
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.34.2
+	github.com/googleapis/gax-go/v2 v2.6.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/multierr v1.8.0
 )

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -21,7 +21,7 @@ require (
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.34.2
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.34.2
-	github.com/googleapis/gax-go/v2 v2.6.0
+	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/multierr v1.8.0
 )
@@ -38,7 +38,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
-	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -56,6 +56,8 @@ type options struct {
 	// resource if the resource does not inherently belong to a specific
 	// project, e.g. on-premise resource like k8s_container or generic_task.
 	projectID string
+	// compression enables gzip compression on gRPC calls.
+	compression string
 	// monitoringClientOptions are additional options to be passed
 	// to the underlying Stackdriver Monitoring API client.
 	// Optional.
@@ -136,5 +138,12 @@ func NoAttributes(attribute.KeyValue) bool {
 func WithDisableCreateMetricDescriptors() func(o *options) {
 	return func(o *options) {
 		o.disableCreateMetricDescriptors = true
+	}
+}
+
+// WithCompression sets the compression to use for gRPC requests.
+func WithCompression(c string) func(o *options) {
+	return func(o *options) {
+		o.compression = c
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/544

This copies GMP's [compression setting](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/30ce1d152c6ecfcde8e57b4553dadc895b233708/pkg/operator/apis/monitoring/v1/types.go#L115) by exposing a string option for users to specify the type of compression to enable for gRPC calls. Currently the only supported option is `gzip`.

This only works for logs and metrics, trying to wire it up for Cloud Trace gave this error:
```
2023/01/26 19:31:25 failed to export to Google Cloud Trace: rpc error: code = InvalidArgument desc = Error skipping unknown field of a message with tag:31, type:google.devtools.cloudtrace.v2.BatchWriteSpansRequest
error details: name = DebugInfo detail = Was unable to extract resource containers for Chemist from the incoming request. Error message during extraction: Error skipping unknown field of a message with tag:31, type:google.devtools.cloudtrace.v2.BatchWriteSpansRequest stack =
2023-01-26T19:31:25.980Z	info	exporterhelper/queued_retry.go:426	Exporting failed. Will retry the request after interval.	{"kind": "exporter", "data_type": "traces", "name": "googlecloud", "error": "rpc error: code = InvalidArgument desc = Error skipping unknown field of a message with tag:31, type:google.devtools.cloudtrace.v2.BatchWriteSpansRequest\nerror details: name = DebugInfo detail = Was unable to extract resource containers for Chemist from the incoming request. Error message during extraction: Error skipping unknown field of a message with tag:31, type:google.devtools.cloudtrace.v2.BatchWriteSpansRequest stack =", "interval": "6.722764325s"}
2023/01/26 19:31:32 failed to export to Google Cloud Trace: rpc error: code = InvalidArgument desc = Error skipping unknown field of a message with tag:31, type:google.devtools.cloudtrace.v2.BatchWriteSpansRequest
error details: name = DebugInfo detail = Was unable to extract resource containers for Chemist from the incoming request. Error message during extraction: Error skipping unknown field of a message with tag:31, type:google.devtools.cloudtrace.v2.BatchWriteSpansRequest stack =
```