### PR TITLE
Enable destination_project_quota for logs exporter

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -322,8 +322,8 @@ By default, the exporter sends telemetry to the project specified by `project` i
 
 ### Multi-Project quota usage
 
-The `gcp.project.id` label can be combined with the `destination_project_quota` option to attribute quota usage to the project parsed by the label. This feature is currently only available
-for traces and metrics. The Collector's default service account will need `roles/serviceusage.serviceUsageConsumer` IAM permissions in the destination quota project.
+The `gcp.project.id` label can be combined with the `destination_project_quota` option to attribute quota usage to the project parsed by the label. This feature is available
+for traces, metrics, and logs. The Collector's default service account will need `roles/serviceusage.serviceUsageConsumer` IAM permissions in the destination quota project.
 
 Note that this option will not work  if a quota project is already defined in your Collector's GCP credentials. In this case, the telemetry will fail to export with a "project not found" error.
 This can be done by manually editing your [ADC file](https://cloud.google.com/docs/authentication/application-default-credentials#personal) (if it exists) to remove the `quota_project_id` entry line.

--- a/exporter/collector/integrationtest/testcases/testcases_logs.go
+++ b/exporter/collector/integrationtest/testcases/testcases_logs.go
@@ -33,6 +33,14 @@ var LogsTestCases = []TestCase{
 		ExpectFixturePath:    "testdata/fixtures/logs/logs_multi_project_expected.json",
 	},
 	{
+		Name:                 "Multi-project logs with destination_project_quota enabled",
+		OTLPInputFixturePath: "testdata/fixtures/logs/logs_multi_project.json",
+		ExpectFixturePath:    "testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.DestinationProjectQuota = true
+		},
+	},
+	{
 		Name:                 "Logs with scope information",
 		OTLPInputFixturePath: "testdata/fixtures/logs/logs_apache_error_scope.json",
 		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_error_scope_expected.json",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -1,0 +1,780 @@
+{
+  "writeLogEntriesRequests": [
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/lamp.png",
+            "status": 200,
+            "responseSize": "51164",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/favicon.ico",
+            "status": 200,
+            "responseSize": "3990",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/lamp.png",
+            "status": 200,
+            "responseSize": "51164",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/favicon.ico",
+            "status": 200,
+            "responseSize": "3990",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    }
+  ]
+}

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -226,7 +226,7 @@ func (l *LogsExporter) PushLogs(ctx context.Context, ld plog.Logs) error {
 func (l logMapper) createEntries(ld plog.Logs) (map[string][]*logpb.LogEntry, error) {
 	// if destination_project_quota is enabled, projectMapKey will be the name of the project for each batch of entries
 	// otherwise, we can mix project entries for more efficient batching and store all entries in a single list
-	projectMapKey := "google-destination-quota-disabled"
+	projectMapKey := ""
 	errors := []error{}
 	entries := make(map[string][]*logpb.LogEntry)
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/558

Adding this was pretty simple, the current logic builds a single LogEntry list and then batches those entries as needed to keep each batch request under the GCP size limit. We can do this without caring about the project for each entry because, while batch LogEntry requests do have a field for project, the request will honor individual project IDs set on each entry in the batch. (Traces and Metrics don't have that)

However, adding destination project quota brings us back to caring about the project at the request/batch level. That's easy to do using a `map[string]LogEntry`, which is similar to how traces and metrics batch.

But, it would be optimal to revert to the efficient, possibly mixed-project batching when `destination_project_quota` is disabled. The best I could think of to do this is to drop everything in a single key in the map, and reuse the rest of the logic. I'm not very satisfied with that, because I don't like using a magic key and it couples the `destination_project_quota` config option to multiple places in the code. So this might be more refactorable, but for unblocking the feature this will do fine imo, but I'm open to ideas