### PR TITLE
Sort fixtures in log exporter tests

### DIFF
--- a/exporter/collector/integrationtest/logs_test.go
+++ b/exporter/collector/integrationtest/logs_test.go
@@ -16,6 +16,7 @@ package integrationtest
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -53,12 +54,20 @@ func TestLogs(t *testing.T) {
 				t,
 				timestamp,
 			)
+			sort.Slice(expectFixture.WriteLogEntriesRequests, func(i, j int) bool {
+				return expectFixture.WriteLogEntriesRequests[i].LogName < expectFixture.WriteLogEntriesRequests[j].LogName
+			})
+
+			fixture := &protos.LogExpectFixture{
+				WriteLogEntriesRequests: testServer.CreateWriteLogEntriesRequests(),
+			}
+			sort.Slice(fixture.WriteLogEntriesRequests, func(i, j int) bool {
+				return fixture.WriteLogEntriesRequests[i].LogName < fixture.WriteLogEntriesRequests[j].LogName
+			})
 
 			diff := DiffLogProtos(
 				t,
-				&protos.LogExpectFixture{
-					WriteLogEntriesRequests: testServer.CreateWriteLogEntriesRequests(),
-				},
+				fixture,
 				expectFixture,
 			)
 


### PR DESCRIPTION
I think following https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/579, failures like [this one](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/actions/runs/4085111271/jobs/7043254353#step:6:469) are due to project/log names not being sorted in the fixtures. We made similar changes to traces and metrics (https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/469, https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/445, https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/429), but not logs. 