### PR TITLE
Actually add logs fixture sorting

### DIFF
--- a/exporter/collector/integrationtest/logs_test.go
+++ b/exporter/collector/integrationtest/logs_test.go
@@ -54,15 +54,38 @@ func TestLogs(t *testing.T) {
 				t,
 				timestamp,
 			)
+
+			// sort the entries in each request
+			for listIndex := 0; listIndex < len(expectFixture.WriteLogEntriesRequests); listIndex++ {
+				sort.Slice(expectFixture.WriteLogEntriesRequests[listIndex].Entries, func(i, j int) bool {
+					return expectFixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < expectFixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+				})
+			}
+			// sort each request. if the requests have the same name (or just as likely, they both have no name set at the request level),
+			// peek at the first entry's logname in the request
 			sort.Slice(expectFixture.WriteLogEntriesRequests, func(i, j int) bool {
-				return expectFixture.WriteLogEntriesRequests[i].LogName < expectFixture.WriteLogEntriesRequests[j].LogName
+				if expectFixture.WriteLogEntriesRequests[i].LogName != expectFixture.WriteLogEntriesRequests[j].LogName {
+					return expectFixture.WriteLogEntriesRequests[i].LogName < expectFixture.WriteLogEntriesRequests[j].LogName
+				}
+				return expectFixture.WriteLogEntriesRequests[i].Entries[0].LogName < expectFixture.WriteLogEntriesRequests[j].Entries[0].LogName
 			})
 
 			fixture := &protos.LogExpectFixture{
 				WriteLogEntriesRequests: testServer.CreateWriteLogEntriesRequests(),
 			}
+			// sort the entries in each request
+			for listIndex := 0; listIndex < len(fixture.WriteLogEntriesRequests); listIndex++ {
+				sort.Slice(fixture.WriteLogEntriesRequests[listIndex].Entries, func(i, j int) bool {
+					return fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+				})
+			}
+			// sort each request. if the requests have the same name (or just as likely, they both have no name set at the request level),
+			// peek at the first entry's logname in the request
 			sort.Slice(fixture.WriteLogEntriesRequests, func(i, j int) bool {
-				return fixture.WriteLogEntriesRequests[i].LogName < fixture.WriteLogEntriesRequests[j].LogName
+				if fixture.WriteLogEntriesRequests[i].LogName != fixture.WriteLogEntriesRequests[j].LogName {
+					return fixture.WriteLogEntriesRequests[i].LogName < fixture.WriteLogEntriesRequests[j].LogName
+				}
+				return fixture.WriteLogEntriesRequests[i].Entries[0].LogName < fixture.WriteLogEntriesRequests[j].Entries[0].LogName
 			})
 
 			diff := DiffLogProtos(

--- a/exporter/collector/integrationtest/logs_test.go
+++ b/exporter/collector/integrationtest/logs_test.go
@@ -58,7 +58,10 @@ func TestLogs(t *testing.T) {
 			// sort the entries in each request
 			for listIndex := 0; listIndex < len(expectFixture.WriteLogEntriesRequests); listIndex++ {
 				sort.Slice(expectFixture.WriteLogEntriesRequests[listIndex].Entries, func(i, j int) bool {
-					return expectFixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < expectFixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+					if expectFixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName != expectFixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName {
+						return expectFixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < expectFixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+					}
+					return expectFixture.WriteLogEntriesRequests[listIndex].Entries[i].String() < expectFixture.WriteLogEntriesRequests[listIndex].Entries[j].String()
 				})
 			}
 			// sort each request. if the requests have the same name (or just as likely, they both have no name set at the request level),
@@ -76,7 +79,10 @@ func TestLogs(t *testing.T) {
 			// sort the entries in each request
 			for listIndex := 0; listIndex < len(fixture.WriteLogEntriesRequests); listIndex++ {
 				sort.Slice(fixture.WriteLogEntriesRequests[listIndex].Entries, func(i, j int) bool {
-					return fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+					if fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName {
+						return fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+					}
+					return fixture.WriteLogEntriesRequests[listIndex].Entries[i].String() < fixture.WriteLogEntriesRequests[listIndex].Entries[j].String()
 				})
 			}
 			// sort each request. if the requests have the same name (or just as likely, they both have no name set at the request level),

--- a/exporter/collector/integrationtest/testcases/testcase.go
+++ b/exporter/collector/integrationtest/testcases/testcase.go
@@ -239,7 +239,10 @@ func NormalizeLogFixture(t testing.TB, fixture *protos.LogExpectFixture) {
 	for listIndex, req := range fixture.WriteLogEntriesRequests {
 		// sort the entries in each request
 		sort.Slice(fixture.WriteLogEntriesRequests[listIndex].Entries, func(i, j int) bool {
-			return fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+			if fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName {
+				return fixture.WriteLogEntriesRequests[listIndex].Entries[i].LogName < fixture.WriteLogEntriesRequests[listIndex].Entries[j].LogName
+			}
+			return fixture.WriteLogEntriesRequests[listIndex].Entries[i].String() < fixture.WriteLogEntriesRequests[listIndex].Entries[j].String()
 		})
 		for _, entry := range req.Entries {
 			// Normalize timestamps if they are set

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
@@ -35,13 +35,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/lamp.png",
+            "requestUrl": "/favicon.ico",
             "status": 200,
-            "responseSize": "51164",
+            "responseSize": "3990",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -58,13 +58,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/favicon.ico",
+            "requestUrl": "/lamp.png",
             "status": 200,
-            "responseSize": "3990",
+            "responseSize": "51164",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -357,16 +357,8 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
           "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "4429",
-            "remoteIp": "127.0.0.2",
-            "protocol": "HTTP/1.1"
-          },
           "labels": {
             "log.file.name": "test.log"
           }
@@ -380,8 +372,16 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
           "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
           "labels": {
             "log.file.name": "test.log"
           }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -38,13 +38,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/lamp.png",
+            "requestUrl": "/favicon.ico",
             "status": 200,
-            "responseSize": "51164",
+            "responseSize": "3990",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -65,13 +65,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/favicon.ico",
+            "requestUrl": "/lamp.png",
             "status": 200,
-            "responseSize": "3990",
+            "responseSize": "51164",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -416,16 +416,8 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
           "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "4429",
-            "remoteIp": "127.0.0.2",
-            "protocol": "HTTP/1.1"
-          },
           "labels": {
             "custom_foobar": "baz",
             "log.file.name": "test.log",
@@ -443,8 +435,16 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
           "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
           "labels": {
             "custom_foobar": "baz",
             "log.file.name": "test.log",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
@@ -31,12 +31,11 @@
             }
           },
           "jsonPayload": {
-            "message": "[pid 417653:tid 139808755448704] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]",
-            "severity": "warn",
-            "time": "Tue Apr 26 00:46:21.457314 2022"
+            "message": "[pid 417653:tid 139808755448704] AH00094: Command line: '/usr/local/apache/bin/httpd'",
+            "severity": "notice",
+            "time": "Tue Apr 26 00:46:21.503003 2022"
           },
           "timestamp": "1970-01-01T00:00:00Z",
-          "severity": "WARNING",
           "labels": {
             "log.file.name": "test.log"
           }
@@ -54,25 +53,6 @@
             "message": "[pid 417653:tid 139808755448704] AH00489: Apache/2.4.46 (Unix) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.6 configured -- resuming normal operations",
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.502940 2022"
-          },
-          "timestamp": "1970-01-01T00:00:00Z",
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/apache-error-fixture",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "jsonPayload": {
-            "message": "[pid 417653:tid 139808755448704] AH00094: Command line: '/usr/local/apache/bin/httpd'",
-            "severity": "notice",
-            "time": "Tue Apr 26 00:46:21.503003 2022"
           },
           "timestamp": "1970-01-01T00:00:00Z",
           "labels": {
@@ -108,6 +88,26 @@
             }
           },
           "jsonPayload": {
+            "message": "[pid 417653:tid 139808755448704] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]",
+            "severity": "warn",
+            "time": "Tue Apr 26 00:46:21.457314 2022"
+          },
+          "timestamp": "1970-01-01T00:00:00Z",
+          "severity": "WARNING",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/apache-error-fixture",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "jsonPayload": {
             "message": "[pid 712:tid 140159306111872] AH01232: suEXEC mechanism enabled (wrapper: /usr/local/apache/bin/suexec)",
             "severity": "notice",
             "time": "Tue Apr 26 22:48:34.466058 2022"
@@ -127,12 +127,11 @@
             }
           },
           "jsonPayload": {
-            "message": "[pid 769:tid 140159306111872] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]",
-            "severity": "warn",
-            "time": "Tue Apr 26 22:48:34.740290 2022"
+            "message": "[pid 769:tid 140159306111872] AH00094: Command line: '/usr/local/apache/bin/httpd'",
+            "severity": "notice",
+            "time": "Tue Apr 26 22:48:35.606298 2022"
           },
           "timestamp": "1970-01-01T00:00:00Z",
-          "severity": "WARNING",
           "labels": {
             "log.file.name": "test.log"
           }
@@ -166,11 +165,12 @@
             }
           },
           "jsonPayload": {
-            "message": "[pid 769:tid 140159306111872] AH00094: Command line: '/usr/local/apache/bin/httpd'",
-            "severity": "notice",
-            "time": "Tue Apr 26 22:48:35.606298 2022"
+            "message": "[pid 769:tid 140159306111872] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]",
+            "severity": "warn",
+            "time": "Tue Apr 26 22:48:34.740290 2022"
           },
           "timestamp": "1970-01-01T00:00:00Z",
+          "severity": "WARNING",
           "labels": {
             "log.file.name": "test.log"
           }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -34,13 +34,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/lamp.png",
+            "requestUrl": "/favicon.ico",
             "status": 200,
-            "responseSize": "51164",
+            "responseSize": "3990",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -57,13 +57,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/favicon.ico",
+            "requestUrl": "/lamp.png",
             "status": 200,
-            "responseSize": "3990",
+            "responseSize": "51164",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -356,16 +356,8 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
           "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "4429",
-            "remoteIp": "127.0.0.2",
-            "protocol": "HTTP/1.1"
-          },
           "labels": {
             "log.file.name": "test.log"
           }
@@ -379,8 +371,16 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
           "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
           "labels": {
             "log.file.name": "test.log"
           }
@@ -422,13 +422,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/lamp.png",
+            "requestUrl": "/favicon.ico",
             "status": 200,
-            "responseSize": "51164",
+            "responseSize": "3990",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -445,13 +445,13 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
-            "requestUrl": "/favicon.ico",
+            "requestUrl": "/lamp.png",
             "status": 200,
-            "responseSize": "3990",
+            "responseSize": "51164",
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
@@ -744,16 +744,8 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
           "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "4429",
-            "remoteIp": "127.0.0.2",
-            "protocol": "HTTP/1.1"
-          },
           "labels": {
             "log.file.name": "test.log"
           }
@@ -767,8 +759,16 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
           "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
           "labels": {
             "log.file.name": "test.log"
           }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -3,7 +3,7 @@
     {
       "entries": [
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -26,7 +26,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -49,7 +49,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -72,7 +72,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -95,7 +95,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -118,7 +118,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -141,7 +141,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -164,7 +164,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -187,7 +187,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -210,7 +210,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -233,7 +233,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -256,7 +256,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -279,7 +279,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -302,7 +302,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -325,7 +325,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -348,7 +348,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -371,7 +371,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -391,7 +391,7 @@
     {
       "entries": [
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -414,7 +414,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -437,7 +437,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -460,7 +460,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -483,7 +483,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -506,7 +506,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -529,7 +529,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -552,7 +552,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -575,7 +575,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -598,7 +598,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -621,7 +621,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -644,7 +644,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -667,7 +667,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -690,7 +690,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -713,7 +713,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -736,7 +736,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -759,7 +759,7 @@
           }
         },
         {
-          "logName": "projects/fake-other-project/logs/multi-project",
+          "logName": "projects/fakeprojectid/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
@@ -3,214 +3,7 @@
     {
       "entries": [
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/lamp.png",
-            "status": 200,
-            "responseSize": "51164",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/favicon.ico",
-            "status": 200,
-            "responseSize": "3990",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -233,7 +26,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -251,136 +44,6 @@
             "remoteIp": "127.0.0.1",
             "protocol": "HTTP/1.1"
           },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "4429",
-            "remoteIp": "127.0.0.2",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
-          "timestamp": "1970-01-01T00:00:00Z",
           "labels": {
             "log.file.name": "test.log"
           }
@@ -417,145 +80,7 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/lamp.png",
-            "status": 200,
-            "responseSize": "51164",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/favicon.ico",
-            "status": 200,
-            "responseSize": "3990",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
@@ -647,76 +172,7 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
@@ -764,6 +220,550 @@
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
           "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/favicon.ico",
+            "status": 200,
+            "responseSize": "3990",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/lamp.png",
+            "status": 200,
+            "responseSize": "51164",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/favicon.ico",
+            "status": 200,
+            "responseSize": "3990",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/lamp.png",
+            "status": 200,
+            "responseSize": "51164",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
           "labels": {
             "log.file.name": "test.log"
           }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
@@ -11,321 +11,7 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "4429",
-            "remoteIp": "127.0.0.2",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fake-other-project/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
@@ -386,7 +72,53 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -409,7 +141,214 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -424,7 +363,7 @@
           }
         },
         {
-          "logName": "projects/fakeprojectid/logs/multi-project",
+          "logName": "projects/fake-other-project/logs/multi-project",
           "resource": {
             "type": "gce_instance",
             "labels": {
@@ -455,260 +394,7 @@
               "zone": ""
             }
           },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/multi-project",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
           "timestamp": "1970-01-01T00:00:00Z",
           "httpRequest": {
             "requestMethod": "GET",
@@ -762,6 +448,320 @@
             "status": 200,
             "responseSize": "51164",
             "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/multi-project",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
             "protocol": "HTTP/1.1"
           },
           "labels": {


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/580 didn't work because I was just checking the `request.LogName` field, which our exporter doesn't set (we set individual entry log names ie, `request.Entries[i].LogName`). I also forgot to add the matching sort to the fixture generator.

The tests still passed due to the randomness of the fixture ordering (until post-merge https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/actions/runs/4086503881). But, I should have caught this based on the fact that fixtures weren't updated in #580.

This sorts each *entry* in each *request*, then sorts the requests based on either their LogName or the LogName of the first entry in the request. This should be sufficiently deterministic for our tests.