### PR TITLE
Fix infinite loop on log exporter batch write

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -46,8 +46,8 @@ type Config struct {
 	ProjectID               string            `mapstructure:"project"`
 	UserAgent               string            `mapstructure:"user_agent"`
 	ImpersonateConfig       ImpersonateConfig `mapstructure:"impersonate"`
-	TraceConfig             TraceConfig       `mapstructure:"trace"`
 	LogConfig               LogConfig         `mapstructure:"log"`
+	TraceConfig             TraceConfig       `mapstructure:"trace"`
 	MetricConfig            MetricConfig      `mapstructure:"metric"`
 	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
 }

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -46,9 +46,9 @@ type Config struct {
 	ProjectID               string            `mapstructure:"project"`
 	UserAgent               string            `mapstructure:"user_agent"`
 	ImpersonateConfig       ImpersonateConfig `mapstructure:"impersonate"`
-	LogConfig               LogConfig         `mapstructure:"log"`
 	TraceConfig             TraceConfig       `mapstructure:"trace"`
 	MetricConfig            MetricConfig      `mapstructure:"metric"`
+	LogConfig               LogConfig         `mapstructure:"log"`
 	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
 }
 
@@ -163,6 +163,12 @@ type LogConfig struct {
 	// Defaults to empty, which won't include any additional resource labels.
 	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
 	ClientConfig    ClientConfig     `mapstructure:",squash"`
+	// MaxEntrySize defines the maximum size of an individual LogEntry in bytes. If a LogEntry
+	// is larger than this size, it will be split and sent as multiple entries. Default: 256000 (256KB).
+	MaxEntrySize int `mapstructure:"max_entry_size"`
+	// MaxRequestSize defines the maximum size of a batch WriteLogEntriesRequest in bytes. If a request
+	// is larger than this size, it will be split into multiple requests. Default: 10000000 (10MB).
+	MaxRequestSize int `mapstructure:"max_request_size"`
 	// ServiceResourceLabels, if true, causes the exporter to copy OTel's
 	// service.name, service.namespace, and service.instance.id resource attributes into the Cloud Logging LogEntry labels.
 	// Disabling this option does not prevent resource_filters from adding those labels. Default is true.

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -47,8 +47,8 @@ type Config struct {
 	UserAgent               string            `mapstructure:"user_agent"`
 	ImpersonateConfig       ImpersonateConfig `mapstructure:"impersonate"`
 	TraceConfig             TraceConfig       `mapstructure:"trace"`
-	MetricConfig            MetricConfig      `mapstructure:"metric"`
 	LogConfig               LogConfig         `mapstructure:"log"`
+	MetricConfig            MetricConfig      `mapstructure:"metric"`
 	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
 }
 
@@ -163,12 +163,6 @@ type LogConfig struct {
 	// Defaults to empty, which won't include any additional resource labels.
 	ResourceFilters []ResourceFilter `mapstructure:"resource_filters"`
 	ClientConfig    ClientConfig     `mapstructure:",squash"`
-	// MaxEntrySize defines the maximum size of an individual LogEntry in bytes. If a LogEntry
-	// is larger than this size, it will be split and sent as multiple entries. Default: 256000 (256KB).
-	MaxEntrySize int `mapstructure:"max_entry_size"`
-	// MaxRequestSize defines the maximum size of a batch WriteLogEntriesRequest in bytes. If a request
-	// is larger than this size, it will be split into multiple requests. Default: 10000000 (10MB).
-	MaxRequestSize int `mapstructure:"max_request_size"`
 	// ServiceResourceLabels, if true, causes the exporter to copy OTel's
 	// service.name, service.namespace, and service.instance.id resource attributes into the Cloud Logging LogEntry labels.
 	// Disabling this option does not prevent resource_filters from adding those labels. Default is true.

--- a/exporter/collector/integrationtest/cmd/recordfixtures/main.go
+++ b/exporter/collector/integrationtest/cmd/recordfixtures/main.go
@@ -103,7 +103,7 @@ func recordLogs(ctx context.Context, t *FakeTesting, timestamp time.Time) {
 		}
 		func() {
 			logs := test.LoadOTLPLogsInput(t, timestamp)
-			testServerExporter := integrationtest.NewLogTestExporter(ctx, t, testServer, test.CreateLogConfig())
+			testServerExporter := integrationtest.NewLogTestExporter(ctx, t, testServer, test.CreateLogConfig(), test.ConfigureLogsExporter)
 
 			require.NoError(t, testServerExporter.PushLogs(ctx, logs), "failed to export logs to local test server")
 			require.NoError(t, testServerExporter.Shutdown(ctx))

--- a/exporter/collector/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/integrationtest/inmemoryocexporter.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/integrationtest/protos"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/logsutil"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock"
 )
 
@@ -174,6 +175,7 @@ func NewLogTestExporter(
 	t testing.TB,
 	l *cloudmock.LogsTestServer,
 	cfg collector.Config,
+	extraConfig *logsutil.ExporterConfig,
 ) *collector.LogsExporter {
 	cfg.LogConfig.ClientConfig.Endpoint = l.Endpoint
 	cfg.LogConfig.ClientConfig.UseInsecure = true
@@ -188,6 +190,10 @@ func NewLogTestExporter(
 		logger,
 	)
 	require.NoError(t, err)
+
+	if extraConfig != nil {
+		exporter.ConfigureExporter(extraConfig)
+	}
 	t.Logf("Collector LogsTestServer exporter started, pointing at %v", cfg.LogConfig.ClientConfig.Endpoint)
 	return exporter
 }

--- a/exporter/collector/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/integrationtest/inmemoryocexporter.go
@@ -191,9 +191,7 @@ func NewLogTestExporter(
 	)
 	require.NoError(t, err)
 
-	if extraConfig != nil {
-		exporter.ConfigureExporter(extraConfig)
-	}
+	exporter.ConfigureExporter(extraConfig)
 	t.Logf("Collector LogsTestServer exporter started, pointing at %v", cfg.LogConfig.ClientConfig.Endpoint)
 	return exporter
 }

--- a/exporter/collector/integrationtest/logs_integration_test.go
+++ b/exporter/collector/integrationtest/logs_integration_test.go
@@ -46,6 +46,9 @@ func createLogsExporter(
 		cfg,
 		logger,
 	)
+	if test.ConfigureLogsExporter != nil {
+		exporter.ConfigureExporter(test.ConfigureLogsExporter)
+	}
 	require.NoError(t, err)
 	t.Log("Collector logs exporter started")
 	return exporter

--- a/exporter/collector/integrationtest/logs_integration_test.go
+++ b/exporter/collector/integrationtest/logs_integration_test.go
@@ -46,9 +46,7 @@ func createLogsExporter(
 		cfg,
 		logger,
 	)
-	if test.ConfigureLogsExporter != nil {
-		exporter.ConfigureExporter(test.ConfigureLogsExporter)
-	}
+	exporter.ConfigureExporter(test.ConfigureLogsExporter)
 	require.NoError(t, err)
 	t.Log("Collector logs exporter started")
 	return exporter

--- a/exporter/collector/integrationtest/logs_test.go
+++ b/exporter/collector/integrationtest/logs_test.go
@@ -42,7 +42,7 @@ func TestLogs(t *testing.T) {
 			go testServer.Serve()
 			defer testServer.Shutdown()
 
-			testServerExporter := NewLogTestExporter(ctx, t, testServer, test.CreateLogConfig())
+			testServerExporter := NewLogTestExporter(ctx, t, testServer, test.CreateLogConfig(), test.ConfigureLogsExporter)
 
 			require.NoError(
 				t,

--- a/exporter/collector/integrationtest/testcases/testcase.go
+++ b/exporter/collector/integrationtest/testcases/testcase.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/logsutil"
 )
 
 var (
@@ -56,6 +57,8 @@ const SecondProjectEnv = "SECOND_PROJECT_ID"
 type TestCase struct {
 	// ConfigureCollector will be called to modify the default configuration for this test case. Optional.
 	ConfigureCollector func(cfg *collector.Config)
+	// ConfigureLogsExporter uses internal types to add extra post-init config to an exporter object.
+	ConfigureLogsExporter *logsutil.ExporterConfig
 	// Name of the test case
 	Name string
 	// OTLPInputFixturePath is the path to the JSON encoded OTLP

--- a/exporter/collector/integrationtest/testcases/testcases_logs.go
+++ b/exporter/collector/integrationtest/testcases/testcases_logs.go
@@ -14,7 +14,10 @@
 
 package testcases
 
-import "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+import (
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/logsutil"
+)
 
 var LogsTestCases = []TestCase{
 	{
@@ -64,9 +67,9 @@ var LogsTestCases = []TestCase{
 		Name:                 "Logs with multiple batches",
 		OTLPInputFixturePath: "testdata/fixtures/logs/logs_apache_access.json",
 		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_access_batches_expected.json",
-		ConfigureCollector: func(cfg *collector.Config) {
-			cfg.LogConfig.MaxEntrySize = 50
-			cfg.LogConfig.MaxRequestSize = 500
+		ConfigureLogsExporter: &logsutil.ExporterConfig{
+			MaxEntrySize:   50,
+			MaxRequestSize: 500,
 		},
 	},
 }

--- a/exporter/collector/integrationtest/testcases/testcases_logs.go
+++ b/exporter/collector/integrationtest/testcases/testcases_logs.go
@@ -60,4 +60,13 @@ var LogsTestCases = []TestCase{
 			}
 		},
 	},
+	{
+		Name:                 "Logs with multiple batches",
+		OTLPInputFixturePath: "testdata/fixtures/logs/logs_apache_access.json",
+		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_access_batches_expected.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.LogConfig.MaxEntrySize = 50
+			cfg.LogConfig.MaxRequestSize = 500
+		},
+	},
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
@@ -1,0 +1,438 @@
+{
+  "writeLogEntriesRequests": [
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log",
+            "single-attribute": "foobar"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/lamp.png",
+            "status": 200,
+            "responseSize": "51164",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/favicon.ico",
+            "status": 200,
+            "responseSize": "3990",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "4429",
+            "remoteIp": "127.0.0.2",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        }
+      ],
+      "partialSuccess": true
+    }
+  ]
+}

--- a/exporter/collector/internal/logsutil/logsutil.go
+++ b/exporter/collector/internal/logsutil/logsutil.go
@@ -1,0 +1,20 @@
+// Copyright 2023 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logsutil
+
+type ExporterConfig struct {
+	MaxEntrySize   int
+	MaxRequestSize int
+}

--- a/exporter/collector/internal/logsutil/logsutil.go
+++ b/exporter/collector/internal/logsutil/logsutil.go
@@ -1,4 +1,4 @@
-// Copyright 2023 OpenTelemetry Authors
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,13 @@
 
 package logsutil
 
+// ExporterConfig configures the Logs exporter with various settings post-initializition.
+// It is meant to be used by integration tests.
 type ExporterConfig struct {
-	MaxEntrySize   int
+	// MaxEntrySize is the maximum size of an individual LogEntry in bytes. Entries
+	// larger than this size will be split into multiple entries.
+	MaxEntrySize int
+	// MaxRequestSize is the maximum size of a batch WriteLogEntries request in bytes.
+	// Request larger than this size will be split into multiple requests.
 	MaxRequestSize int
 }


### PR DESCRIPTION
Fixes #590 

This could have been prevented if we had originally implemented integration tests for batch request sizing ([as TODO'd here](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/a62ae2cc5958c5ea59cbc9064cd4a76a4af25da9/exporter/collector/logs.go#L185))

We do already have unit tests for individual entry sizing, but we chose not to block on request sizing for a few reasons:
1. Requests are sized in `PushLogs()`, which means they likely have to be an integration test as done here.
2. The integration tests work with an actual exporter, so we would either need to create test logs that exceeded the default GCP size limit (10 MB) or configure the test exporter to use a different max size.
3. Configuring the test exporter isn't very easy without exposing that configuration option due to running across Go packages.
4. We didn't feel the need to expose this config option anyway, because the only benefit to users would be to set a *lower* max request size, which would just result in more requests (== higher costs?)
5. 10 MB is a pretty big request, and we didn't realistically expect that to be hit.

We are now running into point number 5. So, the best option I have is to add these options (max_entry_size and max_request_size) to the LogExporter config. Though we don't need to document them, because they aren't very useful, there isn't technically any harm in someone choosing to set these manually.

Another option I suppose would be exposing just the variables and setting those directly. That would keep the collector config cleaner, but imo it's a wash either way.