### PR TITLE
Disable unhandled-error from revive CI check

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -281,6 +281,9 @@ linters-settings:
       - name: useless-break
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
+      - name: unhandled-error
+        disabled: true
+        # this is redundant to the errcheck linter and we need to skip that in certain spots
       - name: waitgroup-by-value
         disabled: false
 


### PR DESCRIPTION
This check is redundant from the errcheck linter, which is already enabled and lets us disable per-line.

Having this enabled causes errors like https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/actions/runs/4254312002/jobs/7400375991#step:9:176

This started running after the golangci-lint bump in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/598. I couldn't find the exact change in either golangci-lint or revive that added/changed this check recently, but it's at least related to that bump.