### PR TITLE
bump to go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.18
+  DEFAULT_GO_VERSION: 1.19
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -14,7 +14,7 @@
 
 steps:
   # Vendor dependencies, and zip the code.
-  - name: golang:1.18
+  - name: golang:1.19
     id: zip-code
     entrypoint: /bin/bash
     args:
@@ -33,7 +33,7 @@ steps:
     env: ["PROJECT_ID=$PROJECT_ID"]
     args:
       - cloud-functions-gen2
-      - --runtime=go118
+      - --runtime=go119
       - --functionsource=/workspace/e2e-test-server/cloud_functions/function-source.zip
       - --entrypoint=HandleCloudFunction
 

--- a/cloudbuild-integration-tests.yaml
+++ b/cloudbuild-integration-tests.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - name: golang:1.18
+  - name: golang:1.19
     env: ["SECOND_PROJECT_ID=opentelemetry-ops-e2e-2"]
     args: ["make", "integrationtest"]
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/compute v1.10.0

--- a/e2e-test-server/Dockerfile
+++ b/e2e-test-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace/e2e-test-server/
 

--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server/cloudfunctions
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/pubsub v1.28.0

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/iam v0.8.0 // indirect

--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric
 
-go 1.18
+go 1.19
 
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric => ../../exporter/metric
 

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/http
 
-go 1.18
+go 1.19
 
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go => ../../..
 

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/logging v1.6.1

--- a/exporter/collector/googlemanagedprometheus/go.mod
+++ b/exporter/collector/googlemanagedprometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus
 
-go 1.18
+go 1.19
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.68.0

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/integrationtest
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/logging v1.6.1

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/monitoring v1.12.0

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/trace v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go
 
-go 1.18
+go 1.19
 
 retract (
 	v1.8.0

--- a/internal/cloudmock/go.mod
+++ b/internal/cloudmock/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock
 
-go 1.18
+go 1.19
 
 require (
 	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55

--- a/internal/resourcemapping/go.mod
+++ b/internal/resourcemapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/otel v1.11.2
 

--- a/propagator/go.mod
+++ b/propagator/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
With go 1.20 out, 1.18 is no longer supported by the go team. Also, upstream otel libraries now use 1.19.

This will probably require a minor (not patch) bump next release