### PR TITLE
Prepare v0.36.0 and 1.12.0

### DIFF
--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/pubsub v1.28.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.6.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.36.0
 	github.com/cloudevents/sdk-go/v2 v2.13.0
 )
 
@@ -16,9 +16,9 @@ require (
 	cloud.google.com/go/functions v1.9.0 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect
 	cloud.google.com/go/trace v1.8.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.11.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.12.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.12.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/iam v0.8.0 // indirect
 	cloud.google.com/go/pubsub v1.27.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.12.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.15.0
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
@@ -18,8 +18,8 @@ require (
 	cloud.google.com/go/compute v1.14.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.8.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.11.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.12.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -9,7 +9,7 @@ replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/clou
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping => ../../internal/resourcemapping
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.36.0
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/metric v0.36.0
 	go.opentelemetry.io/otel/sdk/metric v0.36.0
@@ -19,7 +19,7 @@ require (
 	cloud.google.com/go/compute v1.14.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/monitoring v1.12.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -13,8 +13,8 @@ replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator =>
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock => ../../../internal/cloudmock
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.12.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.36.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/sdk v1.13.0
@@ -25,7 +25,7 @@ require (
 	cloud.google.com/go/compute v1.14.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.8.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -6,8 +6,8 @@ require (
 	cloud.google.com/go/logging v1.6.1
 	cloud.google.com/go/monitoring v1.8.0
 	cloud.google.com/go/trace v1.8.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.12.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/google/go-cmp v0.5.9
 	github.com/googleapis/gax-go/v2 v2.7.0

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -7,11 +7,11 @@ require (
 	cloud.google.com/go/monitoring v1.12.0
 	cloud.google.com/go/trace v1.8.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.35.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.35.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.35.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.35.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.36.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.36.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.36.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.36.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
 	go.opencensus.io v0.24.0
@@ -35,7 +35,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/longrunning v0.3.0 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.2 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.12.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.117 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -223,7 +223,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -402,7 +402,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -581,7 +581,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -745,7 +745,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -875,7 +875,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1005,7 +1005,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1135,7 +1135,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1251,7 +1251,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1347,7 +1347,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1443,7 +1443,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1539,7 +1539,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1664,7 +1664,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1843,7 +1843,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2022,7 +2022,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2186,7 +2186,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2316,7 +2316,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2446,7 +2446,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2576,7 +2576,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2692,7 +2692,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.11.2"
+                  "value": "opentelemetry-go 1.13.0; google-cloud-trace-exporter 1.12.0"
                 }
               },
               "g.co/gae/app/module": {

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -19,8 +19,8 @@ require (
 )
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.35.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.36.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/stretchr/testify v1.8.2
 	go.uber.org/multierr v1.8.0

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.35.2"
+	return "0.36.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -20,8 +20,8 @@ require (
 )
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.35.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.36.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.36.0
 	go.uber.org/multierr v1.8.0
 )
 

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.11.2"
+	return "1.12.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.11.2"
-	unstable = "0.35.2"
+	stable   = "1.12.0"
+	unstable = "0.36.0"
 )
 
 var versions = map[string]string{


### PR DESCRIPTION
Bumping the minor version because we updated from go 1.18 to 1.19 (https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/600) as well as some notable bumps in our otel libraries (https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/603)