### PR TITLE
Fix GMP metric name handling

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
@@ -457,6 +457,19 @@
                            }
                         ]
                      }
+                  },
+                  {
+                     "name":"prometheus.googleapis.com/otlp.test.prefix6",
+                     "description":"GMP metric names are not special",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
                   }
                ]
             }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
@@ -379,6 +379,84 @@
                            }
                         ]
                      }
+                  },
+                  {
+                     "name":"otlp.test.gauge",
+                     "description":"Normal metric name",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name":"workload.googleapis.com/otlp.test.prefix1",
+                     "description":"URI-style metric name",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name":".invalid.googleapis.com/otlp.test.prefix2",
+                     "description":"URI-style metric name with invalid domain",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name":"otlp.test.prefix3/workload.googleapis.com/abc",
+                     "description":"Broken URI-style metric name",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name":"WORKLOAD.GOOGLEAPIS.COM/otlp.test.prefix4",
+                     "description":"Uppercase URI-style metric name",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "name":"WORKLOAD.googleapis.com/otlp.test.prefix5",
+                     "description":"Partial uppercase URI-style metric name",
+                     "unit":"seconds",
+                     "gauge":{
+                        "dataPoints":[
+                           {
+                              "timeUnixNano":"1649443516286000000",
+                              "asDouble":0.00699415
+                           }
+                        ]
+                     }
                   }
                ]
             }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus.json
@@ -459,7 +459,7 @@
                      }
                   },
                   {
-                     "name":"prometheus.googleapis.com/otlp.test.prefix6",
+                     "name":"prometheus.googleapis.com/otlp_test_prefix6/gauge",
                      "description":"GMP metric names are not special",
                      "unit":"seconds",
                      "gauge":{

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -874,7 +874,7 @@
         },
         {
           "metric": {
-            "type": "prometheus.googleapis.com/prometheus_googleapis_com_otlp_test_prefix6/gauge"
+            "type": "prometheus.googleapis.com/prometheus_googleapis_com_otlp_test_prefix6_gauge/gauge"
           },
           "resource": {
             "type": "prometheus_target",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -706,6 +706,174 @@
         },
         {
           "metric": {
+            "type": "prometheus.googleapis.com/otlp_test_gauge/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "workload_googleapis_com_otlp_test_prefix1/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "invalid_googleapis_com_otlp_test_prefix2/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "otlp_test_prefix3_workload_googleapis_com_abc/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/WORKLOAD_GOOGLEAPIS_COM_otlp_test_prefix4/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "WORKLOAD_googleapis_com_otlp_test_prefix5/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
             "type": "prometheus.googleapis.com/target_info/gauge",
             "labels": {
               "cloud_platform": "gcp_kubernetes_engine",
@@ -765,7 +933,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "22"
+                  "int64Value": "28"
                 }
               }
             ]

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -734,7 +734,7 @@
         },
         {
           "metric": {
-            "type": "workload_googleapis_com_otlp_test_prefix1/gauge"
+            "type": "prometheus.googleapis.com/workload_googleapis_com_otlp_test_prefix1/gauge"
           },
           "resource": {
             "type": "prometheus_target",
@@ -762,7 +762,7 @@
         },
         {
           "metric": {
-            "type": "invalid_googleapis_com_otlp_test_prefix2/gauge"
+            "type": "prometheus.googleapis.com/invalid_googleapis_com_otlp_test_prefix2/gauge"
           },
           "resource": {
             "type": "prometheus_target",
@@ -790,7 +790,7 @@
         },
         {
           "metric": {
-            "type": "otlp_test_prefix3_workload_googleapis_com_abc/gauge"
+            "type": "prometheus.googleapis.com/otlp_test_prefix3_workload_googleapis_com_abc/gauge"
           },
           "resource": {
             "type": "prometheus_target",
@@ -846,7 +846,7 @@
         },
         {
           "metric": {
-            "type": "WORKLOAD_googleapis_com_otlp_test_prefix5/gauge"
+            "type": "prometheus.googleapis.com/WORKLOAD_googleapis_com_otlp_test_prefix5/gauge"
           },
           "resource": {
             "type": "prometheus_target",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -874,6 +874,34 @@
         },
         {
           "metric": {
+            "type": "prometheus.googleapis.com/prometheus_googleapis_com_otlp_test_prefix6/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
             "type": "prometheus.googleapis.com/target_info/gauge",
             "labels": {
               "cloud_platform": "gcp_kubernetes_engine",
@@ -933,7 +961,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "28"
+                  "int64Value": "29"
                 }
               }
             ]

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -929,7 +929,7 @@ func (m *metricMapper) metricNameToType(name string, metric pmetric.Metric) (str
 	if err != nil {
 		return "", err
 	}
-	return path.Join(m.getMetricNamePrefix(name), metricName), nil
+	return path.Join(m.getMetricNamePrefix(metricName), metricName), nil
 }
 
 // defaultGetMetricName does not (further) customize the baseName.


### PR DESCRIPTION
If OTLP metric data comes in with a URL-style metric name, the `googlemanagedprometheus` exporter will sanitize the name but forget to prepend the correct `prometheus.googleapis.com/` prefix.