### PR TITLE
Amend an expired link in doc

### DIFF
--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -7,7 +7,7 @@ OpenTelemetry Google Cloud Trace Exporter allows the user to send collected trac
 
 [Google Cloud Trace](https://cloud.google.com/trace) is a distributed tracing backend system. It helps developers to gather timing data needed to troubleshoot latency problems in microservice & monolithic architectures. It manages both the collection and lookup of gathered trace data.
 
-This exporter package assumes your application is [already instrumented](https://github.com/open-telemetry/opentelemetry-go/blob/main/example/http/client/client.go) with the OpenTelemetry SDK. Once you get ready to export OpenTelemetry data, you can add this exporter to your application.
+This exporter package assumes your application is [already instrumented](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/net/http/otelhttp/example/client/client.go) with the OpenTelemetry SDK. Once you get ready to export OpenTelemetry data, you can add this exporter to your application.
 
 ## Setup
 


### PR DESCRIPTION
Hello, maintainer-san! 👋🏽 

I hope you're having a great day! While browsing through the repository, I noticed that there's an expired link in the documentation. It seems that the client example has been moved to the Contrib package.

As a reference, you can find the related Pull Request in both repositories:

- https://github.com/open-telemetry/opentelemetry-go/pull/1032
- https://github.com/open-telemetry/opentelemetry-go-contrib/pull/190

Thank you for your attention and assistance!