### PR TITLE
Add write ahead log to collector metrics exporter

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -180,8 +180,8 @@ Additional configuration for the metric exporter:
 - `metric.prefix` (optional): MetricPrefix overrides the prefix / namespace of the Google Cloud metric type identifier. If not set, defaults to "custom.googleapis.com/opencensus/"
 - `metric.skip_create_descriptor` (optional): Whether to skip creating the
   metric descriptor.
-- `metric.wal.directory` (optional): Path to local write-ahead-log file.
-- `metric.wal.max_backoff` (optional): Maximum duration to retry entries from
+- `metric.experimental_wal.experimental_directory` (optional): Path to local write-ahead-log file.
+- `metric.experimental_wal.experimental_max_backoff` (optional): Maximum duration to retry entries from
   the WAL on network errors.
 
 Addition configuration for the logging exporter:

--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -178,7 +178,11 @@ Note: These `retry_on_failure` and `sending_queue` are provided (and documented)
 Additional configuration for the metric exporter:
 
 - `metric.prefix` (optional): MetricPrefix overrides the prefix / namespace of the Google Cloud metric type identifier. If not set, defaults to "custom.googleapis.com/opencensus/"
-- `metric.skip_create_descriptor` (optional): Whether to skip creating the metric descriptor.
+- `metric.skip_create_descriptor` (optional): Whether to skip creating the
+  metric descriptor.
+- `metric.wal.directory` (optional): Path to local write-ahead-log file.
+- `metric.wal.max_backoff` (optional): Maximum duration to retry entries from
+  the WAL on network errors.
 
 Addition configuration for the logging exporter:
 

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -148,9 +148,9 @@ type MetricConfig struct {
 // it preserves both the data on disk and the order of the data points.
 type WALConfig struct {
 	// Directory is the location to store WAL files.
-	Directory string `mapstructure:"experimental_directory"`
+	Directory string `mapstructure:"directory"`
 	// MaxBackoff sets the length of time to exponentially re-try failed exports.
-	MaxBackoff time.Duration `mapstructure:"experimental_max_backoff"`
+	MaxBackoff time.Duration `mapstructure:"emax_backoff"`
 }
 
 // ImpersonateConfig defines configuration for service account impersonation.

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -46,8 +46,8 @@ type Config struct {
 	ProjectID               string            `mapstructure:"project"`
 	UserAgent               string            `mapstructure:"user_agent"`
 	ImpersonateConfig       ImpersonateConfig `mapstructure:"impersonate"`
-	LogConfig               LogConfig         `mapstructure:"log"`
 	TraceConfig             TraceConfig       `mapstructure:"trace"`
+	LogConfig               LogConfig         `mapstructure:"log"`
 	MetricConfig            MetricConfig      `mapstructure:"metric"`
 	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
 }
@@ -90,11 +90,6 @@ type AttributeMapping struct {
 }
 
 type MetricConfig struct {
-	// GetMetricName is not settable in config files, but can be used by other
-	// exporters which extend the functionality of this exporter. It allows
-	// customizing the naming of metrics. baseName already includes type
-	// suffixes for summary metrics, but does not (yet) include the domain prefix
-	GetMetricName func(baseName string, metric pmetric.Metric) (string, error)
 	// MapMonitoredResource is not exposed as an option in the configuration, but
 	// can be used by other exporters to extend the functionality of this
 	// exporter. It allows overriding the function used to map otel resource to
@@ -103,7 +98,14 @@ type MetricConfig struct {
 	// ExtraMetrics is an extension point for exporters to add to the set
 	// of ResourceMetrics during a call to PushMetrics.
 	ExtraMetrics func(pmetric.Metrics) pmetric.ResourceMetricsSlice
-	Prefix       string `mapstructure:"prefix"`
+	// GetMetricName is not settable in config files, but can be used by other
+	// exporters which extend the functionality of this exporter. It allows
+	// customizing the naming of metrics. baseName already includes type
+	// suffixes for summary metrics, but does not (yet) include the domain prefix
+	GetMetricName func(baseName string, metric pmetric.Metric) (string, error)
+	// WALConfig holds configuration settings for the write ahead log.
+	WALConfig *WALConfig `mapstructure:"wal_config"`
+	Prefix    string     `mapstructure:"prefix"`
 	// KnownDomains contains a list of prefixes. If a metric already has one
 	// of these prefixes, the prefix is not added.
 	KnownDomains []string `mapstructure:"known_domains"`
@@ -138,6 +140,17 @@ type MetricConfig struct {
 	// deviation.  It isn't correct, so we don't send it by default, and don't expose
 	// it to users. For some uses, it is expected, however.
 	EnableSumOfSquaredDeviation bool `mapstructure:"sum_of_squared_deviation"`
+}
+
+// WALConfig defines settings for the write ahead log. WAL buffering writes data
+// points in-order to disk before reading and exporting them. This allows for
+// better retry logic when exporting fails (such as a network outage), because
+// it preserves both the data on disk and the order of the data points.
+type WALConfig struct {
+	// Directory is the location to store WAL files.
+	Directory string `mapstructure:"directory"`
+	// MaxBackoff sets the length of time to exponentially re-try failed exports.
+	MaxBackoff time.Duration `mapstructure:"max_backoff"`
 }
 
 // ImpersonateConfig defines configuration for service account impersonation.

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -104,7 +104,7 @@ type MetricConfig struct {
 	// suffixes for summary metrics, but does not (yet) include the domain prefix
 	GetMetricName func(baseName string, metric pmetric.Metric) (string, error)
 	// WALConfig holds configuration settings for the write ahead log.
-	WALConfig *WALConfig `mapstructure:"wal_config"`
+	WALConfig *WALConfig `mapstructure:"experimental_wal_config"`
 	Prefix    string     `mapstructure:"prefix"`
 	// KnownDomains contains a list of prefixes. If a metric already has one
 	// of these prefixes, the prefix is not added.
@@ -148,9 +148,9 @@ type MetricConfig struct {
 // it preserves both the data on disk and the order of the data points.
 type WALConfig struct {
 	// Directory is the location to store WAL files.
-	Directory string `mapstructure:"directory"`
+	Directory string `mapstructure:"experimental_directory"`
 	// MaxBackoff sets the length of time to exponentially re-try failed exports.
-	MaxBackoff time.Duration `mapstructure:"max_backoff"`
+	MaxBackoff time.Duration `mapstructure:"experimental_max_backoff"`
 }
 
 // ImpersonateConfig defines configuration for service account impersonation.

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/stretchr/testify v1.8.3
+	github.com/tidwall/wal v1.1.7
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0012
 	go.opentelemetry.io/collector/semconv v0.78.0
@@ -47,6 +49,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/gjson v1.10.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/tinylru v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/exporter/collector/go.sum
+++ b/exporter/collector/go.sum
@@ -30,6 +30,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -98,6 +100,16 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/tidwall/gjson v1.10.2 h1:APbLGOM0rrEkd8WBw9C24nllro4ajFuJu0Sc9hRz8Bo=
+github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/tinylru v1.1.0 h1:XY6IUfzVTU9rpwdhKUF6nQdChgCdGjkMfLzbWyiau6I=
+github.com/tidwall/tinylru v1.1.0/go.mod h1:3+bX+TJ2baOLMWTnlyNWHh4QMnFyARg2TLTQ6OFbzw8=
+github.com/tidwall/wal v1.1.7 h1:emc1TRjIVsdKKSnpwGBAcsAGg0767SvUk8+ygx7Bb+4=
+github.com/tidwall/wal v1.1.7/go.mod h1:r6lR1j27W9EPalgHiB7zLJDYu3mzW5BQP5KrzBpYY/E=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
@@ -156,6 +168,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/exporter/collector/integrationtest/cmd/recordfixtures/main.go
+++ b/exporter/collector/integrationtest/cmd/recordfixtures/main.go
@@ -136,18 +136,17 @@ func (fr fixtureRecorder) recordLogs(ctx context.Context, t *FakeTesting, timest
 }
 
 func (fr fixtureRecorder) recordMetrics(ctx context.Context, t *FakeTesting, startTime, endTime time.Time) {
-	testServer, err := cloudmock.NewMetricTestServer()
-	if err != nil {
-		panic(err)
-	}
-	//nolint:errcheck
-	go testServer.Serve()
-	defer testServer.Shutdown()
-
 	for _, test := range testcases.MetricsTestCases {
 		if test.Skip {
 			continue
 		}
+
+		testServer, err := cloudmock.NewMetricTestServer()
+		if err != nil {
+			panic(err)
+		}
+		//nolint:errcheck
+		go testServer.Serve()
 
 		require.NoError(t, fr.checkDuplicate(test))
 
@@ -177,5 +176,7 @@ func (fr fixtureRecorder) recordMetrics(ctx context.Context, t *FakeTesting, sta
 			}
 			test.SaveRecordedMetricFixtures(t, fixture)
 		}()
+
+		testServer.Shutdown()
 	}
 }

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
@@ -76,6 +77,11 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.5 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/gjson v1.10.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/tinylru v1.1.0 // indirect
+	github.com/tidwall/wal v1.1.7 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/exporter/collector/integrationtest/go.sum
+++ b/exporter/collector/integrationtest/go.sum
@@ -111,6 +111,7 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -414,6 +415,16 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
+github.com/tidwall/gjson v1.10.2 h1:APbLGOM0rrEkd8WBw9C24nllro4ajFuJu0Sc9hRz8Bo=
+github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/tinylru v1.1.0 h1:XY6IUfzVTU9rpwdhKUF6nQdChgCdGjkMfLzbWyiau6I=
+github.com/tidwall/tinylru v1.1.0/go.mod h1:3+bX+TJ2baOLMWTnlyNWHh4QMnFyARg2TLTQ6OFbzw8=
+github.com/tidwall/wal v1.1.7 h1:emc1TRjIVsdKKSnpwGBAcsAGg0767SvUk8+ygx7Bb+4=
+github.com/tidwall/wal v1.1.7/go.mod h1:r6lR1j27W9EPalgHiB7zLJDYu3mzW5BQP5KrzBpYY/E=
 github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
@@ -642,6 +653,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=

--- a/exporter/collector/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/integrationtest/inmemoryocexporter.go
@@ -162,7 +162,6 @@ func NewMetricTestExporter(
 		ctx,
 		cfg,
 		zap.NewNop(),
-		//zap.NewExample(),
 		"latest",
 		collector.DefaultTimeout,
 	)

--- a/exporter/collector/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/integrationtest/inmemoryocexporter.go
@@ -162,6 +162,7 @@ func NewMetricTestExporter(
 		ctx,
 		cfg,
 		zap.NewNop(),
+		//zap.NewExample(),
 		"latest",
 		collector.DefaultTimeout,
 	)

--- a/exporter/collector/integrationtest/testcases/testcase.go
+++ b/exporter/collector/integrationtest/testcases/testcase.go
@@ -67,6 +67,9 @@ type TestCase struct {
 	// ExpectFixturePath is the path to the JSON encoded MetricExpectFixture
 	// (see fixtures.proto) that contains request messages the exporter is expected to send.
 	ExpectFixturePath string
+	// CompareFixturePath is a second output fixture that should be equal to this test's output fixture.
+	// Used for cross-referencing multiple tests that should have the same output, without overwriting the same fixtures.
+	CompareFixturePath string
 	// When testing the SDK metrics exporter (not collector), this is the options to use. Optional.
 	MetricSDKExporterOptions []metric.Option
 	// Skip, if true, skips this test case
@@ -75,6 +78,8 @@ type TestCase struct {
 	SkipForSDK bool
 	// ExpectErr sets whether the test is expected to fail
 	ExpectErr bool
+	// ExpectRetries sets whether the test expects the server to report multiple attempts
+	ExpectRetries bool
 }
 
 func (tc *TestCase) LoadOTLPTracesInput(
@@ -329,12 +334,13 @@ func (tc *TestCase) LoadOTLPMetricsInput(
 	return metrics
 }
 
-func (tc *TestCase) LoadMetricExpectFixture(
+func (tc *TestCase) LoadMetricFixture(
 	t testing.TB,
+	path string,
 	startTime time.Time,
 	endTime time.Time,
 ) *protos.MetricExpectFixture {
-	fixtureBytes, err := os.ReadFile(tc.ExpectFixturePath)
+	fixtureBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	fixture := &protos.MetricExpectFixture{}
 	require.NoError(t, protojson.Unmarshal(fixtureBytes, fixture))

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -15,7 +15,9 @@
 package testcases
 
 import (
+	"os"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
@@ -238,6 +240,79 @@ var MetricsTestCases = []TestCase{
 			cfg.MetricConfig.SkipCreateMetricDescriptor = true
 		},
 		// We don't support disabling metric descriptor creation for the SDK exporter
+		SkipForSDK: true,
+	},
+	{
+		Name:                 "Write ahead log enabled",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/basic_counter_metrics.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/basic_counter_metrics_wal_expect.json",
+		CompareFixturePath:   "testdata/fixtures/metrics/basic_counter_metrics_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			dir, _ := os.MkdirTemp("", "test-wal-")
+			cfg.MetricConfig.WALConfig = &collector.WALConfig{
+				Directory:  dir,
+				MaxBackoff: time.Duration(1 * time.Second),
+			}
+		},
+		SkipForSDK: true,
+	},
+	{
+		Name:                 "Write ahead log enabled, basic prometheus metrics",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/basic_prometheus_metrics.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/basic_prometheus_metrics_wal_expect.json",
+		CompareFixturePath:   "testdata/fixtures/metrics/basic_prometheus_metrics_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			dir, _ := os.MkdirTemp("", "test-wal-")
+			cfg.MetricConfig.WALConfig = &collector.WALConfig{
+				Directory:  dir,
+				MaxBackoff: time.Duration(1 * time.Second),
+			}
+		},
+		SkipForSDK: true,
+	},
+	{
+		Name:                 "Write ahead log enabled, basic Counter with unavailable return code",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/basic_counter_metrics.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/basic_counter_metrics_wal_unavailable_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.ProjectID = "unavailableproject"
+			dir, _ := os.MkdirTemp("", "test-wal-")
+			cfg.MetricConfig.WALConfig = &collector.WALConfig{
+				Directory:  dir,
+				MaxBackoff: time.Duration(2 * time.Second),
+			}
+		},
+		SkipForSDK:    true,
+		ExpectRetries: true,
+	},
+	{
+		Name:                 "Write ahead log enabled, basic Counter with deadline_exceeded return code",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/basic_counter_metrics.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/basic_counter_metrics_wal_deadline_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.ProjectID = "deadline_exceededproject"
+			dir, _ := os.MkdirTemp("", "test-wal-")
+			cfg.MetricConfig.WALConfig = &collector.WALConfig{
+				Directory:  dir,
+				MaxBackoff: time.Duration(2 * time.Second),
+			}
+		},
+		SkipForSDK:    true,
+		ExpectRetries: true,
+	},
+	{
+		Name:                 "Write ahead log enabled, CreateServiceTimeSeries",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/create_service_timeseries_metrics.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/create_service_timeseries_metrics_wal_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.MetricConfig.CreateServiceTimeSeries = true
+			dir, _ := os.MkdirTemp("", "test-wal-")
+			cfg.MetricConfig.WALConfig = &collector.WALConfig{
+				Directory:  dir,
+				MaxBackoff: time.Duration(1 * time.Second),
+			}
+		},
+		// SDK exporter does not support CreateServiceTimeSeries
 		SkipForSDK: true,
 	},
 	// TODO: Add integration tests for workload.googleapis.com metrics from the ops agent

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_counter_metrics_wal_deadline_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_counter_metrics_wal_deadline_expect.json
@@ -1,7 +1,44 @@
 {
+  "createTimeSeriesRequests": [
+    {
+      "name": "projects/deadline_exceededproject",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/testcounter",
+            "labels": {
+              "foo": "bar"
+            }
+          },
+          "resource": {
+            "type": "generic_node",
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ],
+          "unit": "1"
+        }
+      ]
+    }
+  ],
   "createMetricDescriptorRequests": [
     {
-      "name": "projects/notfoundproject",
+      "name": "projects/deadline_exceededproject",
       "metricDescriptor": {
         "name": "testcounter",
         "type": "workload.googleapis.com/testcounter",
@@ -27,7 +64,7 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
               "labels": {
-                "status": "NOT_FOUND"
+                "status": "DEADLINE_EXCEEDED"
               }
             },
             "resource": {
@@ -62,7 +99,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "0"
+                  "int64Value": "1"
                 }
               }
             ]
@@ -95,7 +132,30 @@
               "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
-                "grpc_client_status": "NOT_FOUND"
+                "grpc_client_status": "DEADLINE_EXCEEDED"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
+                "grpc_client_status": "OK"
               }
             },
             "resource": {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_counter_metrics_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_counter_metrics_wal_expect.json
@@ -1,7 +1,44 @@
 {
+  "createTimeSeriesRequests": [
+    {
+      "name": "projects/fakeprojectid",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/testcounter",
+            "labels": {
+              "foo": "bar"
+            }
+          },
+          "resource": {
+            "type": "generic_node",
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ],
+          "unit": "1"
+        }
+      ]
+    }
+  ],
   "createMetricDescriptorRequests": [
     {
-      "name": "projects/notfoundproject",
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
         "name": "testcounter",
         "type": "workload.googleapis.com/testcounter",
@@ -27,28 +64,6 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
               "labels": {
-                "status": "NOT_FOUND"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "int64Value": "1"
-                }
-              }
-            ]
-          },
-          {
-            "metric": {
-              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
-              "labels": {
                 "status": "OK"
               }
             },
@@ -62,7 +77,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "0"
+                  "int64Value": "1"
                 }
               }
             ]
@@ -95,7 +110,7 @@
               "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
-                "grpc_client_status": "NOT_FOUND"
+                "grpc_client_status": "OK"
               }
             },
             "resource": {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_counter_metrics_wal_unavailable_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_counter_metrics_wal_unavailable_expect.json
@@ -1,7 +1,44 @@
 {
+  "createTimeSeriesRequests": [
+    {
+      "name": "projects/unavailableproject",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/testcounter",
+            "labels": {
+              "foo": "bar"
+            }
+          },
+          "resource": {
+            "type": "generic_node",
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "253"
+              }
+            }
+          ],
+          "unit": "1"
+        }
+      ]
+    }
+  ],
   "createMetricDescriptorRequests": [
     {
-      "name": "projects/notfoundproject",
+      "name": "projects/unavailableproject",
       "metricDescriptor": {
         "name": "testcounter",
         "type": "workload.googleapis.com/testcounter",
@@ -27,7 +64,7 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
               "labels": {
-                "status": "NOT_FOUND"
+                "status": "OK"
               }
             },
             "resource": {
@@ -49,7 +86,7 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
               "labels": {
-                "status": "OK"
+                "status": "UNAVAILABLE"
               }
             },
             "resource": {
@@ -62,7 +99,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "0"
+                  "int64Value": "1"
                 }
               }
             ]
@@ -95,7 +132,30 @@
               "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
-                "grpc_client_status": "NOT_FOUND"
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
+                "grpc_client_status": "UNAVAILABLE"
               }
             },
             "resource": {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_prometheus_metrics_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/basic_prometheus_metrics_wal_expect.json
@@ -1,20 +1,530 @@
 {
+  "createTimeSeriesRequests": [
+    {
+      "name": "projects/fakeprojectid",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/scrape_series_added",
+            "labels": {
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 22
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/ex_com_one",
+            "labels": {
+              "ex_com_lemons": "13",
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo",
+              "telemetry_sdk_language": "go",
+              "telemetry_sdk_name": "opentelemetry",
+              "telemetry_sdk_version": "1.6.2"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/ex_com_one",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10",
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo",
+              "telemetry_sdk_language": "go",
+              "telemetry_sdk_name": "opentelemetry",
+              "telemetry_sdk_version": "1.6.2"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 13
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/ex_com_two",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "13",
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo",
+              "telemetry_sdk_language": "go",
+              "telemetry_sdk_name": "opentelemetry",
+              "telemetry_sdk_version": "1.6.2"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 2,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/ex_com_two",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10",
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo",
+              "telemetry_sdk_language": "go",
+              "telemetry_sdk_name": "opentelemetry",
+              "telemetry_sdk_version": "1.6.2"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "2",
+                  "mean": 7,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "1",
+                    "0",
+                    "0"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/up",
+            "labels": {
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/scrape_duration_seconds",
+            "labels": {
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/scrape_samples_scraped",
+            "labels": {
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 22
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/scrape_samples_post_metric_relabeling",
+            "labels": {
+              "service_instance_id": "localhost:2222",
+              "service_name": "demo"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "global",
+              "namespace": "",
+              "task_id": "localhost:2222"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 22
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "createMetricDescriptorRequests": [
     {
-      "name": "projects/notfoundproject",
+      "name": "projects/fakeprojectid",
       "metricDescriptor": {
-        "name": "testcounter",
-        "type": "workload.googleapis.com/testcounter",
+        "name": "ex_com_one",
+        "type": "workload.googleapis.com/ex_com_one",
         "labels": [
           {
-            "key": "foo"
+            "key": "A"
+          },
+          {
+            "key": "B"
+          },
+          {
+            "key": "C"
+          },
+          {
+            "key": "ex_com_lemons"
+          },
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          },
+          {
+            "key": "telemetry_sdk_language"
+          },
+          {
+            "key": "telemetry_sdk_name"
+          },
+          {
+            "key": "telemetry_sdk_version"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "displayName": "ex_com_one"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "ex_com_two",
+        "type": "workload.googleapis.com/ex_com_two",
+        "labels": [
+          {
+            "key": "A"
+          },
+          {
+            "key": "B"
+          },
+          {
+            "key": "C"
+          },
+          {
+            "key": "ex_com_lemons"
+          },
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          },
+          {
+            "key": "telemetry_sdk_language"
+          },
+          {
+            "key": "telemetry_sdk_name"
+          },
+          {
+            "key": "telemetry_sdk_version"
           }
         ],
         "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
-        "unit": "1",
-        "description": "This is a test counter",
-        "displayName": "testcounter"
+        "valueType": "DISTRIBUTION",
+        "displayName": "ex_com_two"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_duration_seconds",
+        "type": "workload.googleapis.com/scrape_duration_seconds",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "unit": "seconds",
+        "description": "Duration of the scrape",
+        "displayName": "scrape_duration_seconds"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_samples_post_metric_relabeling",
+        "type": "workload.googleapis.com/scrape_samples_post_metric_relabeling",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The number of samples remaining after metric relabeling was applied",
+        "displayName": "scrape_samples_post_metric_relabeling"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_samples_scraped",
+        "type": "workload.googleapis.com/scrape_samples_scraped",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The number of samples the target exposed",
+        "displayName": "scrape_samples_scraped"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "scrape_series_added",
+        "type": "workload.googleapis.com/scrape_series_added",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The approximate number of new series in this scrape",
+        "displayName": "scrape_series_added"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "up",
+        "type": "workload.googleapis.com/up",
+        "labels": [
+          {
+            "key": "service_instance_id"
+          },
+          {
+            "key": "service_name"
+          }
+        ],
+        "metricKind": "GAUGE",
+        "valueType": "DOUBLE",
+        "description": "The scraping was successful",
+        "displayName": "up"
       }
     }
   ],
@@ -23,28 +533,6 @@
       {
         "name": "projects/myproject",
         "timeSeries": [
-          {
-            "metric": {
-              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
-              "labels": {
-                "status": "NOT_FOUND"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "int64Value": "1"
-                }
-              }
-            ]
-          },
           {
             "metric": {
               "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
@@ -62,7 +550,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "0"
+                  "int64Value": "9"
                 }
               }
             ]
@@ -85,7 +573,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "1"
+                  "int64Value": "7"
                 }
               }
             ]
@@ -95,7 +583,7 @@
               "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
-                "grpc_client_status": "NOT_FOUND"
+                "grpc_client_status": "OK"
               }
             },
             "resource": {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_metrics_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_metrics_wal_expect.json
@@ -1,21 +1,37 @@
 {
-  "createMetricDescriptorRequests": [
+  "createServiceTimeSeriesRequests": [
     {
-      "name": "projects/notfoundproject",
-      "metricDescriptor": {
-        "name": "testcounter",
-        "type": "workload.googleapis.com/testcounter",
-        "labels": [
-          {
-            "key": "foo"
-          }
-        ],
-        "metricKind": "CUMULATIVE",
-        "valueType": "INT64",
-        "unit": "1",
-        "description": "This is a test counter",
-        "displayName": "testcounter"
-      }
+      "name": "projects/fakeprojectid",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "kubernetes.io/internal/nodes/clustermetrics/node_network_availability_transition_time",
+            "labels": {
+              "network_unavailable": "False"
+            }
+          },
+          "resource": {
+            "type": "k8s_node",
+            "labels": {
+              "cluster_name": "rabbitmq-test-dev",
+              "location": "us-central1-c",
+              "node_name": "gke-rabbitmq-test-dev-default-pool-4ffbde79-k6w0"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1639069893"
+              }
+            }
+          ]
+        }
+      ]
     }
   ],
   "selfObservabilityMetrics": {
@@ -27,7 +43,7 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
               "labels": {
-                "status": "NOT_FOUND"
+                "status": "OK"
               }
             },
             "resource": {
@@ -47,31 +63,9 @@
           },
           {
             "metric": {
-              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
-              "labels": {
-                "status": "OK"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "int64Value": "0"
-                }
-              }
-            ]
-          },
-          {
-            "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
               "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor",
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateServiceTimeSeries",
                 "grpc_client_status": "OK"
               }
             },
@@ -92,92 +86,9 @@
           },
           {
             "metric": {
-              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
-              "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
-                "grpc_client_status": "NOT_FOUND"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "int64Value": "1"
-                }
-              }
-            ]
-          },
-          {
-            "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
               "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "distributionValue": {
-                    "bucketOptions": {
-                      "explicitBuckets": {
-                        "bounds": [
-                          0,
-                          1024,
-                          2048,
-                          4096,
-                          16384,
-                          65536,
-                          262144,
-                          1048576,
-                          4194304,
-                          16777216,
-                          67108864,
-                          268435456,
-                          1073741824,
-                          4294967296
-                        ]
-                      }
-                    },
-                    "bucketCounts": [
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "metric": {
-              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
-              "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateServiceTimeSeries"
               }
             },
             "resource": {
@@ -237,121 +148,7 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
               "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "distributionValue": {
-                    "bucketOptions": {
-                      "explicitBuckets": {
-                        "bounds": [
-                          0,
-                          0.01,
-                          0.05,
-                          0.1,
-                          0.3,
-                          0.6,
-                          0.8,
-                          1,
-                          2,
-                          3,
-                          4,
-                          5,
-                          6,
-                          8,
-                          10,
-                          13,
-                          16,
-                          20,
-                          25,
-                          30,
-                          40,
-                          50,
-                          65,
-                          80,
-                          100,
-                          130,
-                          160,
-                          200,
-                          250,
-                          300,
-                          400,
-                          500,
-                          650,
-                          800,
-                          1000,
-                          2000,
-                          5000,
-                          10000,
-                          20000,
-                          50000,
-                          100000
-                        ]
-                      }
-                    },
-                    "bucketCounts": [
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "metric": {
-              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
-              "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateServiceTimeSeries"
               }
             },
             "resource": {
@@ -465,67 +262,7 @@
             "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
               "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
-              }
-            },
-            "resource": {
-              "type": "global"
-            },
-            "points": [
-              {
-                "interval": {
-                  "endTime": "1970-01-01T00:00:00Z",
-                  "startTime": "1970-01-01T00:00:00Z"
-                },
-                "value": {
-                  "distributionValue": {
-                    "bucketOptions": {
-                      "explicitBuckets": {
-                        "bounds": [
-                          0,
-                          1024,
-                          2048,
-                          4096,
-                          16384,
-                          65536,
-                          262144,
-                          1048576,
-                          4194304,
-                          16777216,
-                          67108864,
-                          268435456,
-                          1073741824,
-                          4294967296
-                        ]
-                      }
-                    },
-                    "bucketCounts": [
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0",
-                      "0"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "metric": {
-              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
-              "labels": {
-                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateServiceTimeSeries"
               }
             },
             "resource": {


### PR DESCRIPTION
This adds optional WAL buffering to the collector metrics exporter, heavily based on a similar implementation in the [Prometheus remote write exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6f1b6b97eb5d317bee3d20bcf1a8a96ceabdbd6b/exporter/prometheusremotewriteexporter/wal.go).

The flow for this is:
* If WAL is enabled, set it up in the user-specified directory under `gcp_metrics_wal`
* Update `PushMetrics()` to write byte-marshalled CreateTimeSeriesRequest objects to the WAL
    * if WAL is disabled, just export the requests as normal
* Start a `walRunner()` go routine that spawns a `readWALAndExport()` loop (the goroutine also handles shutdown signals)
* `readWALAndExport()` continuously reads the latest entry from the WAL and exports it to GCM:
    * If the export is successful, move the read index forward and continue (truncating the log file)
    * If the export fails for DeadlineExceeded or Unavailable, retry forever until success or non-retryable failure
    * If the export fails for any other reason, move the read index forward and continue (truncating the log file and skipping this entry)
* If there are no entries found in the WAL, `watchWAL()` opens a file watch to block for changes to the log file.

Added an integration test with WAL enabled to test this