### PR TITLE
Prepare release v0.39.0/1.15.0

### DIFF
--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/pubsub v1.28.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.6.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.39.0
 	github.com/cloudevents/sdk-go/v2 v2.13.0
 )
 
@@ -16,9 +16,9 @@ require (
 	cloud.google.com/go/functions v1.9.0 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect
 	cloud.google.com/go/trace v1.8.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.14.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.14.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.15.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/pubsub v1.27.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.14.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.17.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
@@ -18,8 +18,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect
 	cloud.google.com/go/trace v1.8.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.14.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.15.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/metric/go.mod
+++ b/example/metric/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric
 go 1.20
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.39.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/metric v1.16.0
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
@@ -13,7 +13,7 @@ require (
 	cloud.google.com/go/compute v1.14.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/monitoring v1.12.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -3,8 +3,8 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/
 go 1.20
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.14.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.39.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
@@ -15,7 +15,7 @@ require (
 	cloud.google.com/go/compute v1.14.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.8.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -6,8 +6,8 @@ require (
 	cloud.google.com/go/logging v1.7.0
 	cloud.google.com/go/monitoring v1.12.0
 	cloud.google.com/go/trace v1.8.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.14.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/google/go-cmp v0.5.9
 	github.com/googleapis/gax-go/v2 v2.7.0

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -7,11 +7,11 @@ require (
 	cloud.google.com/go/monitoring v1.13.0
 	cloud.google.com/go/trace v1.9.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.38.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.38.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.38.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.38.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.39.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.39.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.39.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.39.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.3
 	go.opencensus.io v0.24.0
@@ -35,7 +35,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/longrunning v0.4.1 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.14.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.117 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -223,7 +223,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -402,7 +402,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -581,7 +581,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -745,7 +745,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -870,7 +870,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -995,7 +995,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1120,7 +1120,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1231,7 +1231,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1327,7 +1327,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1423,7 +1423,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1519,7 +1519,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1644,7 +1644,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -1823,7 +1823,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2002,7 +2002,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2166,7 +2166,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2296,7 +2296,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2426,7 +2426,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2556,7 +2556,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {
@@ -2672,7 +2672,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.14.0"
+                  "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.15.0"
                 }
               },
               "g.co/gae/app/module": {

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	cloud.google.com/go/monitoring v1.12.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.38.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.39.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/stretchr/testify v1.8.3
 	go.opentelemetry.io/otel v1.16.0

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.38.0"
+	return "0.39.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	cloud.google.com/go/trace v1.8.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.38.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.38.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.39.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0
 	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.8.3
 	go.opentelemetry.io/otel v1.16.0

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.14.0"
+	return "1.15.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.14.0"
-	unstable = "0.38.0"
+	stable   = "1.15.0"
+	unstable = "0.39.0"
 )
 
 var versions = map[string]string{


### PR DESCRIPTION
Bumping to latest otel deps with https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/635