### PR TITLE
(logs exporter) Fall back to observed time if timestamp is not set

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access.json
@@ -28,7 +28,7 @@
           "scope": {},
           "logRecords": [
             {
-              "timeUnixNano": "1650984816000000000",
+              "observedTimeUnixNano": "1650984816000000000",
               "body": {
                 "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
               },

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -176,6 +176,23 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with empty timestamp, but set observed_time",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.SetObservedTimestamp(pcommon.NewTimestampFromTime(testSampleTime))
+				return log
+			},
+			mr: func() *monitoredres.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []logging.Entry{
+				{
+					Timestamp: testSampleTime,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log body with string value",
 			mr: func() *monitoredres.MonitoredResource {
 				return nil


### PR DESCRIPTION
Fixes #639 

When the log exporter was first added (https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/373), the [pdata at the time didn't make ObservedTimestamp accessible](https://github.com/open-telemetry/opentelemetry-collector/blob/699a81b216d21770b8fc53c456ffc2ab47ce4308/model/internal/pdata/generated_log.go#L583). It was [added shortly after](https://github.com/open-telemetry/opentelemetry-collector/blob/763cbc6199b62429a3f41feee51bb4ad96bc2771/pdata/internal/generated_plog.go#L583) but we didn't update this todo.