### PR TITLE
all: unify import alias and sort order

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -28,21 +28,20 @@ import (
 	"cloud.google.com/go/logging"
 	loggingv2 "cloud.google.com/go/logging/apiv2"
 	logpb "cloud.google.com/go/logging/apiv2/loggingpb"
-	"google.golang.org/genproto/googleapis/api/monitoredres"
+	"github.com/googleapis/gax-go/v2"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/googleapis/gax-go/v2"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/logsutil"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"
-
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/plog"
-	"go.uber.org/multierr"
-	"go.uber.org/zap"
 )
 
 const (
@@ -327,7 +326,7 @@ func (l logMapper) logEntryToInternal(
 	entry logging.Entry,
 	logName string,
 	projectID string,
-	mr *monitoredres.MonitoredResource,
+	mr *monitoredrespb.MonitoredResource,
 	splits int,
 	splitIndex int,
 ) (*logpb.LogEntry, error) {
@@ -371,7 +370,7 @@ func (l logMapper) getLogName(log plog.LogRecord) (string, error) {
 
 func (l logMapper) logToSplitEntries(
 	log plog.LogRecord,
-	mr *monitoredres.MonitoredResource,
+	mr *monitoredrespb.MonitoredResource,
 	logLabels map[string]string,
 	processTime time.Time,
 	logName string,

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/api/monitoredres"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
 func newTestLogMapper(entrySize int) logMapper {
@@ -54,7 +54,7 @@ func TestLogMapping(t *testing.T) {
 
 	testCases := []struct {
 		log             func() plog.LogRecord
-		mr              func() *monitoredres.MonitoredResource
+		mr              func() *monitoredrespb.MonitoredResource
 		name            string
 		expectedEntries []logging.Entry
 		maxEntrySize    int
@@ -78,7 +78,7 @@ func TestLogMapping(t *testing.T) {
 					Timestamp: testObservedTime,
 				},
 			},
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 		},
@@ -87,7 +87,7 @@ func TestLogMapping(t *testing.T) {
 			log: func() plog.LogRecord {
 				return plog.NewLogRecord()
 			},
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			expectedEntries: []logging.Entry{{
@@ -102,7 +102,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetEmptyBytes().FromRaw([]byte(`{"this": "is json"}`))
 				return log
 			},
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			expectedEntries: []logging.Entry{
@@ -135,7 +135,7 @@ func TestLogMapping(t *testing.T) {
 					}`))
 				return log
 			},
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			expectedEntries: []logging.Entry{
@@ -165,7 +165,7 @@ func TestLogMapping(t *testing.T) {
 				log.SetTimestamp(pcommon.NewTimestampFromTime(testSampleTime))
 				return log
 			},
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			expectedEntries: []logging.Entry{
@@ -182,7 +182,7 @@ func TestLogMapping(t *testing.T) {
 				log.SetObservedTimestamp(pcommon.NewTimestampFromTime(testSampleTime))
 				return log
 			},
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			expectedEntries: []logging.Entry{
@@ -194,7 +194,7 @@ func TestLogMapping(t *testing.T) {
 		},
 		{
 			name: "log body with string value",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {
@@ -213,7 +213,7 @@ func TestLogMapping(t *testing.T) {
 		{
 			// TODO(damemi): parse/test sourceLocation from more than just bytes values
 			name: "log with sourceLocation (bytes)",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {
@@ -237,7 +237,7 @@ func TestLogMapping(t *testing.T) {
 		},
 		{
 			name: "log with traceSampled (bool)",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {
@@ -255,7 +255,7 @@ func TestLogMapping(t *testing.T) {
 		},
 		{
 			name: "log with trace and span id",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {
@@ -275,7 +275,7 @@ func TestLogMapping(t *testing.T) {
 		},
 		{
 			name: "log with severity number",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {
@@ -293,7 +293,7 @@ func TestLogMapping(t *testing.T) {
 		},
 		{
 			name: "log with invalid severity number",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {
@@ -306,7 +306,7 @@ func TestLogMapping(t *testing.T) {
 		},
 		{
 			name: "log with severity text",
-			mr: func() *monitoredres.MonitoredResource {
+			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
 			log: func() plog.LogRecord {

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -32,6 +32,7 @@ import (
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/googleapis/gax-go/v2"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -48,8 +49,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/googleapis/gax-go/v2"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/datapointstorage"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization"

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -18,10 +18,9 @@ import (
 	"regexp"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
+	"go.uber.org/zap"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -28,12 +28,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
-	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
+	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 )
 
 // TraceExporter is a wrapper struct of OT cloud trace exporter.
 type TraceExporter struct {
-	texporter *cloudtrace.Exporter
+	texporter *texporter.Exporter
 }
 
 func (te *TraceExporter) Shutdown(ctx context.Context) error {
@@ -46,26 +46,26 @@ func NewGoogleCloudTracesExporter(ctx context.Context, cfg Config, version strin
 	view.Register(ocgrpc.DefaultClientViews...)
 	setVersionInUserAgent(&cfg, version)
 
-	topts := []cloudtrace.Option{
-		cloudtrace.WithProjectID(cfg.ProjectID),
-		cloudtrace.WithTimeout(timeout),
+	topts := []texporter.Option{
+		texporter.WithProjectID(cfg.ProjectID),
+		texporter.WithTimeout(timeout),
 	}
 
 	if cfg.DestinationProjectQuota {
-		topts = append(topts, cloudtrace.WithDestinationProjectQuota())
+		topts = append(topts, texporter.WithDestinationProjectQuota())
 	}
 
 	if cfg.TraceConfig.AttributeMappings != nil {
-		topts = append(topts, cloudtrace.WithAttributeMapping(mappingFuncFromAKM(cfg.TraceConfig.AttributeMappings)))
+		topts = append(topts, texporter.WithAttributeMapping(mappingFuncFromAKM(cfg.TraceConfig.AttributeMappings)))
 	}
 
 	copts, err := generateClientOptions(ctx, &cfg.TraceConfig.ClientConfig, &cfg, traceapi.DefaultAuthScopes())
 	if err != nil {
 		return nil, err
 	}
-	topts = append(topts, cloudtrace.WithTraceClientOptions(copts))
+	topts = append(topts, texporter.WithTraceClientOptions(copts))
 
-	exp, err := cloudtrace.New(topts...)
+	exp, err := texporter.New(topts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating GoogleCloud Trace exporter: %w", err)
 	}

--- a/exporter/collector/traces_test.go
+++ b/exporter/collector/traces_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	cloudtracepb "cloud.google.com/go/trace/apiv2/tracepb"
+	"cloud.google.com/go/trace/apiv2/tracepb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -31,16 +31,16 @@ import (
 )
 
 type testServer struct {
-	reqCh chan *cloudtracepb.BatchWriteSpansRequest
+	reqCh chan *tracepb.BatchWriteSpansRequest
 }
 
-func (ts *testServer) BatchWriteSpans(ctx context.Context, req *cloudtracepb.BatchWriteSpansRequest) (*emptypb.Empty, error) {
+func (ts *testServer) BatchWriteSpans(ctx context.Context, req *tracepb.BatchWriteSpansRequest) (*emptypb.Empty, error) {
 	go func() { ts.reqCh <- req }()
 	return &emptypb.Empty{}, nil
 }
 
 // Creates a new span.
-func (ts *testServer) CreateSpan(context.Context, *cloudtracepb.Span) (*cloudtracepb.Span, error) {
+func (ts *testServer) CreateSpan(context.Context, *tracepb.Span) (*tracepb.Span, error) {
 	return nil, nil
 }
 
@@ -86,8 +86,8 @@ func TestGoogleCloudTraceExport(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			srv := grpc.NewServer()
-			reqCh := make(chan *cloudtracepb.BatchWriteSpansRequest)
-			cloudtracepb.RegisterTraceServiceServer(srv, &testServer{reqCh: reqCh})
+			reqCh := make(chan *tracepb.BatchWriteSpansRequest)
+			tracepb.RegisterTraceServiceServer(srv, &testServer{reqCh: reqCh})
 
 			lis, err := net.Listen("tcp", "localhost:8080")
 			require.NoError(t, err)

--- a/exporter/metric/cloudmonitoring.go
+++ b/exporter/metric/cloudmonitoring.go
@@ -19,14 +19,14 @@ import (
 	"errors"
 	"fmt"
 
-	"go.opentelemetry.io/otel/sdk/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"golang.org/x/oauth2/google"
 )
 
 // New creates a new Exporter thats implements metric.Exporter.
-func New(opts ...Option) (metric.Exporter, error) {
+func New(opts ...Option) (sdkmetric.Exporter, error) {
 	o := options{
 		context:                 context.Background(),
 		resourceAttributeFilter: DefaultResourceAttributesFilter,

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -34,6 +34,7 @@ import (
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/googleapis/gax-go/v2"
 	"go.uber.org/multierr"
 	"google.golang.org/api/option"
 	"google.golang.org/genproto/googleapis/api/distribution"
@@ -44,8 +45,6 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/googleapis/gax-go/v2"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"
 )

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/trace v1.8.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.39.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.39.0
-	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.8.3
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
@@ -29,6 +28,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect

--- a/exporter/trace/trace.go
+++ b/exporter/trace/trace.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"time"
 
-	traceclient "cloud.google.com/go/trace/apiv2"
-	"cloud.google.com/go/trace/apiv2/tracepb"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	traceapi "cloud.google.com/go/trace/apiv2"
+	"cloud.google.com/go/trace/apiv2/tracepb"
 	"go.uber.org/multierr"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
@@ -35,14 +36,14 @@ type traceExporter struct {
 	o *options
 	// uploadFn defaults in uploadSpans; it can be replaced for tests.
 	uploadFn  func(ctx context.Context, req *tracepb.BatchWriteSpansRequest) error
-	client    *traceclient.Client
+	client    *traceapi.Client
 	projectID string
 	overflowLogger
 }
 
 func newTraceExporter(o *options) (*traceExporter, error) {
 	clientOps := append(o.traceClientOptions, option.WithUserAgent(userAgent))
-	client, err := traceclient.NewClient(o.context, clientOps...)
+	client, err := traceapi.NewClient(o.context, clientOps...)
 	if err != nil {
 		return nil, fmt.Errorf("stackdriver: couldn't initiate trace client: %v", err)
 	}

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -30,10 +30,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"cloud.google.com/go/trace/apiv2/tracepb"
-	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
-	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	codepb "google.golang.org/genproto/googleapis/rpc/code"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping"
 )

--- a/exporter/trace/trace_proto_test.go
+++ b/exporter/trace/trace_proto_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/trace/apiv2/tracepb"
-	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -28,6 +26,9 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+
+	"cloud.google.com/go/trace/apiv2/tracepb"
+	"github.com/stretchr/testify/assert"
 )
 
 func testExporter() *traceExporter {

--- a/internal/cloudmock/metrics.go
+++ b/internal/cloudmock/metrics.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"sync"
 
-	"google.golang.org/genproto/googleapis/api/metric"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -128,9 +128,9 @@ func (f *fakeMetricServiceServer) CreateServiceTimeSeries(
 func (f *fakeMetricServiceServer) CreateMetricDescriptor(
 	ctx context.Context,
 	req *monitoringpb.CreateMetricDescriptorRequest,
-) (*metric.MetricDescriptor, error) {
+) (*metricpb.MetricDescriptor, error) {
 	f.metricsTestServer.appendCreateMetricDescriptorReq(req)
-	return &metric.MetricDescriptor{}, nil
+	return &metricpb.MetricDescriptor{}, nil
 }
 
 func NewMetricTestServer() (*MetricsTestServer, error) {

--- a/propagator/propagator_test.go
+++ b/propagator/propagator_test.go
@@ -22,9 +22,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 const (

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -20,8 +20,8 @@ import (
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/itchyny/gojq/cmd/gojq"
+	_ "github.com/wadey/gocovmerge"
 	_ "golang.org/x/tools/cmd/stringer"
 	_ "golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
-	_ "github.com/wadey/gocovmerge"
 )


### PR DESCRIPTION
Unify import alias and sort order, and switch protobuf to v2 on `exporter/trace` that will remove direct `github.com/golang/protobuf` dependency.