### PR TITLE
Fix typo in WAL config field

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -180,8 +180,8 @@ Additional configuration for the metric exporter:
 - `metric.prefix` (optional): MetricPrefix overrides the prefix / namespace of the Google Cloud metric type identifier. If not set, defaults to "custom.googleapis.com/opencensus/"
 - `metric.skip_create_descriptor` (optional): Whether to skip creating the
   metric descriptor.
-- `metric.experimental_wal.experimental_directory` (optional): Path to local write-ahead-log file.
-- `metric.experimental_wal.experimental_max_backoff` (optional): Maximum duration to retry entries from
+- `metric.experimental_wal.directory` (optional): Path to local write-ahead-log file.
+- `metric.experimental_wal.max_backoff` (optional): Maximum duration to retry entries from
   the WAL on network errors.
 
 Addition configuration for the logging exporter:

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -150,7 +150,7 @@ type WALConfig struct {
 	// Directory is the location to store WAL files.
 	Directory string `mapstructure:"directory"`
 	// MaxBackoff sets the length of time to exponentially re-try failed exports.
-	MaxBackoff time.Duration `mapstructure:"emax_backoff"`
+	MaxBackoff time.Duration `mapstructure:"max_backoff"`
 }
 
 // ImpersonateConfig defines configuration for service account impersonation.


### PR DESCRIPTION
Fixes `emax_backoff` -> `max_backoff` and readme

Will need another release