### PR TITLE
Update docs with correct wal config name

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -180,8 +180,8 @@ Additional configuration for the metric exporter:
 - `metric.prefix` (optional): MetricPrefix overrides the prefix / namespace of the Google Cloud metric type identifier. If not set, defaults to "custom.googleapis.com/opencensus/"
 - `metric.skip_create_descriptor` (optional): Whether to skip creating the
   metric descriptor.
-- `metric.experimental_wal.directory` (optional): Path to local write-ahead-log file.
-- `metric.experimental_wal.max_backoff` (optional): Maximum duration to retry entries from
+- `metric.experimental_wal_config.directory` (optional): Path to local write-ahead-log file.
+- `metric.experimental_wal_config.max_backoff` (optional): Maximum duration to retry entries from
   the WAL on network errors.
 
 Addition configuration for the logging exporter:


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/650

Will need to be updated upstream too