### PR TITLE
Add option to parse error logs to Error Reporting type

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -188,6 +188,10 @@ Addition configuration for the logging exporter:
 
 - `log.default_log_name` (optional): Defines a default name for log entries. If left unset, and a log entry does not have the `gcp.log_name` 
 attribute set, the exporter will return an error processing that entry.
+- `log.error_reporting_type` (option, default = false): If `true`, log records with a severity of `error` or higher will be converted to
+JSON payloads with the `@type` field set for [GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text).
+If the body is currently a string, it will be converted to a `message` field in the new JSON payload. If the body is already a map, the `@type`
+field will be added to the map. Other body types (such as byte) are undefined for this behavior.
 
 Example:
 

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -180,6 +180,9 @@ type LogConfig struct {
 	// service.name, service.namespace, and service.instance.id resource attributes into the Cloud Logging LogEntry labels.
 	// Disabling this option does not prevent resource_filters from adding those labels. Default is true.
 	ServiceResourceLabels bool `mapstructure:"service_resource_labels"`
+	// ErrorReportingType enables automatically parsing error logs to a json payload containing the
+	// type value for GCP Error Reporting. See https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text.
+	ErrorReportingType bool `mapstructure:"error_reporting_type"`
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.

--- a/exporter/collector/integrationtest/testcases/testcases_logs.go
+++ b/exporter/collector/integrationtest/testcases/testcases_logs.go
@@ -31,6 +31,22 @@ var LogsTestCases = []TestCase{
 		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_error_expected.json",
 	},
 	{
+		Name:                 "Apache error log (text payload) with severity converted to Error Reporting type",
+		OTLPInputFixturePath: "testdata/fixtures/logs/logs_apache_text_error.json",
+		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.LogConfig.ErrorReportingType = true
+		},
+	},
+	{
+		Name:                 "Apache error log (json payload) with severity converted to Error Reporting type",
+		OTLPInputFixturePath: "testdata/fixtures/logs/logs_apache_error.json",
+		ExpectFixturePath:    "testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.LogConfig.ErrorReportingType = true
+		},
+	},
+	{
 		Name:                 "Multi-project logs",
 		OTLPInputFixturePath: "testdata/fixtures/logs/logs_multi_project.json",
 		ExpectFixturePath:    "testdata/fixtures/logs/logs_multi_project_expected.json",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error.json
@@ -277,8 +277,8 @@
             },
             {
               "timeUnixNano": "1651013314740290000",
-              "severityNumber": "SEVERITY_NUMBER_WARN",
-              "severityText": "Warn",
+              "severityNumber": "SEVERITY_NUMBER_ERROR",
+              "severityText": "Error",
               "body": {
                 "kvlistValue": {
                   "values": [
@@ -291,7 +291,7 @@
                     {
                       "key": "severity",
                       "value": {
-                        "stringValue": "warn"
+                        "stringValue": "error"
                       }
                     },
                     {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
@@ -12,6 +12,27 @@
             }
           },
           "jsonPayload": {
+            "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
+            "message": "[pid 769:tid 140159306111872] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]",
+            "severity": "error",
+            "time": "Tue Apr 26 22:48:34.740290 2022"
+          },
+          "timestamp": "1970-01-01T00:00:00Z",
+          "severity": "ERROR",
+          "labels": {
+            "log.file.name": "test.log"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/apache-error-fixture",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "jsonPayload": {
             "message": "[pid 417652:tid 139808755448704] AH01232: suEXEC mechanism enabled (wrapper: /usr/local/apache/bin/suexec)",
             "severity": "notice",
             "time": "Tue Apr 26 00:46:21.412645 2022"
@@ -151,26 +172,6 @@
             "time": "Tue Apr 26 22:48:35.606223 2022"
           },
           "timestamp": "1970-01-01T00:00:00Z",
-          "labels": {
-            "log.file.name": "test.log"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/apache-error-fixture",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "jsonPayload": {
-            "message": "[pid 769:tid 140159306111872] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]",
-            "severity": "error",
-            "time": "Tue Apr 26 22:48:34.740290 2022"
-          },
-          "timestamp": "1970-01-01T00:00:00Z",
-          "severity": "ERROR",
           "labels": {
             "log.file.name": "test.log"
           }

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error.json
@@ -1,0 +1,69 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "cloud.platform",
+            "value": {
+              "stringValue": "gcp_compute_engine"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "apache_service"
+            }
+          },
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": ""
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "observedTimeUnixNano": "1650984816000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "severity_number": 17,
+              "attributes": [
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            },
+            {
+              "observedTimeUnixNano": "1650984816000000000",
+              "body": {
+                "stringValue": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
+              },
+              "severity_text": "ERROR",
+              "attributes": [
+                {
+                  "key": "gcp.log_name",
+                  "value": {
+                    "stringValue": "my-log-name-foo"
+                  }
+                }
+              ],
+              "traceId": "",
+              "spanId": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
@@ -1,0 +1,47 @@
+{
+  "writeLogEntriesRequests": [
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "jsonPayload": {
+            "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
+            "message": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
+          },
+          "timestamp": "1970-01-01T00:00:00Z",
+          "severity": "ERROR",
+          "labels": {
+            "service_name": "apache_service"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": ""
+            }
+          },
+          "jsonPayload": {
+            "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
+            "message": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247"
+          },
+          "timestamp": "1970-01-01T00:00:00Z",
+          "severity": "ERROR",
+          "labels": {
+            "service_name": "apache_service"
+          }
+        }
+      ],
+      "partialSuccess": true
+    }
+  ]
+}

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -52,6 +52,9 @@ const (
 	LogNameAttributeKey        = "gcp.log_name"
 	SourceLocationAttributeKey = "gcp.source_location"
 	TraceSampledAttributeKey   = "gcp.trace_sampled"
+
+	GCPTypeKey                 = "@type"
+	GCPErrorReportingTypeValue = "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"
 )
 
 // severityMapping maps the integer severity level values from OTel [0-24]
@@ -462,7 +465,7 @@ func (l logMapper) logToSplitEntries(
 			logRecord.Body().SetEmptyMap()
 			logRecord.Body().Map().PutStr("message", strValue)
 		}
-		logRecord.Body().Map().PutStr("@type", "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent")
+		logRecord.Body().Map().PutStr(GCPTypeKey, GCPErrorReportingTypeValue)
 	}
 
 	entry.Labels = logLabels

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -376,16 +376,20 @@ func (l logMapper) logToSplitEntries(
 	logName string,
 	projectID string,
 ) ([]logging.Entry, error) {
+	// make a copy in case we mutate the record
+	logRecord := plog.NewLogRecord()
+	log.CopyTo(logRecord)
+
 	entry := logging.Entry{
 		Resource: mr,
 	}
 
-	entry.Timestamp = log.Timestamp().AsTime()
-	if log.Timestamp() == 0 {
+	entry.Timestamp = logRecord.Timestamp().AsTime()
+	if logRecord.Timestamp() == 0 {
 		// if timestamp is unset, fall back to observed_time_unix_nano as recommended
 		//   (see https://github.com/open-telemetry/opentelemetry-proto/blob/4abbb78/opentelemetry/proto/logs/v1/logs.proto#L176-L179)
-		if log.ObservedTimestamp() != 0 {
-			entry.Timestamp = log.ObservedTimestamp().AsTime()
+		if logRecord.ObservedTimestamp() != 0 {
+			entry.Timestamp = logRecord.ObservedTimestamp().AsTime()
 		} else {
 			// if observed_time is 0, use the current time
 			entry.Timestamp = processTime
@@ -395,7 +399,7 @@ func (l logMapper) logToSplitEntries(
 	// build our own map off OTel attributes so we don't have to call .Get() for each special case
 	// (.Get() ranges over all attributes each time)
 	attrsMap := make(map[string]pcommon.Value)
-	log.Attributes().Range(func(k string, v pcommon.Value) bool {
+	logRecord.Attributes().Range(func(k string, v pcommon.Value) bool {
 		attrsMap[k] = v
 		return true
 	})
@@ -418,10 +422,10 @@ func (l logMapper) logToSplitEntries(
 	}
 
 	// parse TraceID and SpanID, if present
-	if traceID := log.TraceID(); !traceID.IsEmpty() {
+	if traceID := logRecord.TraceID(); !traceID.IsEmpty() {
 		entry.Trace = fmt.Sprintf("projects/%s/traces/%s", projectID, hex.EncodeToString(traceID[:]))
 	}
-	if spanID := log.SpanID(); !spanID.IsEmpty() {
+	if spanID := logRecord.SpanID(); !spanID.IsEmpty() {
 		entry.SpanID = hex.EncodeToString(spanID[:])
 	}
 
@@ -435,10 +439,10 @@ func (l logMapper) logToSplitEntries(
 		delete(attrsMap, HTTPRequestAttributeKey)
 	}
 
-	if log.SeverityNumber() < 0 || int(log.SeverityNumber()) > len(severityMapping)-1 {
-		return []logging.Entry{entry}, fmt.Errorf("unknown SeverityNumber %v", log.SeverityNumber())
+	if logRecord.SeverityNumber() < 0 || int(logRecord.SeverityNumber()) > len(severityMapping)-1 {
+		return []logging.Entry{entry}, fmt.Errorf("unknown SeverityNumber %v", logRecord.SeverityNumber())
 	}
-	severityNumber := log.SeverityNumber()
+	severityNumber := logRecord.SeverityNumber()
 	// Log severity levels are based on numerical values defined by Otel/GCP, which are informally mapped to generic text values such as "ALERT", "Debug", etc.
 	// In some cases, a SeverityText value can be automatically mapped to a matching SeverityNumber.
 	// If not (for example, when directly setting the SeverityText on a Log entry with the Transform processor), then the
@@ -446,10 +450,20 @@ func (l logMapper) logToSplitEntries(
 	// In this case, we will attempt to map the text ourselves to one of the defined Otel SeverityNumbers.
 	// We do this by checking that the SeverityText is NOT "default" (ie, it exists in our map) and that the SeverityNumber IS "0".
 	// (This also excludes other unknown/custom severity text values, which may have user-defined mappings in the collector)
-	if severityForText, ok := otelSeverityForText[strings.ToLower(log.SeverityText())]; ok && severityNumber == 0 {
+	if severityForText, ok := otelSeverityForText[strings.ToLower(logRecord.SeverityText())]; ok && severityNumber == 0 {
 		severityNumber = severityForText
 	}
 	entry.Severity = severityMapping[severityNumber]
+
+	// Parse severityNumber > 17 (error) to a GCP Error Reporting entry if enabled
+	if severityNumber >= 17 && l.cfg.LogConfig.ErrorReportingType {
+		if logRecord.Body().Type() != pcommon.ValueTypeMap {
+			strValue := logRecord.Body().AsString()
+			logRecord.Body().SetEmptyMap()
+			logRecord.Body().Map().PutStr("message", strValue)
+		}
+		logRecord.Body().Map().PutStr("@type", "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent")
+	}
 
 	entry.Labels = logLabels
 
@@ -478,7 +492,7 @@ func (l logMapper) logToSplitEntries(
 	overheadClone := proto.Clone(logOverhead)
 	overheadBytes := proto.Size(overheadClone)
 
-	payload, splits, err := parseEntryPayload(log.Body(), l.maxEntrySize-overheadBytes)
+	payload, splits, err := parseEntryPayload(logRecord.Body(), l.maxEntrySize-overheadBytes)
 	if err != nil {
 		return []logging.Entry{entry}, err
 	}

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -232,8 +232,83 @@ func TestLogMapping(t *testing.T) {
 			expectedEntries: []logging.Entry{
 				{
 					Payload: map[string]interface{}{
-						"@type":   "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
-						"message": `{"message": "hello!"}`,
+						GCPTypeKey: GCPErrorReportingTypeValue,
+						"message":  `{"message": "hello!"}`,
+					},
+					Timestamp: testObservedTime,
+					Severity:  logging.Error,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+			config: func(cfg *Config) {
+				cfg.LogConfig.ErrorReportingType = true
+			},
+		},
+		{
+			name: "log body with simple string value and error converted to json payload",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.SetSeverityNumber(18)
+				log.Body().SetStr("test string message")
+				return log
+			},
+			expectedEntries: []logging.Entry{
+				{
+					Payload: map[string]interface{}{
+						GCPTypeKey: GCPErrorReportingTypeValue,
+						"message":  "test string message",
+					},
+					Timestamp: testObservedTime,
+					Severity:  logging.Error,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+			config: func(cfg *Config) {
+				cfg.LogConfig.ErrorReportingType = true
+			},
+		},
+		{
+			name: "log body with simple string value and non-error is not converted to json payload",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.SetSeverityNumber(16)
+				log.Body().SetStr("test string message")
+				return log
+			},
+			expectedEntries: []logging.Entry{
+				{
+					Payload:   "test string message",
+					Timestamp: testObservedTime,
+					Severity:  logging.Warning,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+			config: func(cfg *Config) {
+				cfg.LogConfig.ErrorReportingType = true
+			},
+		},
+		{
+			name: "log body with map value and error converted to json payload",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.SetSeverityNumber(18)
+				log.Body().SetEmptyMap().PutStr("msg", "test map value")
+				return log
+			},
+			expectedEntries: []logging.Entry{
+				{
+					Payload: map[string]interface{}{
+						GCPTypeKey: GCPErrorReportingTypeValue,
+						"msg":      "test map value",
 					},
 					Timestamp: testObservedTime,
 					Severity:  logging.Error,


### PR DESCRIPTION
Fixes #665 
This adds an option to the logs exporter, `log.error_reporting_type`, to automatically [format error logs to GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text). To do this, it adds the `@type` field to existing JSON payloads, or converts string payloads to JSON (with a `message` field) and then adds `@type`.

I don't think there is a behavior that makes sense for byte payloads, since that would mean a mixture of byte and string values in the json payload (?).

An improvement to this could be using the [`ReportedErrorEvent` protobuf](https://github.com/googleapis/google-cloud-go/blob/c9aebae6d9cd8518bc247b7198ed38365577a872/errorreporting/apiv1beta1/errorreportingpb/report_errors_service.pb.go#L148) directly rather than just setting `@type`, as documented in https://cloud.google.com/error-reporting/docs/formatting-error-messages#reported-error-example. This adds a requirement for a `service` field.