### PR TITLE
Add GCE resource detector for Instance/Hostname attributes

### DIFF
--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -81,6 +81,7 @@ type metadataProvider interface {
 	InstanceID() (string, error)
 	Get(string) (string, error)
 	InstanceName() (string, error)
+	Hostname() (string, error)
 	Zone() (string, error)
 	InstanceAttributeValue(string) (string, error)
 }

--- a/detectors/gcp/gce.go
+++ b/detectors/gcp/gce.go
@@ -39,8 +39,23 @@ func (d *Detector) GCEHostID() (string, error) {
 }
 
 // GCEHostName returns the instance name of the instance on which this program is running.
+// Recommended to use GCEInstanceName() or GCEInstanceHostname() to more accurately reflect which
+// value is returned.
 func (d *Detector) GCEHostName() (string, error) {
 	return d.metadata.InstanceName()
+}
+
+// GCEInstanceName returns the instance name of the instance on which this program is running.
+// This is the value visible in the Cloud Console UI, and the prefix for the default hostname
+// of the instance as defined by the default internal DNS name (see https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names).
+func (d *Detector) GCEInstanceName() (string, error) {
+	return d.metadata.InstanceName()
+}
+
+// GCEInstanceHostname returns the full value of the default or custom hostname of the instance
+// on which this program is running. See https://cloud.google.com/compute/docs/instances/custom-hostname-vm.
+func (d *Detector) GCEInstanceHostname() (string, error) {
+	return d.metadata.Hostname()
 }
 
 // GCEAvailabilityZoneAndRegion returns the zone and region in which this program is running.

--- a/detectors/gcp/gce_test.go
+++ b/detectors/gcp/gce_test.go
@@ -66,6 +66,25 @@ func TestGCEHostName(t *testing.T) {
 	assert.Equal(t, hostName, "my-host-123")
 }
 
+func TestGCEInstanceName(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		FakeInstanceName: "my-host-123",
+	}, &FakeOSProvider{})
+	hostName, err := d.GCEInstanceName()
+	assert.NoError(t, err)
+	assert.Equal(t, hostName, "my-host-123")
+}
+
+func TestGCEInstanceHostname(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{
+		FakeInstanceName:     "my-host-123",
+		FakeInstanceHostname: "custom-dns.fakevm.example",
+	}, &FakeOSProvider{})
+	hostName, err := d.GCEInstanceHostname()
+	assert.NoError(t, err)
+	assert.Equal(t, hostName, "custom-dns.fakevm.example")
+}
+
 func TestGCEHostNameErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		Err: fmt.Errorf("fake error"),

--- a/detectors/gcp/utils_test.go
+++ b/detectors/gcp/utils_test.go
@@ -19,13 +19,14 @@ func NewTestDetector(metadata *FakeMetadataProvider, os *FakeOSProvider) *Detect
 }
 
 type FakeMetadataProvider struct {
-	Err                error
-	Attributes         map[string]string
-	InstanceAttributes map[string]string
-	FakeInstanceID     string
-	FakeInstanceName   string
-	FakeZone           string
-	Project            string
+	Err                  error
+	Attributes           map[string]string
+	InstanceAttributes   map[string]string
+	FakeInstanceID       string
+	FakeInstanceName     string
+	FakeInstanceHostname string
+	FakeZone             string
+	Project              string
 }
 
 func (f *FakeMetadataProvider) ProjectID() (string, error) {
@@ -51,6 +52,12 @@ func (f *FakeMetadataProvider) InstanceName() (string, error) {
 		return "", f.Err
 	}
 	return f.FakeInstanceName, nil
+}
+func (f *FakeMetadataProvider) Hostname() (string, error) {
+	if f.Err != nil {
+		return "", f.Err
+	}
+	return f.FakeInstanceHostname, nil
 }
 func (f *FakeMetadataProvider) Zone() (string, error) {
 	if f.Err != nil {


### PR DESCRIPTION
Fixes #511 

This adds 2 new GCE resource detector functions: `GCEInstanceName()` and `GCEInstanceHostname()`. These functions are meant to clearly indicate their relation to the [GCP-specific semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/cloud-provider/gcp/gce.md) for `gcp.gce.instance.name` and `gcp.gce.instance.hostname`.

Replaces https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/515