### PR TITLE
non-monotonic sums have the /gauge suffix added in GMP exporter

### DIFF
--- a/exporter/collector/googlemanagedprometheus/naming.go
+++ b/exporter/collector/googlemanagedprometheus/naming.go
@@ -28,6 +28,10 @@ func GetMetricName(baseName string, metric pmetric.Metric) (string, error) {
 	// Second, ad the GMP-specific suffix
 	switch metric.Type() {
 	case pmetric.MetricTypeSum:
+		if !metric.Sum().IsMonotonic() {
+			// Non-monotonic sums are converted to GCM gauges
+			return compliantName + "/gauge", nil
+		}
 		return compliantName + getUnknownMetricSuffix(metric.Sum().DataPoints(), "/counter", "counter"), nil
 	case pmetric.MetricTypeGauge:
 		return compliantName + getUnknownMetricSuffix(metric.Gauge().DataPoints(), "/gauge", ""), nil

--- a/exporter/collector/googlemanagedprometheus/naming_test.go
+++ b/exporter/collector/googlemanagedprometheus/naming_test.go
@@ -77,6 +77,16 @@ func TestGetMetricName(t *testing.T) {
 			expected: "foo_total/counter",
 		},
 		{
+			desc:     "non-monotonic sum",
+			baseName: "foo_total",
+			metric: func(m pmetric.Metric) {
+				m.SetName("foo_total")
+				sum := m.SetEmptySum()
+				sum.SetIsMonotonic(false)
+			},
+			expected: "foo_total/gauge",
+		},
+		{
 			desc:     "gauge",
 			baseName: "bar",
 			metric: func(m pmetric.Metric) {
@@ -150,6 +160,7 @@ func TestGetMetricName(t *testing.T) {
 				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, false)
 				m.SetName("bar")
 				m.SetEmptySum()
+				m.Sum().SetIsMonotonic(true)
 				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			expected: "bar/counter",
@@ -174,6 +185,7 @@ func TestGetMetricName(t *testing.T) {
 				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
 				m.SetName("bar")
 				m.SetEmptySum()
+				m.Sum().SetIsMonotonic(true)
 				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			expected: "bar/unknown:counter",


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/675