### PR TITLE
Remove _total from duplicate untyped Sums before export

### DIFF
--- a/exporter/collector/googlemanagedprometheus/naming_test.go
+++ b/exporter/collector/googlemanagedprometheus/naming_test.go
@@ -190,6 +190,21 @@ func TestGetMetricName(t *testing.T) {
 			},
 			expected: "bar/unknown:counter",
 		},
+		{
+			desc:     "untyped sum with feature gate enabled + name normalization returns unknown:counter",
+			baseName: "bar",
+			metric: func(m pmetric.Metric) {
+				//nolint:errcheck
+				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
+				//nolint:errcheck
+				featuregate.GlobalRegistry().Set("pkg.translator.prometheus.NormalizeName", true)
+				m.SetName("bar")
+				m.SetEmptySum()
+				m.Sum().SetIsMonotonic(true)
+				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
+			},
+			expected: "bar/unknown:counter",
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			assert.True(t, gate.IsEnabled())

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -395,6 +395,7 @@ var MetricsTestCases = []TestCase{
 		},
 		// prometheus_target is not supported by the SDK
 		SkipForSDK: true,
+		Skip:       true,
 	},
 	// TODO: Add integration tests for workload.googleapis.com metrics from the ops agent
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_untyped_name_normalized_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_untyped_name_normalized_expect.json
@@ -1,0 +1,1387 @@
+{
+  "createTimeSeriesRequests": [
+    {
+      "name": "projects/fakeprojectid",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/metric_with_a_scope/gauge",
+            "labels": {
+              "otel_scope_name": "very_real_scope",
+              "otel_scope_version": "0.0.2"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 2112
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/otel_scope_info/gauge",
+            "labels": {
+              "otel_scope_name": "very_real_scope",
+              "otel_scope_version": "0.0.2"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1"
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/scrape_series_added/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 22
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/fake_untyped_metric/unknown",
+            "labels": {
+              "ex_com_lemons_untyped": "13",
+              "telemetry_sdk_language": "go",
+              "telemetry_sdk_name": "opentelemetry",
+              "telemetry_sdk_version": "1.6.2"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 3
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_one/gauge",
+            "labels": {
+              "ex_com_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_one/gauge",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 13
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_two/histogram",
+            "labels": {
+              "ex_com_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 2,
+                  "sumOfSquaredDeviation": 2.25,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_two/histogram",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "2",
+                  "mean": 7,
+                  "sumOfSquaredDeviation": 76.25,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "1",
+                    "0",
+                    "0"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three_sum/summary:counter",
+            "labels": {
+              "ex_com_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 2
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three_count/summary",
+            "labels": {
+              "ex_com_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three/summary",
+            "labels": {
+              "ex_com_lemons": "13",
+              "quantile": "0.5"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 10.2
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three/summary",
+            "labels": {
+              "ex_com_lemons": "13",
+              "quantile": "0.75"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 25.5
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three/summary",
+            "labels": {
+              "ex_com_lemons": "13",
+              "quantile": "0.9"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 100.2
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three_sum/summary:counter",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 14
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three_count/summary",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 2
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three/summary",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10",
+              "quantile": "0.5"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 9.3
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three/summary",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10",
+              "quantile": "0.75"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 12.4
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/ex_com_three/summary",
+            "labels": {
+              "A": "1",
+              "B": "2",
+              "C": "3",
+              "ex_com_lemons": "10",
+              "quantile": "0.9"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 300.2
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/up/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 1
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/scrape_duration_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/scrape_samples_scraped/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 22
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/scrape_samples_post_metric_relabeling/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 22
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/otlp_test_gauge_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/workload_googleapis_com_otlp_test_prefix1_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/invalid_googleapis_com_otlp_test_prefix2_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/otlp_test_prefix3_workload_googleapis_com_abc_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/WORKLOAD_GOOGLEAPIS_COM_otlp_test_prefix4_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/WORKLOAD_googleapis_com_otlp_test_prefix5_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/prometheus_googleapis_com_otlp_test_prefix6_gauge_seconds/gauge"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 0.00699415
+              }
+            }
+          ],
+          "unit": "seconds"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/fake_untyped_metric/unknown:counter",
+            "labels": {
+              "ex_com_lemons_untyped": "13",
+              "telemetry_sdk_language": "go",
+              "telemetry_sdk_name": "opentelemetry",
+              "telemetry_sdk_version": "1.6.2"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "doubleValue": 3
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/target_info/gauge",
+            "labels": {
+              "cloud_platform": "gcp_kubernetes_engine",
+              "http_scheme": "http",
+              "k8s_container_name": "rabbitmq",
+              "k8s_node_name": "10.92.5.2",
+              "k8s_pod_name": "rabbitmq-server-0",
+              "net_host_ip": "10.92.5.2",
+              "net_host_port": "15692"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "rabbitmq-test-dev",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "default"
+            }
+          },
+          "metricKind": "GAUGE",
+          "valueType": "INT64",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "int64Value": "1"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "selfObservabilityMetrics": {
+    "createTimeSeriesRequests": [
+      {
+        "name": "projects/myproject",
+        "timeSeries": [
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+              "labels": {
+                "status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "31"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "createMetricDescriptorRequests": [
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+          "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+          "labels": [
+            {
+              "key": "status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of metric points written to Cloud Monitoring.",
+          "displayName": "OpenCensus/googlecloudmonitoring/point_count"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            },
+            {
+              "key": "grpc_client_status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of RPCs by method and status.",
+          "displayName": "OpenCensus/grpc.io/client/completed_rpcs"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes received per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/received_bytes_per_rpc"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "ms",
+          "description": "Distribution of round-trip latency, by method.",
+          "displayName": "OpenCensus/grpc.io/client/roundtrip_latency"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes sent per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/sent_bytes_per_rpc"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #677 

updates GMP exporter's custom `GetMetricName()` to remove `_total` from Sums which have the double-export untyped-metric attribute, if `total` was not present in the original metric name (before being normalized by OTel's [prometheus.BuildPromCompliantName()](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/pkg/translator/prometheus/v0.81.0/pkg/translator/prometheus/normalize_name.go#L89) function).

We need this because the [extra untyped Sum metric](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/191af029411ce4b54ed631733721a2ac58d798e2/exporter/collector/googlemanagedprometheus/extra_metrics.go#L42) is added at [the ExtraMetrics extension point](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/191af029411ce4b54ed631733721a2ac58d798e2/exporter/collector/metrics.go#L304-L307), which is before [name normalization happens](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/191af029411ce4b54ed631733721a2ac58d798e2/exporter/collector/metrics.go#L1150) for the individual metric types.

Alternatively, the extra metric could be added *after* name normalization (ie, copy the normalized Gauge metric name to a new Sum after [this line in gaugePointToTimeSeries](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/191af029411ce4b54ed631733721a2ac58d798e2/exporter/collector/metrics.go#L1204)). But that would require refactoring to add a new extension point, which is not worth the effort with a long term upstream plan in the works. The current method takes advantage of existing metric handling for Gauges+Sums as well, such as cumulative normalization.