### PR TITLE
fix: only drop _total for untyped sums

### DIFF
--- a/exporter/collector/googlemanagedprometheus/naming.go
+++ b/exporter/collector/googlemanagedprometheus/naming.go
@@ -65,14 +65,10 @@ func getUnknownMetricName(points pmetric.NumberDataPointSlice, suffix, secondary
 		return compliantName + suffix
 	}
 
-	// de-normalize "_total" suffix for counters where not present on original metric name
 	nameTokens := strings.FieldsFunc(
 		originalName,
 		func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) },
 	)
-	if nameTokens[len(nameTokens)-1] != "total" && strings.HasSuffix(compliantName, "_total") {
-		compliantName = strings.TrimSuffix(compliantName, "_total")
-	}
 
 	newSuffix := suffix
 	for i := 0; i < points.Len(); i++ {
@@ -80,6 +76,12 @@ func getUnknownMetricName(points pmetric.NumberDataPointSlice, suffix, secondary
 		if val, ok := point.Attributes().Get(GCPOpsAgentUntypedMetricKey); ok && val.AsString() == "true" {
 			// delete the special Ops Agent untyped attribute
 			point.Attributes().Remove(GCPOpsAgentUntypedMetricKey)
+
+			// de-normalize "_total" suffix for counters where not present on original metric name
+			if nameTokens[len(nameTokens)-1] != "total" && strings.HasSuffix(compliantName, "_total") {
+				compliantName = strings.TrimSuffix(compliantName, "_total")
+			}
+
 			newSuffix = "/unknown"
 			if len(secondarySuffix) > 0 {
 				newSuffix = newSuffix + ":" + secondarySuffix

--- a/exporter/collector/googlemanagedprometheus/naming_test.go
+++ b/exporter/collector/googlemanagedprometheus/naming_test.go
@@ -46,7 +46,7 @@ func TestGetMetricName(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			desc:     "sum without total gets added",
+			desc:     "sum without total is unaffected",
 			baseName: "foo",
 			metric: func(m pmetric.Metric) {
 				m.SetName("foo")
@@ -191,7 +191,7 @@ func TestGetMetricName(t *testing.T) {
 			expected: "bar/unknown:counter",
 		},
 		{
-			desc:     "untyped sum with feature gate enabled + name normalization returns unknown:counter",
+			desc:     "untyped sum with feature gate enabled + name normalization returns unknown:counter without _total",
 			baseName: "bar",
 			metric: func(m pmetric.Metric) {
 				//nolint:errcheck
@@ -204,6 +204,20 @@ func TestGetMetricName(t *testing.T) {
 				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			expected: "bar/unknown:counter",
+		},
+		{
+			desc:     "normal sum without total and feature gate enabled + name normalization adds _total",
+			baseName: "foo",
+			metric: func(m pmetric.Metric) {
+				//nolint:errcheck
+				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
+				//nolint:errcheck
+				featuregate.GlobalRegistry().Set("pkg.translator.prometheus.NormalizeName", true)
+				m.SetName("foo")
+				sum := m.SetEmptySum()
+				sum.SetIsMonotonic(true)
+			},
+			expected: "foo_total/counter",
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
Fixup https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/678#issuecomment-1640701294