### PR TITLE
Add option to Metrics SDK exporter to allow sending sum of squared deviation

### DIFF
--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -102,12 +102,15 @@ var MetricsTestCases = []TestCase{
 		Name:                 "Histogram becomes a GCM Distribution",
 		OTLPInputFixturePath: "testdata/fixtures/metrics/histogram.json",
 		ExpectFixturePath:    "testdata/fixtures/metrics/histogram_expect.json",
-		// TODO(dashpole): implement sum of squared deviation in the SDK exporter and enable here.
 		ConfigureCollector: func(cfg *collector.Config) {
 			cfg.MetricConfig.ServiceResourceLabels = false
 			cfg.MetricConfig.InstrumentationLibraryLabels = true
+			cfg.MetricConfig.EnableSumOfSquaredDeviation = true
 		},
-		MetricSDKExporterOptions: []metric.Option{metric.WithFilteredResourceAttributes(metric.NoAttributes)},
+		MetricSDKExporterOptions: []metric.Option{
+			metric.WithFilteredResourceAttributes(metric.NoAttributes),
+			metric.WithSumOfSquaredDeviation(),
+		},
 	},
 	{
 		Name:                 "Exponential Histogram becomes a GCM Distribution with exponential bucketOptions",
@@ -124,13 +127,22 @@ var MetricsTestCases = []TestCase{
 		Name:                 "Metrics from the Prometheus receiver can be successfully delivered",
 		OTLPInputFixturePath: "testdata/fixtures/metrics/prometheus.json",
 		ExpectFixturePath:    "testdata/fixtures/metrics/prometheus_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.MetricConfig.EnableSumOfSquaredDeviation = true
+		},
+		MetricSDKExporterOptions: []metric.Option{
+			metric.WithSumOfSquaredDeviation(),
+		},
 	},
 	{
 		Name:                 "Prometheus stale data point is dropped",
 		OTLPInputFixturePath: "testdata/fixtures/metrics/prometheus_stale.json",
 		ExpectFixturePath:    "testdata/fixtures/metrics/prometheus_stale_expect.json",
 		CompareFixturePath:   "testdata/fixtures/metrics/prometheus_expect.json",
-		SkipForSDK:           true, // Stale point handling is not required for the SDK.
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.MetricConfig.EnableSumOfSquaredDeviation = true
+		},
+		SkipForSDK: true, // Stale point handling is not required for the SDK.
 	},
 	// Tests with special configuration options
 	{
@@ -255,6 +267,7 @@ var MetricsTestCases = []TestCase{
 				Directory:  dir,
 				MaxBackoff: time.Duration(1 * time.Second),
 			}
+			cfg.MetricConfig.EnableSumOfSquaredDeviation = true
 		},
 		SkipForSDK: true,
 	},

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -31,6 +31,7 @@
                 "distributionValue": {
                   "count": "1",
                   "mean": 2,
+                  "sumOfSquaredDeviation": 2.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [
@@ -86,6 +87,7 @@
                 "distributionValue": {
                   "count": "2",
                   "mean": 7,
+                  "sumOfSquaredDeviation": 76.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
@@ -140,6 +140,7 @@
                 "distributionValue": {
                   "count": "1",
                   "mean": 2,
+                  "sumOfSquaredDeviation": 2.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [
@@ -202,6 +203,7 @@
                 "distributionValue": {
                   "count": "2",
                   "mean": 7,
+                  "sumOfSquaredDeviation": 76.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
@@ -140,6 +140,7 @@
                 "distributionValue": {
                   "count": "1",
                   "mean": 2,
+                  "sumOfSquaredDeviation": 2.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [
@@ -202,6 +203,7 @@
                 "distributionValue": {
                   "count": "2",
                   "mean": 7,
+                  "sumOfSquaredDeviation": 76.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
@@ -140,6 +140,7 @@
                 "distributionValue": {
                   "count": "1",
                   "mean": 2,
+                  "sumOfSquaredDeviation": 2.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [
@@ -202,6 +203,7 @@
                 "distributionValue": {
                   "count": "2",
                   "mean": 7,
+                  "sumOfSquaredDeviation": 76.25,
                   "bucketOptions": {
                     "explicitBuckets": {
                       "bounds": [

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -579,6 +579,8 @@ func sumToTimeSeries[N int64 | float64](point metricdata.DataPoint[N], metrics m
 	}, nil
 }
 
+// TODO(@dashpole): Refactor to pass control-coupling lint check.
+//
 //nolint:revive
 func histogramToTimeSeries[N int64 | float64](point metricdata.HistogramDataPoint[N], metrics metricdata.Metrics, mr *monitoredrespb.MonitoredResource, enableSOSD bool) (*monitoringpb.TimeSeries, error) {
 	interval, err := toNonemptyTimeIntervalpb(point.StartTime, point.Time)

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -68,6 +68,10 @@ type options struct {
 
 	// disableCreateMetricDescriptors disables automatic MetricDescriptor creation
 	disableCreateMetricDescriptors bool
+
+	// enableSumOfSquaredDeviation enables calculation of an estimated sum of squared
+	// deviation.  It isn't correct, so we don't send it by default.
+	enableSumOfSquaredDeviation bool
 }
 
 // WithProjectID sets Google Cloud Platform project as projectID.
@@ -145,5 +149,13 @@ func WithDisableCreateMetricDescriptors() func(o *options) {
 func WithCompression(c string) func(o *options) {
 	return func(o *options) {
 		o.compression = c
+	}
+}
+
+// WithSumOfSquaredDeviation sets the SumOfSquaredDeviation field on histograms.
+// It is an estimate, and is not the actual sum of squared deviations.
+func WithSumOfSquaredDeviation() func(o *options) {
+	return func(o *options) {
+		o.enableSumOfSquaredDeviation = true
 	}
 }


### PR DESCRIPTION
This is useful for users, but also allows me to test sumofsquareddeviations in the fixture tests for the collector and SDK.