### PR TITLE
Expand scope of kubernetes monitored resource mapping to include other platforms

### DIFF
--- a/exporter/collector/monitoredresource_test.go
+++ b/exporter/collector/monitoredresource_test.go
@@ -128,6 +128,220 @@ func TestResourceMetricsToMonitoredResource(t *testing.T) {
 			},
 		},
 		{
+			name: "EKS cluster",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "aws_eks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_cluster",
+				Labels: map[string]string{
+					"cluster_name": "mycluster",
+					"location":     "us-central1",
+				},
+			},
+		},
+		{
+			name: "AKS cluster",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "azure_aks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_cluster",
+				Labels: map[string]string{
+					"cluster_name": "mycluster",
+					"location":     "us-central1",
+				},
+			},
+		},
+		{
+			name: "EKS pod",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "aws_eks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"cluster_name":   "mycluster",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+					"location":       "us-central1",
+				},
+			},
+		},
+		{
+			name: "AKS pod",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "azure_aks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"cluster_name":   "mycluster",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+					"location":       "us-central1",
+				},
+			},
+		},
+		{
+			name: "EKS node",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "aws_eks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.node.name":           "mynode",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_node",
+				Labels: map[string]string{
+					"cluster_name": "mycluster",
+					"node_name":    "mynode",
+					"location":     "us-central1",
+				},
+			},
+		},
+		{
+			name: "AKS node",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "azure_aks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.node.name":           "mynode",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_node",
+				Labels: map[string]string{
+					"cluster_name": "mycluster",
+					"node_name":    "mynode",
+					"location":     "us-central1",
+				},
+			},
+		},
+		{
+			name: "EKS container",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "aws_eks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+				"k8s.container.name":      "mycontainer",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"cluster_name":   "mycluster",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+					"container_name": "mycontainer",
+					"location":       "us-central1",
+				},
+			},
+		},
+		{
+			name: "AKS container",
+			resourceLabels: map[string]string{
+				"cloud.platform":          "azure_aks",
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "mycluster",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+				"k8s.container.name":      "mycontainer",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"cluster_name":   "mycluster",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+					"container_name": "mycontainer",
+					"location":       "us-central1",
+				},
+			},
+		},
+		{
+			name: "Non-cloud k8s cluster",
+			resourceLabels: map[string]string{
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "minikube",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_cluster",
+				Labels: map[string]string{
+					"location":     "us-central1",
+					"cluster_name": "minikube",
+				},
+			},
+		},
+		{
+			name: "Non-cloud k8s node",
+			resourceLabels: map[string]string{
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "minikube",
+				"k8s.node.name":           "mynode",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_node",
+				Labels: map[string]string{
+					"location":     "us-central1",
+					"cluster_name": "minikube",
+					"node_name":    "mynode",
+				},
+			},
+		},
+		{
+			name: "Non-cloud k8s pod",
+			resourceLabels: map[string]string{
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "minikube",
+				"k8s.node.name":           "mynode",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"location":       "us-central1",
+					"cluster_name":   "minikube",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+				},
+			},
+		},
+		{
+			name: "Non-cloud k8s container",
+			resourceLabels: map[string]string{
+				"cloud.availability_zone": "us-central1",
+				"k8s.cluster.name":        "minikube",
+				"k8s.node.name":           "mynode",
+				"k8s.namespace.name":      "mynamespace",
+				"k8s.pod.name":            "mypod",
+				"k8s.container.name":      "mycontainer",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"location":       "us-central1",
+					"cluster_name":   "minikube",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+					"container_name": "mycontainer",
+				},
+			},
+		},
+		{
 			name: "AWS ec2 instance",
 			resourceLabels: map[string]string{
 				"cloud.platform":          "aws_ec2",

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -479,7 +479,25 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 			},
 		},
 		{
-			desc: "nonexisting resource types",
+			desc: "nonexisting resource types (no k8s.cluster.name)",
+			resource: resource.NewWithAttributes(
+				semconv.SchemaURL,
+				attribute.String("cloud.provider", "none"),
+				attribute.String("cloud.platform", "gcp_foobar"),
+				attribute.String("cloud.availability_zone", "us-central1-a"),
+				attribute.String("k8s.namespace.name", "default"),
+				attribute.String("k8s.pod.name", "opentelemetry-pod-autoconf"),
+				attribute.String("k8s.container.name", "opentelemetry"),
+			),
+			expectedType: "generic_node",
+			expectedLabels: map[string]string{
+				"location":  "us-central1-a",
+				"namespace": "",
+				"node_id":   "",
+			},
+		},
+		{
+			desc: "non-cloud k8s platform",
 			resource: resource.NewWithAttributes(
 				semconv.SchemaURL,
 				attribute.String("cloud.provider", "none"),
@@ -490,11 +508,13 @@ func TestResourceToMonitoredResourcepb(t *testing.T) {
 				attribute.String("k8s.pod.name", "opentelemetry-pod-autoconf"),
 				attribute.String("k8s.container.name", "opentelemetry"),
 			),
-			expectedType: "generic_node",
+			expectedType: "k8s_container",
 			expectedLabels: map[string]string{
-				"location":  "us-central1-a",
-				"namespace": "",
-				"node_id":   "",
+				"location":       "us-central1-a",
+				"cluster_name":   "opentelemetry-cluster",
+				"namespace_name": "default",
+				"pod_name":       "opentelemetry-pod-autoconf",
+				"container_name": "opentelemetry",
 			},
 		},
 		{

--- a/internal/resourcemapping/resourcemapping.go
+++ b/internal/resourcemapping/resourcemapping.go
@@ -168,55 +168,47 @@ type ReadOnlyAttributes interface {
 // E.g.
 // This may output `gce_instance` type with appropriate labels.
 func ResourceAttributesToMonitoredResource(attrs ReadOnlyAttributes) *GceResource {
-	cloudPlatform := getK8sClusterOrCloudPlatform(attrs)
-	var mr *GceResource
+	cloudPlatform, _ := attrs.GetString(string(semconv.CloudPlatformKey))
 	switch cloudPlatform {
 	case semconv.CloudPlatformGCPComputeEngine.Value.AsString():
-		mr = createMonitoredResource(gceInstance, attrs)
-	case k8sCluster:
-		// Try for most to least specific k8s_container, k8s_pod, etc
-		if _, ok := attrs.GetString(string(semconv.K8SContainerNameKey)); ok {
-			mr = createMonitoredResource(k8sContainer, attrs)
-		} else if _, ok := attrs.GetString(string(semconv.K8SPodNameKey)); ok {
-			mr = createMonitoredResource(k8sPod, attrs)
-		} else if _, ok := attrs.GetString(string(semconv.K8SNodeNameKey)); ok {
-			mr = createMonitoredResource(k8sNode, attrs)
-		} else {
-			mr = createMonitoredResource(k8sCluster, attrs)
-		}
+		return createMonitoredResource(gceInstance, attrs)
 	case semconv.CloudPlatformGCPAppEngine.Value.AsString():
-		mr = createMonitoredResource(gaeInstance, attrs)
+		return createMonitoredResource(gaeInstance, attrs)
 	case semconv.CloudPlatformAWSEC2.Value.AsString():
-		mr = createMonitoredResource(awsEc2Instance, attrs)
+		return createMonitoredResource(awsEc2Instance, attrs)
 	// TODO(alex-basinov): replace this string literal with semconv.CloudPlatformGCPBareMetalSolution
 	// once https://github.com/open-telemetry/semantic-conventions/pull/64 makes its way
 	// into the semconv module.
 	case "gcp_bare_metal_solution":
-		mr = createMonitoredResource(bmsInstance, attrs)
+		return createMonitoredResource(bmsInstance, attrs)
 	default:
+		// if k8s.cluster.name is set, pattern match for various k8s resources.
+		// this will also match non-cloud k8s platforms like minikube.
+		if _, ok := attrs.GetString(string(semconv.K8SClusterNameKey)); ok {
+			// Try for most to least specific k8s_container, k8s_pod, etc
+			if _, ok := attrs.GetString(string(semconv.K8SContainerNameKey)); ok {
+				return createMonitoredResource(k8sContainer, attrs)
+			} else if _, ok := attrs.GetString(string(semconv.K8SPodNameKey)); ok {
+				return createMonitoredResource(k8sPod, attrs)
+			} else if _, ok := attrs.GetString(string(semconv.K8SNodeNameKey)); ok {
+				return createMonitoredResource(k8sNode, attrs)
+			} else {
+				return createMonitoredResource(k8sCluster, attrs)
+			}
+		}
+
 		// Fallback to generic_task
 		_, hasServiceName := attrs.GetString(string(semconv.ServiceNameKey))
 		_, hasFaaSName := attrs.GetString(string(semconv.FaaSNameKey))
 		_, hasServiceInstanceID := attrs.GetString(string(semconv.ServiceInstanceIDKey))
 		_, hasFaaSID := attrs.GetString(string(semconv.FaaSIDKey))
 		if (hasServiceName && hasServiceInstanceID) || (hasFaaSID && hasFaaSName) {
-			mr = createMonitoredResource(genericTask, attrs)
-		} else {
-			mr = createMonitoredResource(genericNode, attrs)
+			return createMonitoredResource(genericTask, attrs)
 		}
-	}
-	return mr
-}
 
-// getK8sClusterOrCloudPlatform returns "k8s_cluster" if K8SClusterNameKey is set
-// (which identifies cloud provider clusters like GKE, EKS, AKS, or non-cloud clusters like minikube)
-// Otherwise, it returns the cloud.platform value.
-func getK8sClusterOrCloudPlatform(attrs ReadOnlyAttributes) string {
-	if _, cluster := attrs.GetString(string(semconv.K8SClusterNameKey)); cluster {
-		return k8sCluster
+		// Everything else fallback to generic_node
+		return createMonitoredResource(genericNode, attrs)
 	}
-	cloudPlatform, _ := attrs.GetString(string(semconv.CloudPlatformKey))
-	return cloudPlatform
 }
 
 func createMonitoredResource(


### PR DESCRIPTION
Fixes #627 
This broadens the exporter's monitored resource mapping to match anything with `k8s.cluster.name` resource attribute to a k8s monitored resource. Using `k8s.cluster.name` means that any cloud provider k8s platforms like GKE, EKS, or AKS should be identified, as well as non-cloud clusters like local k8s or minikube.

This is a change from the previous behavior, in which any non-GKE kubernetes resources were mapped to `generic_node`.