### PR TITLE
Add TraceFlags support to logs exporter

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id.json
@@ -31,7 +31,7 @@
                             {
                               "key": "msg",
                               "value": {
-                                "stringValue": "hello world 0"
+                                "stringValue": "this log has IsSampled=0"
                               }
                             }
                           ]
@@ -41,6 +41,7 @@
                   ]
                 }
               },
+              "flags": 0,
               "attributes": [
                 {
                   "key": "file.name",
@@ -83,7 +84,7 @@
                             {
                               "key": "msg",
                               "value": {
-                                "stringValue": "hello world 1"
+                                "stringValue": "this log has IsSampled=1"
                               }
                             }
                           ]
@@ -93,6 +94,7 @@
                   ]
                 }
               },
+              "flags": 1,
               "attributes": [
                 {
                   "key": "file.name",
@@ -129,7 +131,7 @@
                             {
                               "key": "msg",
                               "value": {
-                                "stringValue": "hello world 2"
+                                "stringValue": "this log has neither flag nor gcp.trace_sampled"
                               }
                             },
                             {
@@ -187,7 +189,7 @@
                             {
                               "key": "msg",
                               "value": {
-                                "stringValue": "hello world 3"
+                                "stringValue": "this log has gcp.trace_sampled=false"
                               }
                             }
                           ]
@@ -208,6 +210,12 @@
                   "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
+                  }
+                },
+                {
+                  "key": "gcp.trace_sampled",
+                  "value": {
+                    "boolValue": false
                   }
                 }
               ],
@@ -239,7 +247,7 @@
                             {
                               "key": "msg",
                               "value": {
-                                "stringValue": "hello world 4"
+                                "stringValue": "this log has gcp.trace_sampled=true"
                               }
                             }
                           ]
@@ -260,6 +268,12 @@
                   "key": "gcp.log_name",
                   "value": {
                     "stringValue": "my-log-name-foo"
+                  }
+                },
+                {
+                  "key": "gcp.trace_sampled",
+                  "value": {
+                    "boolValue": true
                   }
                 }
               ],

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
@@ -15,7 +15,7 @@
           "jsonPayload": {
             "body": {
               "level": "info",
-              "msg": "hello world 0",
+              "msg": "this log has IsSampled=0",
               "time": "2022-06-22T16:13:19Z"
             }
           },
@@ -39,7 +39,7 @@
           "jsonPayload": {
             "body": {
               "level": "info",
-              "msg": "hello world 1",
+              "msg": "this log has IsSampled=1",
               "time": "2022-06-22T16:13:19Z"
             }
           },
@@ -48,7 +48,8 @@
             "file.name": "apache.log"
           },
           "trace": "projects/fakeprojectid/traces/ad57e7b40d6f172d04f8a0e1b80cafe4",
-          "spanId": "97c0f2f642dd1306"
+          "spanId": "97c0f2f642dd1306",
+          "traceSampled": true
         },
         {
           "logName": "projects/fakeprojectid/logs/my-log-name-foo",
@@ -63,31 +64,7 @@
           "jsonPayload": {
             "body": {
               "level": "info",
-              "msg": "hello world 2",
-              "time": "2022-06-22T16:13:19Z"
-            }
-          },
-          "timestamp": "1970-01-01T00:00:00Z",
-          "labels": {
-            "file.name": "apache.log"
-          },
-          "trace": "projects/fakeprojectid/traces/ad57e7b40d6f172d04f8a0e1b80cafe4",
-          "spanId": "fded437fb39abed9"
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
-          "resource": {
-            "type": "generic_node",
-            "labels": {
-              "location": "global",
-              "namespace": "",
-              "node_id": ""
-            }
-          },
-          "jsonPayload": {
-            "body": {
-              "level": "info",
-              "msg": "hello world 3",
+              "msg": "this log has gcp.trace_sampled=false",
               "time": "2022-06-22T16:13:19Z"
             }
           },
@@ -111,7 +88,7 @@
           "jsonPayload": {
             "body": {
               "level": "info",
-              "msg": "hello world 4",
+              "msg": "this log has gcp.trace_sampled=true",
               "time": "2022-06-22T16:13:19Z"
             }
           },
@@ -120,7 +97,32 @@
             "file.name": "apache.log"
           },
           "trace": "projects/fakeprojectid/traces/ad57e7b40d6f172d04f8a0e1b80cafe4",
-          "spanId": "d9ae3a7b26ef239f"
+          "spanId": "d9ae3a7b26ef239f",
+          "traceSampled": true
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "generic_node",
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            }
+          },
+          "jsonPayload": {
+            "body": {
+              "level": "info",
+              "msg": "this log has neither flag nor gcp.trace_sampled",
+              "time": "2022-06-22T16:13:19Z"
+            }
+          },
+          "timestamp": "1970-01-01T00:00:00Z",
+          "labels": {
+            "file.name": "apache.log"
+          },
+          "trace": "projects/fakeprojectid/traces/ad57e7b40d6f172d04f8a0e1b80cafe4",
+          "spanId": "fded437fb39abed9"
         }
       ],
       "partialSuccess": true

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -418,9 +418,9 @@ func (l logMapper) logToSplitEntries(
 		delete(attrsMap, SourceLocationAttributeKey)
 	}
 
-	// parse TraceSampled boolean from OTel attribute
-	if traceSampled, ok := attrsMap[TraceSampledAttributeKey]; ok {
-		entry.TraceSampled = traceSampled.Bool()
+	// parse TraceSampled boolean from OTel attribute or IsSampled OTLP flag
+	if traceSampled, ok := attrsMap[TraceSampledAttributeKey]; ok || logRecord.Flags().IsSampled() {
+		entry.TraceSampled = (traceSampled.Bool() || logRecord.Flags().IsSampled())
 		delete(attrsMap, TraceSampledAttributeKey)
 	}
 

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -363,6 +363,24 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with IsSampled",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.SetFlags(log.Flags().WithIsSampled(true))
+				return log
+			},
+			expectedEntries: []logging.Entry{
+				{
+					TraceSampled: true,
+					Timestamp:    testObservedTime,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log with trace and span id",
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil


### PR DESCRIPTION
Fixes #685 
Adds support for TraceFlags to parse traceID sampling (alongside the existing `gcp.trace_sampled` attribute)

Right now, if either flag is set then TraceSampled will be true. We might want to shift to one taking precedence, but for backward compatibility this is the least breaking way to introduce the feature.