### PR TITLE
feat: Add invalid_json_byte_strings option to logs exporter

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -186,12 +186,23 @@ Additional configuration for the metric exporter:
 
 Addition configuration for the logging exporter:
 
-- `log.default_log_name` (optional): Defines a default name for log entries. If left unset, and a log entry does not have the `gcp.log_name` 
-attribute set, the exporter will return an error processing that entry.
-- `log.error_reporting_type` (option, default = false): If `true`, log records with a severity of `error` or higher will be converted to
-JSON payloads with the `@type` field set for [GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text).
-If the body is currently a string, it will be converted to a `message` field in the new JSON payload. If the body is already a map, the `@type`
-field will be added to the map. Other body types (such as byte) are undefined for this behavior.
+- `log.default_log_name` (optional): Defines a default name for log entries. If
+left unset, and a log entry does not have the `gcp.log_name` attribute set, the
+exporter will return an error processing that entry.
+- `log.error_reporting_type` (option, default = false): If `true`, log records
+with a severity of `error` or higher will be converted to JSON payloads with the
+`@type` field set for [GCP Error
+Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text).
+If the body is currently a string, it will be converted to a `message` field in
+the new JSON payload. If the body is already a map, the `@type` field will be
+added to the map. Other body types (such as byte) are undefined for this
+behavior.
+- `log.invalid_json_byte_strings` (optional, default = false): If `true`, any
+  log with a body of type byte will be converted to a string payload, if the
+  original byte body does not marshal to valid JSON. Cloud Logging requires
+  non-string payloads to marshal to JSON, but it is possible to have a byte body
+  in OTLP that is not a valid JSON object. Enabling this setting allows such
+  OTLP byte bodies to be exported to Cloud Logging as raw strings.
 
 Example:
 

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -183,6 +183,11 @@ type LogConfig struct {
 	// ErrorReportingType enables automatically parsing error logs to a json payload containing the
 	// type value for GCP Error Reporting. See https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text.
 	ErrorReportingType bool `mapstructure:"error_reporting_type"`
+	// InvalidJsonByteStrings exports any Log body of type byte as a raw byte string, when the
+	// byte body does not marshal to valid JSON. Cloud Logging requires byte payloads to marshal to
+	// valid JSON via the encoding/json package. When byte payloads do not translate to valid JSON,
+	// this allows them to still be passed to Cloud Logging as a raw string payload.
+	InvalidJSONByteStrings bool `mapstructure:"invalid_json_byte_strings"`
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -122,6 +122,43 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with invalid json byte body returns raw byte string",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyBytes().FromRaw([]byte(`"this is not json"`))
+				return log
+			},
+			config: func(cfg *Config) {
+				cfg.LogConfig.InvalidJSONByteStrings = true
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []logging.Entry{
+				{
+					Payload:   "InRoaXMgaXMgbm90IGpzb24i", // "this is not json" as raw bytes body
+					Timestamp: testObservedTime,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with invalid json byte body and flag disabled returns error",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyBytes().FromRaw([]byte(`"this is not json"`))
+				return log
+			},
+			config: func(cfg *Config) {
+				cfg.LogConfig.InvalidJSONByteStrings = false
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectError:  true,
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log with json and httpRequest, empty monitoredresource",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()


### PR DESCRIPTION
Fixes #689 

Cloud Logging requires payloads to be a string, or something that marshals to a JSON object. However, a Log body in OTLP can be anything, even bytes that don't necessarily represent valid JSON.

Currently, sending non-JSON bytes through the exporter results in a json.Unmarshal error. But, users may want to export these bytes as a byte string, not necessarily JSON.

You can workaround this by transforming the data to an object. This PR adds a feature to pass along the raw byte string as a string payload instead.