### PR TITLE
Map faas.name and faas.instance to prometheus job and instance for GMP

### DIFF
--- a/exporter/collector/googlemanagedprometheus/monitoredresource.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource.go
@@ -40,9 +40,9 @@ var promTargetKeys = map[string][]string{
 	locationLabel:         {locationLabel, semconv.AttributeCloudAvailabilityZone, semconv.AttributeCloudRegion},
 	clusterLabel:          {clusterLabel, semconv.AttributeK8SClusterName},
 	namespaceLabel:        {namespaceLabel, semconv.AttributeK8SNamespaceName},
-	jobLabel:              {semconv.AttributeServiceName},
+	jobLabel:              {jobLabel, semconv.AttributeFaaSName, semconv.AttributeServiceName},
 	serviceNamespaceLabel: {semconv.AttributeServiceNamespace},
-	instanceLabel:         {semconv.AttributeServiceInstanceID},
+	instanceLabel:         {instanceLabel, semconv.AttributeFaaSInstance, semconv.AttributeServiceInstanceID},
 }
 
 func MapToPrometheusTarget(res pcommon.Resource) *monitoredrespb.MonitoredResource {

--- a/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
@@ -146,6 +146,25 @@ func TestMapToPrometheusTarget(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Attributes from cloud run",
+			resourceLabels: map[string]string{
+				"cloud.region":  "us-central1",
+				"service.name":  "service:unknown",
+				"faas.name":     "my-cloud-run-service",
+				"faas.instance": "1234759430923053489543203",
+			},
+			expected: &monitoredrespb.MonitoredResource{
+				Type: "prometheus_target",
+				Labels: map[string]string{
+					"location":  "us-central1",
+					"cluster":   "",
+					"namespace": "",
+					"job":       "my-cloud-run-service",
+					"instance":  "1234759430923053489543203",
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			r := pcommon.NewResource()


### PR DESCRIPTION
Step 1 for https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/679.

Since service.name has a default value, we need faas.name to take precedence over service.name.  But I still want to give users the option to override job, so i've opted to add `job` as the override to match other labels.

For instance, i've opted to follow the pattern set by name.

In theory, this could be breaking for users if they are setting service.name or service.instance.id on cloud run and expect it to show up.  But if we don't take this approach, this doesn't make the migration to the new value seamless for users that followed the example.

Thoughts? @punya @aabmass 