### PR TITLE
Second attempt: Switch to using log protos directly

### DIFF
--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.42.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9
 	github.com/googleapis/gax-go/v2 v2.11.0
 	github.com/stretchr/testify v1.8.4
@@ -25,6 +26,7 @@ require (
 	go.uber.org/zap v1.23.0
 	golang.org/x/oauth2 v0.8.0
 	google.golang.org/api v0.126.0
+	google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
@@ -41,7 +43,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -61,7 +62,6 @@ require (
 	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -343,8 +343,6 @@ func (l logMapper) logEntryToInternal(
 		return nil, err
 	}
 
-	internalLogEntry.LogName = fmt.Sprintf("projects/%s/logs/%s", projectID, url.PathEscape(logName))
-	internalLogEntry.Resource = mr
 	if splits > 1 {
 		internalLogEntry.Split = &logpb.LogSplit{
 			Uid:         fmt.Sprintf("%s-%s", logName, entry.Timestamp.String()),
@@ -759,6 +757,7 @@ func (l logMapper) logToSplitEntries(
 			entry.Labels[k] = v.AsString()
 		}
 	}
+	entry.LogName = fmt.Sprintf("projects/%s/logs/%s", projectID, url.PathEscape(logName))
 
 	// Calculate the size of the internal log entry so this overhead can be accounted
 	// for when determining the need to split based on payload size

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -390,8 +390,8 @@ func toLogEntryInternal(e logging.Entry, parent string, skipLevels int) (*logpb.
 		HttpRequest: req,
 		Operation:   e.Operation,
 		Labels:      e.Labels,
-		Trace:       e.Trace,
-		SpanId:      e.SpanID,
+		// Trace:       e.Trace,
+		// SpanId:      e.SpanID,
 		// Resource:       e.Resource,
 		SourceLocation: e.SourceLocation,
 		TraceSampled:   e.TraceSampled,
@@ -701,7 +701,7 @@ func (l logMapper) logToSplitEntries(
 		entry.Trace = fmt.Sprintf("projects/%s/traces/%s", projectID, hex.EncodeToString(traceID[:]))
 	}
 	if spanID := logRecord.SpanID(); !spanID.IsEmpty() {
-		entry.SpanID = hex.EncodeToString(spanID[:])
+		entry.SpanId = hex.EncodeToString(spanID[:])
 	}
 
 	if httpRequestAttr, ok := attrsMap[HTTPRequestAttributeKey]; ok {

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -379,15 +379,20 @@ func toLogEntryInternal(e logging.Entry, skipLevels int) (*logpb.LogEntry, error
 	ent := &logpb.LogEntry{
 		// Timestamp:      ts,
 		// Severity: logtypepb.LogSeverity(e.Severity),
-		InsertId: e.InsertID,
+		// // We never set InsertID
+		// InsertId: e.InsertID,
 		// HttpRequest: req,
-		Operation: e.Operation,
-		Labels:    e.Labels,
+		// // We never set Operation
+		// Operation: e.Operation,
+		// // We already set this above.
+		// Labels: e.Labels,
 		// Trace:       e.Trace,
 		// SpanId:      e.SpanID,
 		// Resource:       e.Resource,
-		SourceLocation: e.SourceLocation,
-		TraceSampled:   e.TraceSampled,
+		// // We already set this above.
+		// SourceLocation: e.SourceLocation,
+		// // We already set this above.
+		// TraceSampled:   e.TraceSampled,
 	}
 	switch p := e.Payload.(type) {
 	case string:

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -651,7 +651,7 @@ func (l logMapper) logToSplitEntries(
 	logRecord := plog.NewLogRecord()
 	log.CopyTo(logRecord)
 
-	entry := logging.Entry{
+	entry := &logpb.LogEntry{
 		Resource: mr,
 	}
 

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -385,7 +385,7 @@ func toLogEntryInternal(e logging.Entry, parent string, skipLevels int) (*logpb.
 	// }
 	ent := &logpb.LogEntry{
 		// Timestamp:      ts,
-		Severity: logtypepb.LogSeverity(e.Severity),
+		// Severity: logtypepb.LogSeverity(e.Severity),
 		InsertId: e.InsertID,
 		// HttpRequest: req,
 		Operation: e.Operation,
@@ -732,7 +732,7 @@ func (l logMapper) logToSplitEntries(
 	if severityForText, ok := otelSeverityForText[strings.ToLower(logRecord.SeverityText())]; ok && severityNumber == 0 {
 		severityNumber = severityForText
 	}
-	entry.Severity = severityMapping[severityNumber]
+	entry.Severity = logtypepb.LogSeverity(severityMapping[severityNumber])
 
 	// Parse severityNumber > 17 (error) to a GCP Error Reporting entry if enabled
 	if severityNumber >= 17 && l.cfg.LogConfig.ErrorReportingType {

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -354,9 +354,10 @@ func (l logMapper) logEntryToInternal(
 }
 
 func toLogEntryInternal(e logging.Entry, skipLevels int) (*logpb.LogEntry, error) {
-	if e.LogName != "" {
-		return nil, errors.New("logging: Entry.LogName should be not be set when writing")
-	}
+	// LogName is always set above.
+	// if e.LogName != "" {
+	// 	return nil, errors.New("logging: Entry.LogName should be not be set when writing")
+	// }
 	// t := e.Timestamp
 	// if t.IsZero() {
 	// 	t = time.Now()

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -379,17 +379,17 @@ func toLogEntryInternal(e logging.Entry, parent string, skipLevels int) (*logpb.
 			e.Trace = fmt.Sprintf("%s/traces/%s", parent, e.Trace)
 		}
 	}
-	req, err := fromHTTPRequest(e.HTTPRequest)
-	if err != nil {
-		return nil, err
-	}
+	// req, err := fromHTTPRequest(e.HTTPRequest)
+	// if err != nil {
+	// 	return nil, err
+	// }
 	ent := &logpb.LogEntry{
 		// Timestamp:      ts,
-		Severity:    logtypepb.LogSeverity(e.Severity),
-		InsertId:    e.InsertID,
-		HttpRequest: req,
-		Operation:   e.Operation,
-		Labels:      e.Labels,
+		Severity: logtypepb.LogSeverity(e.Severity),
+		InsertId: e.InsertID,
+		// HttpRequest: req,
+		Operation: e.Operation,
+		Labels:    e.Labels,
 		// Trace:       e.Trace,
 		// SpanId:      e.SpanID,
 		// Resource:       e.Resource,
@@ -710,7 +710,11 @@ func (l logMapper) logToSplitEntries(
 		if err != nil {
 			l.obs.log.Debug("Unable to parse httpRequest", zap.Error(err))
 		}
-		entry.HTTPRequest = httpRequest
+		req, err := fromHTTPRequest(httpRequest)
+		if err != nil {
+			return nil, err
+		}
+		entry.HttpRequest = req
 		delete(attrsMap, HTTPRequestAttributeKey)
 	}
 

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -61,7 +61,6 @@ func TestLogMapping(t *testing.T) {
 	testSpanID := pcommon.SpanID([8]byte{
 		0, 0, 0, 0, 0, 0, 0, 1,
 	})
-	emptyPayload := &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{}}}
 	logName := "projects/fakeprojectid/logs/default-log"
 
 	testCases := []struct {
@@ -118,7 +117,6 @@ func TestLogMapping(t *testing.T) {
 			expectedEntries: []*logpb.LogEntry{{
 				LogName:   logName,
 				Timestamp: timestamppb.New(testObservedTime),
-				Payload:   emptyPayload,
 			}},
 			maxEntrySize: defaultMaxEntrySize,
 		},
@@ -207,7 +205,6 @@ func TestLogMapping(t *testing.T) {
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testSampleTime),
-					Payload:   emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
@@ -226,7 +223,6 @@ func TestLogMapping(t *testing.T) {
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testSampleTime),
-					Payload:   emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
@@ -377,7 +373,6 @@ func TestLogMapping(t *testing.T) {
 						Line:     100,
 						Function: "helloWorld",
 					},
-					Payload: emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
@@ -397,7 +392,6 @@ func TestLogMapping(t *testing.T) {
 					LogName:      logName,
 					Timestamp:    timestamppb.New(testObservedTime),
 					TraceSampled: true,
-					Payload:      emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
@@ -419,7 +413,6 @@ func TestLogMapping(t *testing.T) {
 					Timestamp: timestamppb.New(testObservedTime),
 					Trace:     fmt.Sprintf("projects/fakeprojectid/traces/%s", hex.EncodeToString(testTraceID[:])),
 					SpanId:    hex.EncodeToString(testSpanID[:]),
-					Payload:   emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
@@ -439,7 +432,6 @@ func TestLogMapping(t *testing.T) {
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
 					Severity:  logtypepb.LogSeverity(logging.Critical),
-					Payload:   emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
@@ -472,7 +464,6 @@ func TestLogMapping(t *testing.T) {
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
 					Severity:  logtypepb.LogSeverity(logging.Alert),
-					Payload:   emptyPayload,
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	logtypepb "google.golang.org/genproto/googleapis/logging/type"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -68,7 +69,7 @@ func TestLogMapping(t *testing.T) {
 		mr              func() *monitoredrespb.MonitoredResource
 		config          Option
 		name            string
-		expectedEntries []*logpb.LogEntry
+		expectedEntries []logpb.LogEntry
 		maxEntrySize    int
 		expectError     bool
 	}{
@@ -80,7 +81,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetStr("abcxyz")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Payload:   &logpb.LogEntry_TextPayload{TextPayload: "abc"},
@@ -114,7 +115,7 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
-			expectedEntries: []*logpb.LogEntry{{
+			expectedEntries: []logpb.LogEntry{{
 				LogName:   logName,
 				Timestamp: timestamppb.New(testObservedTime),
 			}},
@@ -131,7 +132,7 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -166,7 +167,7 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -201,7 +202,7 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testSampleTime),
@@ -219,7 +220,7 @@ func TestLogMapping(t *testing.T) {
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testSampleTime),
@@ -237,7 +238,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetStr("{\"message\": \"hello!\"}")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -257,7 +258,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetStr("{\"message\": \"hello!\"}")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -284,7 +285,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetStr("test string message")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -311,7 +312,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetStr("test string message")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -335,7 +336,7 @@ func TestLogMapping(t *testing.T) {
 				log.Body().SetEmptyMap().PutStr("msg", "test map value")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -364,7 +365,7 @@ func TestLogMapping(t *testing.T) {
 				)
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -387,7 +388,7 @@ func TestLogMapping(t *testing.T) {
 				log.Attributes().PutBool(TraceSampledAttributeKey, true)
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:      logName,
 					Timestamp:    timestamppb.New(testObservedTime),
@@ -407,7 +408,7 @@ func TestLogMapping(t *testing.T) {
 				log.SetSpanID(testSpanID)
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -427,7 +428,7 @@ func TestLogMapping(t *testing.T) {
 				log.SetSeverityNumber(plog.SeverityNumberFatal)
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -459,7 +460,7 @@ func TestLogMapping(t *testing.T) {
 				log.SetSeverityText("fatal3")
 				return log
 			},
-			expectedEntries: []*logpb.LogEntry{
+			expectedEntries: []logpb.LogEntry{
 				{
 					LogName:   logName,
 					Timestamp: timestamppb.New(testObservedTime),
@@ -489,7 +490,10 @@ func TestLogMapping(t *testing.T) {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, testCase.expectedEntries, entries)
+				assert.Equal(t, len(testCase.expectedEntries), len(entries))
+				for i := range testCase.expectedEntries {
+					assert.True(t, proto.Equal(&testCase.expectedEntries[i], &entries[i]))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Superceeds https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/692

This switches the logging exporter to use the generated logging protos directly, rather than using the handwritten logging.LogEntry structs (which we were just converting to the generated protos before sending anyway)

I ensured that this maintains the same behavior by starting by copying in the implementation of ToLogEntry and working from that point.