### PR TITLE
Always fall back to string payload if we can't handle structured logs

### DIFF
--- a/exporter/collector/README.md
+++ b/exporter/collector/README.md
@@ -186,12 +186,17 @@ Additional configuration for the metric exporter:
 
 Addition configuration for the logging exporter:
 
-- `log.default_log_name` (optional): Defines a default name for log entries. If left unset, and a log entry does not have the `gcp.log_name` 
-attribute set, the exporter will return an error processing that entry.
-- `log.error_reporting_type` (option, default = false): If `true`, log records with a severity of `error` or higher will be converted to
-JSON payloads with the `@type` field set for [GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text).
-If the body is currently a string, it will be converted to a `message` field in the new JSON payload. If the body is already a map, the `@type`
-field will be added to the map. Other body types (such as byte) are undefined for this behavior.
+- `log.default_log_name` (optional): Defines a default name for log entries. If
+left unset, and a log entry does not have the `gcp.log_name` attribute set, the
+exporter will return an error processing that entry.
+- `log.error_reporting_type` (option, default = false): If `true`, log records
+with a severity of `error` or higher will be converted to JSON payloads with the
+`@type` field set for [GCP Error
+Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text).
+If the body is currently a string, it will be converted to a `message` field in
+the new JSON payload. If the body is already a map, the `@type` field will be
+added to the map. Other body types (such as byte) are undefined for this
+behavior.
 
 Example:
 

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -470,7 +470,7 @@ func (l logMapper) logToSplitEntries(
 			entry.Payload = &logpb.LogEntry_JsonPayload{JsonPayload: s}
 			return []*logpb.LogEntry{entry}, nil
 		}
-		l.obs.log.Warn(fmt.Sprintf("bytes body cannot be converted to a json payload, exporting as base64 string: %+v", err))
+		l.obs.log.Debug(fmt.Sprintf("bytes body cannot be converted to a json payload, exporting as base64 string: %+v", err))
 	}
 	// For all other ValueTypes, export as a string payload.
 

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -139,6 +139,24 @@ func TestLogMapping(t *testing.T) {
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
+		}, {
+			name: "log with invalid json byte body returns raw byte string",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyBytes().FromRaw([]byte(`"this is not json"`))
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Payload:   &logpb.LogEntry_TextPayload{TextPayload: "InRoaXMgaXMgbm90IGpzb24i"},
+					Timestamp: timestamppb.New(testObservedTime),
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
 			name: "log with json and httpRequest, empty monitoredresource",


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/689

Supersedes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/689

This is slightly broader in scope than https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/689.  That PR only handled the case where we are unable to marshal the payload to JSON.  It could still fail to export for other reasons, such as map keys or values containing invalid UTF-8.  It could also fail if we didn't support the ValueType (e.g. ValueTypeSlice, or ValueTypeInt).

This PR changes the logs exporter to always fall back to attempting to send a raw string payload if we are unable to create a structpb.Struct from the body.