### PR TITLE
Write logs to gae_app instead of gae_instance

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -203,7 +203,7 @@ func DefaultConfig() Config {
 			ServiceResourceLabels:            true,
 			CumulativeNormalization:          true,
 			GetMetricName:                    defaultGetMetricName,
-			MapMonitoredResource:             defaultResourceToMonitoredResource,
+			MapMonitoredResource:             defaultResourceToMonitoringMonitoredResource,
 		},
 	}
 }

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -247,7 +247,7 @@ func (l logMapper) createEntries(ld plog.Logs) (map[string][]*logpb.LogEntry, er
 	entries := make(map[string][]*logpb.LogEntry)
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
-		mr := defaultResourceToMonitoredResource(rl.Resource())
+		mr := defaultResourceToLoggingMonitoredResource(rl.Resource())
 		extraResourceLabels := resourceToLabels(rl.Resource(), l.cfg.LogConfig.ServiceResourceLabels, l.cfg.LogConfig.ResourceFilters, l.obs.log)
 		projectID := l.cfg.ProjectID
 		// override project ID with gcp.project.id, if present

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -2397,7 +2397,7 @@ func TestPushMetricsOntoWAL(t *testing.T) {
 	obs := selfObservability{zap.NewNop()}
 	cfg := Config{
 		MetricConfig: MetricConfig{
-			MapMonitoredResource: defaultResourceToMonitoredResource,
+			MapMonitoredResource: defaultResourceToMonitoringMonitoredResource,
 			GetMetricName:        defaultGetMetricName,
 			WALConfig: &WALConfig{
 				Directory: tmpDir,

--- a/exporter/collector/monitoredresource.go
+++ b/exporter/collector/monitoredresource.go
@@ -39,20 +39,17 @@ func (attrs *attributes) GetString(key string) (string, bool) {
 }
 
 // defaultResourceToMonitoredResource pdata Resource to a GCM Monitored Resource.
-func defaultResourceToMonitoredResource(resource pcommon.Resource) *monitoredrespb.MonitoredResource {
-	attrs := resource.Attributes()
-	gmr := resourcemapping.ResourceAttributesToMonitoredResource(&attributes{
-		Attrs: attrs,
+func defaultResourceToMonitoringMonitoredResource(resource pcommon.Resource) *monitoredrespb.MonitoredResource {
+	return resourcemapping.ResourceAttributesToMonitoringMonitoredResource(&attributes{
+		Attrs: resource.Attributes(),
 	})
-	newLabels := make(labels, len(gmr.Labels))
-	for k, v := range gmr.Labels {
-		newLabels[k] = sanitizeUTF8(v)
-	}
-	mr := &monitoredrespb.MonitoredResource{
-		Type:   gmr.Type,
-		Labels: newLabels,
-	}
-	return mr
+}
+
+// defaultResourceToMonitoredResource pdata Resource to a GCM Monitored Resource.
+func defaultResourceToLoggingMonitoredResource(resource pcommon.Resource) *monitoredrespb.MonitoredResource {
+	return resourcemapping.ResourceAttributesToLoggingMonitoredResource(&attributes{
+		Attrs: resource.Attributes(),
+	})
 }
 
 // resourceToLabels converts the Resource attributes into labels.

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -357,7 +357,7 @@ func (attrs *attributes) GetString(key string) (string, bool) {
 //
 // https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.monitoredResourceDescriptors
 func (me *metricExporter) resourceToMonitoredResourcepb(res *resource.Resource) *monitoredrespb.MonitoredResource {
-	gmr := resourcemapping.ResourceAttributesToMonitoredResource(&attributes{
+	gmr := resourcemapping.ResourceAttributesToMonitoringMonitoredResource(&attributes{
 		attrs: attribute.NewSet(res.Attributes()...),
 	})
 	newLabels := make(map[string]string, len(gmr.Labels))

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -118,7 +118,7 @@ func attributeWithLabelsFromResources(sd sdktrace.ReadOnlySpan) []attribute.KeyV
 	}
 
 	// Monitored resource attributes (`g.co/r/{resource_type}/{resource_label}`) come next.
-	gceResource := resourcemapping.ResourceAttributesToMonitoredResource(&attrs{
+	gceResource := resourcemapping.ResourceAttributesToMonitoringMonitoredResource(&attrs{
 		Attrs: sd.Resource().Attributes(),
 	})
 	for key, value := range gceResource.Labels {

--- a/internal/resourcemapping/go.mod
+++ b/internal/resourcemapping/go.mod
@@ -2,4 +2,12 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resou
 
 go 1.21
 
-require go.opentelemetry.io/otel v1.16.0
+require (
+	go.opentelemetry.io/otel v1.16.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
+)
+
+require (
+	google.golang.org/genproto v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
+)

--- a/internal/resourcemapping/go.sum
+++ b/internal/resourcemapping/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -8,5 +10,13 @@ github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gt
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=
 go.opentelemetry.io/otel v1.16.0/go.mod h1:vl0h9NUa1D5s1nv3A5vZOYWn8av4K8Ml6JDeHrT/bx4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/genproto v0.0.0-20230706204954-ccb25ca9f130 h1:Au6te5hbKUV8pIYWHqOUZ1pva5qK/rwbIhoXEUB9Lu8=
+google.golang.org/genproto v0.0.0-20230706204954-ccb25ca9f130/go.mod h1:O9kGHb51iE/nOGvQaDUuadVYqovW56s5emA88lQnj6Y=
+google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e h1:z3vDksarJxsAKM5dmEGv0GHwE2hKJ096wZra71Vs4sw=
+google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e/go.mod h1:rsr7RhLuwsDKL7RmgDDCUc6yaGr1iqceVb5Wv6f6YvQ=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/696

I also simplified MR mapping by moving returning a *monitoredrespb.MonitoredResource from the internal package, and performing utf-8 sanitization in the internal package.