### PR TITLE
Fix release tool

### DIFF
--- a/tools/release.go
+++ b/tools/release.go
@@ -84,14 +84,16 @@ func (m module) editRequirement(dep, version string) error {
 	return nil
 }
 
-func (m module) version() string {
+func (m module) dir() string {
 	modDir := filepath.Dir(string(m))
 	if modDir == "." {
-		modDir = ""
-	} else {
-		modDir += "/"
+		return ""
 	}
-	return versionForPath(modDir)
+	return modDir + "/"
+}
+
+func (m module) version() string {
+	return versionForPath(m.dir())
 }
 
 func versionForPath(modDir string) string {
@@ -153,9 +155,8 @@ func tag() error {
 	if err != nil {
 		return err
 	}
-	for _, dir := range mods {
-		ver := versionForPath(string(dir))
-		tag := string(dir) + "v" + ver
+	for _, m := range mods {
+		tag := m.dir() + "v" + m.version()
 		fmt.Printf("Creating tag %s\n", tag)
 		cmd := exec.Command("git", "tag", tag)
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
It tagged:

```
Creating tag detectors/gcp/go.modv0.43.0
Creating tag e2e-test-server/cloud_functions/go.modv0.43.0
Creating tag e2e-test-server/go.modv0.43.0
Creating tag example/metric/collector/go.modv0.43.0
Creating tag example/metric/sdk/go.modv0.43.0
Creating tag example/trace/http/go.modv0.43.0
Creating tag exporter/collector/go.modv0.43.0
Creating tag exporter/collector/googlemanagedprometheus/go.modv0.43.0
Creating tag exporter/collector/integrationtest/go.modv0.43.0
Creating tag exporter/metric/go.modv0.43.0
Creating tag exporter/trace/go.modv0.43.0
Creating tag go.modv0.43.0
Creating tag internal/cloudmock/go.modv0.43.0
Creating tag internal/resourcemapping/go.modv0.43.0
Creating tag propagator/go.modv0.43.0
Creating tag tools/go.modv0.43.0
```

I didn't push the tags, but this fixes the paths:

```
Creating tag detectors/gcp/v1.19.0
Creating tag e2e-test-server/cloud_functions/v0.43.0
Creating tag e2e-test-server/v0.43.0
Creating tag example/metric/collector/v0.43.0
Creating tag example/metric/sdk/v0.43.0
Creating tag example/trace/http/v0.43.0
Creating tag exporter/collector/v0.43.0
Creating tag exporter/collector/googlemanagedprometheus/v0.43.0
Creating tag exporter/collector/integrationtest/v0.43.0
Creating tag exporter/metric/v0.43.0
Creating tag exporter/trace/v1.19.0
Creating tag v0.43.0
Creating tag internal/cloudmock/v0.43.0
Creating tag internal/resourcemapping/v0.43.0
Creating tag propagator/v0.43.0
Creating tag tools/v0.43.0
Now push the newly created tags to Github using git push --tags
```