### PR TITLE
remove service.name -> g.co/gae/app/module mapping from trace exporter's default mapping

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -47,11 +47,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -162,6 +157,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -224,11 +224,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -341,6 +336,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -403,11 +403,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -520,6 +515,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -582,11 +582,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -699,6 +694,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -746,11 +746,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -822,6 +817,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -873,11 +873,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -947,6 +942,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -998,11 +998,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1072,6 +1067,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1123,11 +1123,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1199,6 +1194,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -1232,11 +1232,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1293,6 +1288,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1330,11 +1330,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1389,6 +1384,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1426,11 +1426,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1485,6 +1480,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1522,11 +1522,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1581,6 +1576,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1645,11 +1645,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1762,6 +1757,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -1824,11 +1824,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1941,6 +1936,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -2003,11 +2003,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2120,6 +2115,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -2167,11 +2167,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2248,6 +2243,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -2299,11 +2299,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -2378,6 +2373,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -2429,11 +2429,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -2508,6 +2503,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -2559,11 +2559,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -2640,6 +2635,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -2673,11 +2673,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2734,6 +2729,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -47,11 +47,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -162,6 +157,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -224,11 +224,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -341,6 +336,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -403,11 +403,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -520,6 +515,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -582,11 +582,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -699,6 +694,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -746,11 +746,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -822,6 +817,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -873,11 +873,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -947,6 +942,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -998,11 +998,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1072,6 +1067,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1123,11 +1123,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1199,6 +1194,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -1232,11 +1232,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1293,6 +1288,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1330,11 +1330,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1389,6 +1384,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1426,11 +1426,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1485,6 +1480,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1522,11 +1522,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -1581,6 +1576,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -1645,11 +1645,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1762,6 +1757,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -1824,11 +1824,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1941,6 +1936,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -2003,11 +2003,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-server"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2120,6 +2115,11 @@
                   "value": "foo"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-server"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -2167,11 +2167,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2248,6 +2243,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -2299,11 +2299,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -2378,6 +2373,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -2429,11 +2429,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -2508,6 +2503,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {
@@ -2559,11 +2559,6 @@
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
                 }
               },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
-                }
-              },
               "g.co/r/generic_node/location": {
                 "stringValue": {
                   "value": "global"
@@ -2640,6 +2635,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
+                }
+              },
               "telemetry.sdk.language": {
                 "stringValue": {
                   "value": "go"
@@ -2673,11 +2673,6 @@
               "g.co/agent": {
                 "stringValue": {
                   "value": "opentelemetry-go 1.16.0; google-cloud-trace-exporter 1.19.1"
-                }
-              },
-              "g.co/gae/app/module": {
-                "stringValue": {
-                  "value": "demo-client"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2734,6 +2729,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "service.name": {
+                "stringValue": {
+                  "value": "demo-client"
                 }
               },
               "telemetry.sdk.language": {

--- a/exporter/collector/traces_test.go
+++ b/exporter/collector/traces_test.go
@@ -64,10 +64,10 @@ func TestGoogleCloudTraceExport(t *testing.T) {
 					},
 				},
 			},
-			expectedServiceKey: "g.co/gae/app/module",
+			expectedServiceKey: "service.name",
 		},
 		{
-			name: "With Empty Mapping",
+			name: "With Custom Mapping",
 			cfg: Config{
 				ProjectID: "idk",
 				TraceConfig: TraceConfig{
@@ -75,10 +75,15 @@ func TestGoogleCloudTraceExport(t *testing.T) {
 						Endpoint:    "127.0.0.1:8080",
 						UseInsecure: true,
 					},
-					AttributeMappings: []AttributeMapping{},
+					AttributeMappings: []AttributeMapping{
+						{
+							Key:         "service.name",
+							Replacement: "g.co/gae/app/module",
+						},
+					},
 				},
 			},
-			expectedServiceKey: "service.name",
+			expectedServiceKey: "g.co/gae/app/module",
 		},
 	}
 

--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -61,9 +61,6 @@ const (
 	labelHTTPStatusCode = `/http/status_code`
 	labelHTTPPath       = `/http/path`
 	labelHTTPUserAgent  = `/http/user_agent`
-	// This is prefixed for google app engine, but translates to the service
-	// in the trace UI.
-	labelService = `g.co/gae/app/module`
 
 	instrumentationScopeNameAttribute    = "otel.scope.name"
 	instrumentationScopeVersionAttribute = "otel.scope.version"
@@ -306,8 +303,6 @@ func defaultAttributeMapping(k attribute.Key) attribute.Key {
 		return labelHTTPUserAgent
 	case statusCodeAttribute:
 		return labelHTTPStatusCode
-	case serviceAttribute:
-		return labelService
 	}
 	return k
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/711

 The UI now supports service.name.

This brings the go trace exporter in-line with trace exporters in other languages.