### PR TITLE
Move metric example to example_test.go

### DIFF
--- a/exporter/metric/README.md
+++ b/exporter/metric/README.md
@@ -11,51 +11,6 @@ OpenTelemetry Google Cloud Monitoring Exporter allow the user to send collected 
 
 Google Cloud Monitoring is a managed service provided by Google Cloud Platform. Google Cloud Monitoring requires to set up "Workspace" in advance. The guide to create a new Workspace is available on [the official document](https://cloud.google.com/monitoring/workspaces/create).
 
-## Usage
-
-After you import the metric exporter package, then register the exporter to the application, and start sending metrics. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instructions in [Authentication](#Authentication).
-
-```go
-package main
-
-import (
-	"context"
-	"log"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric"
-
-	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
-)
-
-func main() {
-	exporter, err := mexporter.New()
-	if err != nil {
-		log.Fatalf("Failed to create exporter: %v", err)
-	}
-	// initialize a MeterProvider with that periodically exports to the GCP exporter.
-	provider := metric.NewMeterProvider(
-		metric.WithReader(metric.NewPeriodicReader(exporter)),
-	)
-	ctx := context.Background()
-	defer provider.Shutdown(ctx)
-
-	// Start meter
-	meter := provider.Meter("github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric")
-
-	counter, err := meter.Int64Counter("counter-foo")
-	if err != nil {
-		log.Fatalf("Failed to create counter: %v", err)
-	}
-	attrs := []attribute.KeyValue{
-		attribute.Key("key").String("value"),
-	}
-	counter.Add(ctx, 123, attrs...)
-}
-```
-
-Note that, as of version 0.2.1, `ValueObserver` and `ValueRecorder` are aggregated to `LastValue`, and other metric kinds are to `Sum`. This behaviour should be change once [Views API](https://github.com/open-telemetry/oteps/pull/89) is introduced to the specification.
-
 ## Authentication
 
 The Google Cloud Monitoring exporter depends upon [`google.FindDefaultCredentials`](https://pkg.go.dev/golang.org/x/oauth2/google?tab=doc#FindDefaultCredentials), so the service account is automatically detected by default, but also the custom credential file (so called `service_account_key.json`) can be detected with specific conditions. Quoting from the document of `google.FindDefaultCredentials`:

--- a/exporter/metric/example_test.go
+++ b/exporter/metric/example_test.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric_test
+
+import (
+	"context"
+	"log"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
+)
+
+func ExampleNew() {
+	exporter, err := mexporter.New()
+	if err != nil {
+		log.Printf("Failed to create exporter: %v", err)
+		return
+	}
+	// initialize a MeterProvider with that periodically exports to the GCP exporter.
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+	)
+	ctx := context.Background()
+	defer func() {
+		if err = provider.Shutdown(ctx); err != nil {
+			log.Printf("Failed to shut down meter provider: %v", err)
+		}
+	}()
+
+	// Start meter
+	meter := provider.Meter("github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric")
+
+	counter, err := meter.Int64Counter("counter-foo")
+	if err != nil {
+		log.Printf("Failed to create counter: %v", err)
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.Key("key").String("value"),
+	}
+	counter.Add(ctx, 123, metric.WithAttributes(attrs...))
+}


### PR DESCRIPTION
Related: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/726

Part of https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/725

This ensures the example builds correctly.