### PR TITLE
Fix issue where errors exporting from the collector are not logged

### DIFF
--- a/exporter/collector/integrationtest/inmemoryocexporter.go
+++ b/exporter/collector/integrationtest/inmemoryocexporter.go
@@ -136,9 +136,13 @@ func NewTraceTestExporter(
 	cfg.TraceConfig.ClientConfig.UseInsecure = true
 	cfg.ProjectID = "fakeprojectid"
 
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
 	exporter, err := collector.NewGoogleCloudTracesExporter(
 		ctx,
 		cfg,
+		logger,
 		"latest",
 		collector.DefaultTimeout,
 	)

--- a/exporter/collector/integrationtest/traces_integration_test.go
+++ b/exporter/collector/integrationtest/traces_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/integrationtest/testcases"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func createTracesExporter(
@@ -35,9 +36,11 @@ func createTracesExporter(
 ) *collector.TraceExporter {
 	cfg := test.CreateTraceConfig()
 	cfg.ProjectID = os.Getenv("PROJECT_ID")
+	logger, _ := zap.NewProduction()
 	exporter, err := collector.NewGoogleCloudTracesExporter(
 		ctx,
 		cfg,
+		logger,
 		"latest",
 		collector.DefaultTimeout,
 	)

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -196,6 +196,17 @@ func (l *LogsExporter) Shutdown(ctx context.Context) error {
 }
 
 func (l *LogsExporter) PushLogs(ctx context.Context, ld plog.Logs) error {
+	err := l.pushLogs(ctx, ld)
+	if err != nil {
+		l.obs.log.Error(
+			"Exporting logs failed",
+			zap.Error(err),
+		)
+	}
+	return err
+}
+
+func (l *LogsExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
 	projectEntries, err := l.mapper.createEntries(ld)
 	if err != nil {
 		return err

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -396,7 +396,14 @@ func (me *MetricsExporter) PushMetrics(ctx context.Context, m pmetric.Metrics) e
 			}
 		}
 	}
-	return errors.Join(errs...)
+	err := errors.Join(errs...)
+	if err != nil {
+		me.obs.log.Error(
+			"Exporting metrics failed",
+			zap.Error(err),
+		)
+	}
+	return err
 }
 
 // exportToTimeSeries is the default exporting call to GCM.

--- a/exporter/collector/traces_test.go
+++ b/exporter/collector/traces_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -100,7 +101,7 @@ func TestGoogleCloudTraceExport(t *testing.T) {
 
 			//nolint:errcheck
 			go srv.Serve(lis)
-			sde, err := NewGoogleCloudTracesExporter(ctx, test.cfg, "latest", DefaultTimeout)
+			sde, err := NewGoogleCloudTracesExporter(ctx, test.cfg, zap.NewNop(), "latest", DefaultTimeout)
 			if test.expectedErr != "" {
 				assert.EqualError(t, err, test.expectedErr)
 				return


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/761

Rather than restore the retry_on_failure component, add logging in the library directly.  This has the added advantage of removing the "Try enabling retry_on_failure config option to retry on retryable errors" from the message.