### PR TITLE
Metrics exporter cache requests that fail with an unrecoverable error

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -661,6 +661,7 @@ func projectName(projectID string) string {
 	return fmt.Sprintf("projects/%s", projectID)
 }
 
+// isNotRecoverable returns true if the error is permanent.
 func isNotRecoverable(err error) bool {
 	s := status.Convert(err)
 	return !(s.Code() == codes.DeadlineExceeded || s.Code() == codes.Unavailable)

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -137,6 +137,8 @@ const (
 
 type labels map[string]string
 
+// monitoringClient is the subset of monitoring.MetricClient this exporter uses,
+// and allows us to mock the implementation for testing.
 type monitoringClient interface {
 	CreateTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest, opts ...gax.CallOption) error
 	CreateServiceTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest, opts ...gax.CallOption) error

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -79,7 +79,7 @@ type MetricsExporter struct {
 	mdCache map[string]*monitoringpb.CreateMetricDescriptorRequest
 	// A channel that receives metric descriptor and sends them to GCM once
 	metricDescriptorC chan *monitoringpb.CreateMetricDescriptorRequest
-	client            *monitoring.MetricClient
+	client            monitoringClient
 	// Only used for testing purposes in lieu of initializing a fake client
 	exportFunc func(context.Context, *monitoringpb.CreateTimeSeriesRequest) error
 	// requestOpts applies options to the context for requests, such as additional headers.
@@ -136,6 +136,13 @@ const (
 )
 
 type labels map[string]string
+
+type monitoringClient interface {
+	CreateTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest, opts ...gax.CallOption) error
+	CreateServiceTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest, opts ...gax.CallOption) error
+	Close() error
+	CreateMetricDescriptor(ctx context.Context, req *monitoringpb.CreateMetricDescriptorRequest, opts ...gax.CallOption) (*metricpb.MetricDescriptor, error)
+}
 
 func (me *MetricsExporter) Shutdown(ctx context.Context) error {
 	// TODO: pass ctx to goroutines so that we can use its deadline

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -72,8 +72,8 @@ func (m *mock) CreateMetricDescriptor(ctx context.Context, req *monitoringpb.Cre
 func TestExportCreateMetricDescriptorCache(t *testing.T) {
 	for _, tc := range []struct {
 		reqs                            []*monitoringpb.CreateMetricDescriptorRequest
-		createMetricDescriptorResponses []error
 		desc                            string
+		createMetricDescriptorResponses []error
 		expectedTimesRequestCalled      int
 		expectedTimesZapCalled          int
 	}{

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -71,16 +71,16 @@ func (m *mock) CreateMetricDescriptor(ctx context.Context, req *monitoringpb.Cre
 
 func TestExportCreateMetricDescriptorCache(t *testing.T) {
 	for _, tc := range []struct {
-		desc                            string
 		expectedTimesRequestCalled      int
 		expectedTimesZapCalled          int
-		reqs                            []*monitoringpb.CreateMetricDescriptorRequest
+		desc                            string
 		createMetricDescriptorResponses []error
+		reqs                            []*monitoringpb.CreateMetricDescriptorRequest
 	}{
 		{
-			desc:                            "valid metric descriptor gets created",
 			expectedTimesRequestCalled:      2,
 			expectedTimesZapCalled:          0,
+			desc:                            "valid metric descriptor gets created",
 			createMetricDescriptorResponses: []error{nil, nil},
 			reqs: []*monitoringpb.CreateMetricDescriptorRequest{
 				{
@@ -98,9 +98,9 @@ func TestExportCreateMetricDescriptorCache(t *testing.T) {
 			},
 		},
 		{
-			desc:                       "non-recoverable error",
 			expectedTimesRequestCalled: 1,
 			expectedTimesZapCalled:     1,
+			desc:                       "non-recoverable error",
 			createMetricDescriptorResponses: []error{
 				status.Error(codes.PermissionDenied, "permission denied"),
 				status.Error(codes.PermissionDenied, "permission denied"),
@@ -121,9 +121,9 @@ func TestExportCreateMetricDescriptorCache(t *testing.T) {
 			},
 		},
 		{
-			desc:                       "recoverable error",
 			expectedTimesRequestCalled: 2,
 			expectedTimesZapCalled:     1,
+			desc:                       "recoverable error",
 			createMetricDescriptorResponses: []error{
 				status.Error(codes.DeadlineExceeded, "deadline exceeded"),
 				nil,

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -24,12 +24,14 @@ import (
 
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/gax-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/wal"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/genproto/googleapis/api/label"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
@@ -56,6 +58,120 @@ func newTestMetricMapper() (metricMapper, func()) {
 		cfg:        cfg,
 		normalizer: normalization.NewStandardNormalizer(s, zap.NewNop()),
 	}, func() { close(s) }
+}
+
+type mock struct {
+	monitoringClient
+	createMetricDescriptor func(ctx context.Context, req *monitoringpb.CreateMetricDescriptorRequest, opts ...gax.CallOption) (*metricpb.MetricDescriptor, error)
+}
+
+func (m *mock) CreateMetricDescriptor(ctx context.Context, req *monitoringpb.CreateMetricDescriptorRequest, opts ...gax.CallOption) (*metricpb.MetricDescriptor, error) {
+	return m.createMetricDescriptor(ctx, req)
+}
+
+func TestExportCreateMetricDescriptorCache(t *testing.T) {
+	for _, tc := range []struct {
+		desc                            string
+		expectedTimesRequestCalled      int
+		expectedTimesZapCalled          int
+		reqs                            []*monitoringpb.CreateMetricDescriptorRequest
+		createMetricDescriptorResponses []error
+	}{
+		{
+			desc:                            "valid metric descriptor gets created",
+			expectedTimesRequestCalled:      2,
+			expectedTimesZapCalled:          0,
+			createMetricDescriptorResponses: []error{nil, nil},
+			reqs: []*monitoringpb.CreateMetricDescriptorRequest{
+				{
+					Name: "foo",
+					MetricDescriptor: &metricpb.MetricDescriptor{
+						Type: "goo",
+					},
+				},
+				{
+					Name: "bar",
+					MetricDescriptor: &metricpb.MetricDescriptor{
+						Type: "baz",
+					},
+				},
+			},
+		},
+		{
+			desc:                       "non-recoverable error",
+			expectedTimesRequestCalled: 1,
+			expectedTimesZapCalled:     1,
+			createMetricDescriptorResponses: []error{
+				status.Error(codes.PermissionDenied, "permission denied"),
+				status.Error(codes.PermissionDenied, "permission denied"),
+			},
+			reqs: []*monitoringpb.CreateMetricDescriptorRequest{
+				{
+					Name: "foo",
+					MetricDescriptor: &metricpb.MetricDescriptor{
+						Type: "goo",
+					},
+				},
+				{
+					Name: "foo",
+					MetricDescriptor: &metricpb.MetricDescriptor{
+						Type: "goo",
+					},
+				},
+			},
+		},
+		{
+			desc:                       "recoverable error",
+			expectedTimesRequestCalled: 2,
+			expectedTimesZapCalled:     1,
+			createMetricDescriptorResponses: []error{
+				status.Error(codes.DeadlineExceeded, "deadline exceeded"),
+				nil,
+			},
+			reqs: []*monitoringpb.CreateMetricDescriptorRequest{
+				{
+					Name: "foo",
+					MetricDescriptor: &metricpb.MetricDescriptor{
+						Type: "goo",
+					},
+				},
+				{
+					Name: "foo",
+					MetricDescriptor: &metricpb.MetricDescriptor{
+						Type: "goo",
+					},
+				},
+			},
+		},
+	} {
+		logger, observed := observer.New(zap.DebugLevel)
+
+		actualTimesCalled := 0
+		i := 0
+		m := &mock{
+			createMetricDescriptor: func(ctx context.Context, req *monitoringpb.CreateMetricDescriptorRequest, opts ...gax.CallOption) (*metricpb.MetricDescriptor, error) {
+				actualTimesCalled++
+				err := tc.createMetricDescriptorResponses[i]
+				i++
+				return req.MetricDescriptor, err
+			},
+		}
+
+		me := MetricsExporter{
+			mdCache: make(map[string]*monitoringpb.CreateMetricDescriptorRequest),
+			obs: selfObservability{
+				log: zap.New(logger),
+			},
+			client: m,
+		}
+
+		for _, r := range tc.reqs {
+			me.exportMetricDescriptor(r)
+		}
+
+		require.Len(t, observed.FilterLevelExact(zap.ErrorLevel).All(), tc.expectedTimesZapCalled)
+		require.Equal(t, tc.expectedTimesRequestCalled, actualTimesCalled)
+	}
 }
 
 func TestMetricToTimeSeries(t *testing.T) {

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -71,11 +71,11 @@ func (m *mock) CreateMetricDescriptor(ctx context.Context, req *monitoringpb.Cre
 
 func TestExportCreateMetricDescriptorCache(t *testing.T) {
 	for _, tc := range []struct {
+		reqs                            []*monitoringpb.CreateMetricDescriptorRequest
+		createMetricDescriptorResponses []error
+		desc                            string
 		expectedTimesRequestCalled      int
 		expectedTimesZapCalled          int
-		desc                            string
-		createMetricDescriptorResponses []error
-		reqs                            []*monitoringpb.CreateMetricDescriptorRequest
 	}{
 		{
 			expectedTimesRequestCalled:      2,


### PR DESCRIPTION
Fixes [#765](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/765)

When the metrics exporter fails to create a new metric descriptor any non-recoverable grpc errors will update the cache, preventing further CMD calls.