### PR TITLE
Prepare for v1.21.0/v0.45.0

### DIFF
--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.6.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.45.0
 	github.com/cloudevents/sdk-go/v2 v2.13.0
 )
 
@@ -16,9 +16,9 @@ require (
 	cloud.google.com/go/functions v1.15.1 // indirect
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/trace v1.10.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.20.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.21.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.21.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/pubsub v1.33.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.21.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.19.0
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/sdk v1.19.0
@@ -18,8 +18,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/trace v1.10.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.20.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.21.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/metric/sdk/go.mod
+++ b/example/metric/sdk/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric
 go 1.20
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.45.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.19.0
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/metric v1.19.0
@@ -15,8 +15,8 @@ require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/monitoring v1.15.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.20.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.21.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -3,8 +3,8 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/
 go 1.20
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.21.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.45.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/sdk v1.19.0
@@ -15,7 +15,7 @@ require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.10.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -6,8 +6,8 @@ require (
 	cloud.google.com/go/logging v1.7.0
 	cloud.google.com/go/monitoring v1.15.1
 	cloud.google.com/go/trace v1.10.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.21.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/go-cmp v0.5.9

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -7,11 +7,11 @@ require (
 	cloud.google.com/go/monitoring v1.15.1
 	cloud.google.com/go/trace v1.10.1
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.44.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.44.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.44.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.44.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.45.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.45.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.45.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.45.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	go.opencensus.io v0.24.0
@@ -36,7 +36,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.21.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.117 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -223,7 +223,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -402,7 +402,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -581,7 +581,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -745,7 +745,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -870,7 +870,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -995,7 +995,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1120,7 +1120,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1231,7 +1231,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1327,7 +1327,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1423,7 +1423,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1519,7 +1519,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1644,7 +1644,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1823,7 +1823,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2002,7 +2002,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2166,7 +2166,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2296,7 +2296,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2426,7 +2426,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2556,7 +2556,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2672,7 +2672,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -223,7 +223,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -402,7 +402,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -581,7 +581,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -745,7 +745,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -870,7 +870,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -995,7 +995,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1120,7 +1120,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1231,7 +1231,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1327,7 +1327,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1423,7 +1423,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1519,7 +1519,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1644,7 +1644,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1823,7 +1823,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2002,7 +2002,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2166,7 +2166,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2296,7 +2296,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2426,7 +2426,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2556,7 +2556,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2672,7 +2672,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.20.0"
+                  "value": "opentelemetry-go 1.19.0; google-cloud-trace-exporter 1.21.0"
                 }
               },
               "g.co/r/generic_node/location": {

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	cloud.google.com/go/monitoring v1.15.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.44.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.45.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0
 	github.com/googleapis/gax-go/v2 v2.11.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.19.0

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.44.0"
+	return "0.45.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	cloud.google.com/go/trace v1.10.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.44.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.45.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.45.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/sdk v1.19.0

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.20.0"
+	return "1.21.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.20.0"
-	unstable = "0.44.0"
+	stable   = "1.21.0"
+	unstable = "0.45.0"
 )
 
 var stableModules = map[string]struct{}{


### PR DESCRIPTION
Release needed for https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/769.