### PR TITLE
Provide useful cluster names for non k8s environments on managed prom…

### DIFF
--- a/exporter/collector/googlemanagedprometheus/config.go
+++ b/exporter/collector/googlemanagedprometheus/config.go
@@ -21,9 +21,6 @@ type Config struct {
 	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
 	// ExtraMetricsConfig configures the target_info and otel_scope_info metrics.
 	ExtraMetricsConfig ExtraMetricsConfig `mapstructure:"extra_metrics_config"`
-	// UseEnvironmentClusterNames controls whether cluster names "__run__" and "__gce__" are used on
-	// these environments.
-	UseEnvironmentClusterNames bool `mapstructure:"use_environment_cluster_names"`
 }
 
 // ExtraMetricsConfig controls the inclusion of additional metrics.
@@ -41,7 +38,6 @@ func DefaultConfig() Config {
 			EnableTargetInfo: true,
 			EnableScopeInfo:  true,
 		},
-		UseEnvironmentClusterNames: true,
 	}
 }
 

--- a/exporter/collector/googlemanagedprometheus/config.go
+++ b/exporter/collector/googlemanagedprometheus/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
 	// ExtraMetricsConfig configures the target_info and otel_scope_info metrics.
 	ExtraMetricsConfig ExtraMetricsConfig `mapstructure:"extra_metrics_config"`
+	// UseEnvironmentClusterNames controls whether cluster names "__run__" and "__gce__" are used on
+	// these environments.
+	UseEnvironmentClusterNames bool `mapstructure:"use_environment_cluster_names"`
 }
 
 // ExtraMetricsConfig controls the inclusion of additional metrics.
@@ -38,6 +41,7 @@ func DefaultConfig() Config {
 			EnableTargetInfo: true,
 			EnableScopeInfo:  true,
 		},
+		UseEnvironmentClusterNames: true,
 	}
 }
 

--- a/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
@@ -165,6 +165,45 @@ func TestMapToPrometheusTarget(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Attributes from cloud run with environment label",
+			resourceLabels: map[string]string{
+				"cloud.platform": "gcp_cloud_run",
+				"cloud.region":   "us-central1",
+				"service.name":   "unknown_service:go",
+				"faas.name":      "my-cloud-run-service",
+				"faas.instance":  "1234759430923053489543203",
+			},
+			expected: &monitoredrespb.MonitoredResource{
+				Type: "prometheus_target",
+				Labels: map[string]string{
+					"location":  "us-central1",
+					"cluster":   "__run__",
+					"namespace": "",
+					"job":       "my-cloud-run-service",
+					"instance":  "1234759430923053489543203",
+				},
+			},
+		},
+		{
+			desc: "Attributes from GCE with environment label",
+			resourceLabels: map[string]string{
+				"cloud.platform":      "gcp_compute_engine",
+				"cloud.region":        "us-central1",
+				"service.name":        "service-name",
+				"service.instance.id": "1234759430923053489543203",
+			},
+			expected: &monitoredrespb.MonitoredResource{
+				Type: "prometheus_target",
+				Labels: map[string]string{
+					"location":  "us-central1",
+					"cluster":   "__gce__",
+					"namespace": "",
+					"job":       "service-name",
+					"instance":  "1234759430923053489543203",
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			r := pcommon.NewResource()


### PR DESCRIPTION
…etheus exporter.


- we use `__run__` on cloud run and `__gce__` on compute engine.
- This matches the documentation for cloud run and support in Ops Agent.
- This can be controlled via a configuration parameter.

cc @ridwanmsharif 

Note: This just modifies the defaults, happy to provide docs or transition period.