### PR TITLE
Fixes #778 - Exemplars should be sorted before sending to Cloud Ops.

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -927,6 +928,10 @@ func (m *metricMapper) exemplars(exs pmetric.ExemplarSlice, projectID string) []
 	for i := 0; i < exs.Len(); i++ {
 		exemplars[i] = m.exemplar(exs.At(i), projectID)
 	}
+	sort.Slice(exemplars, func(i, j int) bool {
+		return exemplars[i].Value < exemplars[j].Value
+	})
+
 	return exemplars
 }
 

--- a/exporter/collector/metrics_test.go
+++ b/exporter/collector/metrics_test.go
@@ -1043,6 +1043,31 @@ func TestZeroCountExponentialHistogramPointToTimeSeries(t *testing.T) {
 	assert.Equal(t, int32(3), hdp.BucketOptions.GetExponentialBuckets().NumFiniteBuckets)
 }
 
+func TestExemplarSorted(t *testing.T) {
+	mapper, shutdown := newTestMetricMapper()
+	defer shutdown()
+	exemplars := pmetric.NewExemplarSlice()
+
+	exemplar := exemplars.AppendEmpty()
+	exemplar.SetTimestamp(pcommon.NewTimestampFromTime(start))
+	exemplar.SetDoubleValue(2)
+
+	exemplar2 := exemplars.AppendEmpty()
+	exemplar2.SetTimestamp(pcommon.NewTimestampFromTime(start))
+	exemplar2.SetDoubleValue(1)
+
+	exemplar3 := exemplars.AppendEmpty()
+	exemplar3.SetTimestamp(pcommon.NewTimestampFromTime(start))
+	exemplar3.SetDoubleValue(3)
+
+	result := mapper.exemplars(exemplars, mapper.cfg.ProjectID)
+	assert.Equal(t, len(result), 3)
+	// Ensure exemplars are in value order.
+	assert.Equal(t, float64(1), result[0].Value)
+	assert.Equal(t, float64(2), result[1].Value)
+	assert.Equal(t, float64(3), result[2].Value)
+}
+
 func TestExemplarNoAttachements(t *testing.T) {
 	mapper, shutdown := newTestMetricMapper()
 	defer shutdown()


### PR DESCRIPTION
Fixes #778 

We discovered that using the fixed-sized reservoir does not guarantee exemplar order, but this is required in Cloud Operations for most distribution types.

cc @franciscovalentecastro 