### PR TITLE
Support gcp.source_location being set as other types

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -654,15 +654,15 @@ func fixUTF8(s string) string {
 }
 
 func bytesFromValue(v pcommon.Value) ([]byte, error) {
-	var bytes []byte
+	var valueBytes []byte
 	var err error
 	switch v.Type() {
 	case pcommon.ValueTypeBytes:
-		bytes = v.Bytes().AsRaw()
+		valueBytes = v.Bytes().AsRaw()
 	case pcommon.ValueTypeMap, pcommon.ValueTypeStr:
-		bytes = []byte(v.AsString())
+		valueBytes = []byte(v.AsString())
 	default:
 		err = &UnsupportedValueTypeError{ValueType: v.Type()}
 	}
-	return bytes, err
+	return valueBytes, err
 }

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -393,8 +393,16 @@ func (l logMapper) logToSplitEntries(
 
 	// parse LogEntrySourceLocation struct from OTel attribute
 	if sourceLocation, ok := attrsMap[SourceLocationAttributeKey]; ok {
+		var sourceLocationBytes []byte
+		switch sourceLocation.Type() {
+		case pcommon.ValueTypeBytes:
+			sourceLocationBytes = sourceLocation.Bytes().AsRaw()
+		case pcommon.ValueTypeMap, pcommon.ValueTypeStr:
+			sourceLocationStr := sourceLocation.AsString()
+			sourceLocationBytes = []byte(sourceLocationStr)
+		}
 		var logEntrySourceLocation logpb.LogEntrySourceLocation
-		err := json.Unmarshal(sourceLocation.Bytes().AsRaw(), &logEntrySourceLocation)
+		err := json.Unmarshal(sourceLocationBytes, &logEntrySourceLocation)
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -124,24 +124,24 @@ var otelSeverityForText = map[string]plog.SeverityNumber{
 	"fatal4": plog.SeverityNumberFatal4,
 }
 
-type AttributeProcessingError struct {
+type attributeProcessingError struct {
 	Err error
 	Key string
 }
 
-func (e *AttributeProcessingError) Error() string {
+func (e *attributeProcessingError) Error() string {
 	return fmt.Sprintf("could not process attribute %s: %s", e.Key, e.Err.Error())
 }
 
-func (e *AttributeProcessingError) Unwrap() error {
+func (e *attributeProcessingError) Unwrap() error {
 	return e.Err
 }
 
-type UnsupportedValueTypeError struct {
+type unsupportedValueTypeError struct {
 	ValueType pcommon.ValueType
 }
 
-func (e *UnsupportedValueTypeError) Error() string {
+func (e *unsupportedValueTypeError) Error() string {
 	return fmt.Sprintf("unsupported value type %v", e.ValueType)
 }
 
@@ -416,7 +416,7 @@ func (l logMapper) logToSplitEntries(
 	if sourceLocation, ok := attrsMap[SourceLocationAttributeKey]; ok {
 		sourceLocationBytes, err := bytesFromValue(sourceLocation)
 		if err != nil {
-			return nil, &AttributeProcessingError{Key: SourceLocationAttributeKey, Err: err}
+			return nil, &attributeProcessingError{Key: SourceLocationAttributeKey, Err: err}
 		}
 		var logEntrySourceLocation logpb.LogEntrySourceLocation
 		err = json.Unmarshal(sourceLocationBytes, &logEntrySourceLocation)
@@ -575,7 +575,7 @@ type httpRequestLog struct {
 func (l logMapper) parseHTTPRequest(httpRequestAttr pcommon.Value) (*logtypepb.HttpRequest, error) {
 	httpBytes, err := bytesFromValue(httpRequestAttr)
 	if err != nil {
-		return nil, &AttributeProcessingError{Key: HTTPRequestAttributeKey, Err: err}
+		return nil, &attributeProcessingError{Key: HTTPRequestAttributeKey, Err: err}
 	}
 	// TODO: Investigate doing this without the JSON unmarshal. Getting the attribute as a map
 	// instead of a slice of bytes could do, but would need a lot of type casting and checking
@@ -662,7 +662,7 @@ func bytesFromValue(v pcommon.Value) ([]byte, error) {
 	case pcommon.ValueTypeMap, pcommon.ValueTypeStr:
 		valueBytes = []byte(v.AsString())
 	default:
-		err = &UnsupportedValueTypeError{ValueType: v.Type()}
+		err = &unsupportedValueTypeError{ValueType: v.Type()}
 	}
 	return valueBytes, err
 }

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -398,8 +398,7 @@ func (l logMapper) logToSplitEntries(
 		case pcommon.ValueTypeBytes:
 			sourceLocationBytes = sourceLocation.Bytes().AsRaw()
 		case pcommon.ValueTypeMap, pcommon.ValueTypeStr:
-			sourceLocationStr := sourceLocation.AsString()
-			sourceLocationBytes = []byte(sourceLocationStr)
+			sourceLocationBytes = []byte(sourceLocation.AsString())
 		}
 		var logEntrySourceLocation logpb.LogEntrySourceLocation
 		err := json.Unmarshal(sourceLocationBytes, &logEntrySourceLocation)

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -64,12 +64,12 @@ func TestLogMapping(t *testing.T) {
 
 	testCases := []struct {
 		expectedError   error
-		expectError     bool
 		log             func() plog.LogRecord
 		mr              func() *monitoredrespb.MonitoredResource
 		config          Option
 		name            string
 		expectedEntries []*logpb.LogEntry
+		expectError     bool
 		maxEntrySize    int
 	}{
 		{

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -164,8 +164,8 @@ func TestLogMapping(t *testing.T) {
 				log := plog.NewLogRecord()
 				log.Body().SetEmptyMap().PutStr("message", "hello!")
 				log.Attributes().PutEmptyBytes(HTTPRequestAttributeKey).FromRaw([]byte(`{
-						"requestMethod": "GET", 
-						"requestURL": "https://www.example.com", 
+						"requestMethod": "GET",
+						"requestURL": "https://www.example.com",
 						"requestSize": "1",
 						"status": "200",
 						"responseSize": "1",
@@ -381,6 +381,32 @@ func TestLogMapping(t *testing.T) {
 				log.Attributes().PutEmptyBytes(SourceLocationAttributeKey).FromRaw(
 					[]byte(`{"file": "test.php", "line":100, "function":"helloWorld"}`),
 				)
+				return log
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					SourceLocation: &logpb.LogEntrySourceLocation{
+						File:     "test.php",
+						Line:     100,
+						Function: "helloWorld",
+					},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with sourceLocation (map)",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				sourceLocationMap := log.Attributes().PutEmptyMap(SourceLocationAttributeKey)
+				sourceLocationMap.PutStr("file", "test.php")
+				sourceLocationMap.PutInt("line", 100)
+				sourceLocationMap.PutStr("function", "helloWorld")
 				return log
 			},
 			expectedEntries: []*logpb.LogEntry{

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -371,7 +371,6 @@ func TestLogMapping(t *testing.T) {
 			},
 		},
 		{
-			// TODO(damemi): parse/test sourceLocation from more than just bytes values
 			name: "log with sourceLocation (bytes)",
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
@@ -395,6 +394,21 @@ func TestLogMapping(t *testing.T) {
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with bad source location (bytes)",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Attributes().PutEmptyBytes(SourceLocationAttributeKey).FromRaw(
+					[]byte(`{"file": 100}`),
+				)
+				return log
+			},
+			maxEntrySize: defaultMaxEntrySize,
+			expectError:  true,
 		},
 		{
 			name: "log with sourceLocation (map)",
@@ -423,6 +437,20 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with bad source location (map)",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				sourceLocationMap := log.Attributes().PutEmptyMap(SourceLocationAttributeKey)
+				sourceLocationMap.PutStr("line", "100")
+				return log
+			},
+			maxEntrySize: defaultMaxEntrySize,
+			expectError:  true,
+		},
+		{
 			name: "log with sourceLocation (string)",
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil
@@ -447,6 +475,22 @@ func TestLogMapping(t *testing.T) {
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with bad source location (string)",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Attributes().PutStr(
+					SourceLocationAttributeKey,
+					`{"file": 100}`,
+				)
+				return log
+			},
+			maxEntrySize: defaultMaxEntrySize,
+			expectError:  true,
 		},
 		{
 			name: "log with traceSampled (bool)",

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -212,6 +212,28 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with httpRequest attribute unsupported type",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyMap().PutStr("message", "hello!")
+				log.Attributes().PutBool(HTTPRequestAttributeKey, true)
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
+					}}},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log with timestamp",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
@@ -525,6 +547,24 @@ func TestLogMapping(t *testing.T) {
 					LogName:      logName,
 					Timestamp:    timestamppb.New(testObservedTime),
 					TraceSampled: true,
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with traceSampled (unsupported type)",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Attributes().PutStr(TraceSampledAttributeKey, "hi!")
+				return log
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -423,6 +423,32 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with sourceLocation (string)",
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Attributes().PutStr(
+					SourceLocationAttributeKey,
+					`{"file": "test.php", "line":100, "function":"helloWorld"}`,
+				)
+				return log
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					SourceLocation: &logpb.LogEntrySourceLocation{
+						File:     "test.php",
+						Line:     100,
+						Function: "helloWorld",
+					},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log with traceSampled (bool)",
 			mr: func() *monitoredrespb.MonitoredResource {
 				return nil

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -527,9 +527,9 @@ func TestLogMapping(t *testing.T) {
 			},
 			maxEntrySize: defaultMaxEntrySize,
 			expectError:  true,
-			expectedError: &AttributeProcessingError{
+			expectedError: &attributeProcessingError{
 				Key: SourceLocationAttributeKey,
-				Err: &UnsupportedValueTypeError{ValueType: pcommon.ValueTypeBool},
+				Err: &unsupportedValueTypeError{ValueType: pcommon.ValueTypeBool},
 			},
 		},
 		{

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -63,14 +63,14 @@ func TestLogMapping(t *testing.T) {
 	logName := "projects/fakeprojectid/logs/default-log"
 
 	testCases := []struct {
+		expectedError   error
+		expectError     bool
 		log             func() plog.LogRecord
 		mr              func() *monitoredrespb.MonitoredResource
 		config          Option
 		name            string
 		expectedEntries []*logpb.LogEntry
 		maxEntrySize    int
-		expectError     bool
-		expectedError   error
 	}{
 		{
 			name:         "split entry size",


### PR DESCRIPTION
By copying the logic from parsing gcp.http_request, this PR adds support to also parse `gcp.source_location` from types other than Bytes.

This fixes the basic case of #792 such that the collector does not panic when setting `gcp.source_location` as something other than bytes.