### PR TITLE
Fall back to global for all monitored resources that accept it

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -38,7 +38,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -67,7 +67,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -96,7 +96,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -120,7 +120,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -149,7 +149,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -173,60 +173,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log",
-            "service.name": "apache_service"
-          }
-        }
-      ],
-      "partialSuccess": true
-    },
-    {
-      "entries": [
-        {
-          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
-            }
-          },
-          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
-          "timestamp": "1970-01-01T00:00:00Z",
-          "httpRequest": {
-            "requestMethod": "GET",
-            "requestUrl": "/",
-            "status": 200,
-            "responseSize": "1247",
-            "remoteIp": "127.0.0.1",
-            "protocol": "HTTP/1.1"
-          },
-          "labels": {
-            "log.file.name": "test.log",
-            "service.name": "apache_service"
-          }
-        },
-        {
-          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
-          "resource": {
-            "type": "gce_instance",
-            "labels": {
-              "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -255,7 +202,60 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log",
+            "service.name": "apache_service"
+          }
+        },
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": "global"
+            }
+          },
+          "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
+          "timestamp": "1970-01-01T00:00:00Z",
+          "httpRequest": {
+            "requestMethod": "GET",
+            "requestUrl": "/",
+            "status": 200,
+            "responseSize": "1247",
+            "remoteIp": "127.0.0.1",
+            "protocol": "HTTP/1.1"
+          },
+          "labels": {
+            "log.file.name": "test.log",
+            "service.name": "apache_service"
+          }
+        }
+      ],
+      "partialSuccess": true
+    },
+    {
+      "entries": [
+        {
+          "logName": "projects/fakeprojectid/logs/my-log-name-foo",
+          "resource": {
+            "type": "gce_instance",
+            "labels": {
+              "instance_id": "",
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -279,7 +279,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -308,7 +308,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -332,7 +332,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -361,7 +361,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -385,7 +385,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -414,7 +414,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -430,7 +430,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -33,7 +33,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -57,7 +57,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -81,7 +81,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -105,7 +105,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -129,7 +129,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -153,7 +153,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -177,7 +177,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -201,7 +201,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -225,7 +225,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -249,7 +249,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -273,7 +273,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -297,7 +297,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -321,7 +321,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -345,7 +345,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -369,7 +369,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -385,7 +385,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -35,7 +35,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -62,7 +62,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -89,7 +89,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -116,7 +116,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -143,7 +143,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -170,7 +170,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -197,7 +197,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -224,7 +224,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -251,7 +251,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -278,7 +278,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -305,7 +305,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -332,7 +332,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -359,7 +359,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -386,7 +386,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -413,7 +413,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -432,7 +432,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -27,7 +27,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -46,7 +46,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -65,7 +65,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -84,7 +84,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -104,7 +104,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -123,7 +123,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -142,7 +142,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -161,7 +161,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -29,7 +29,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -48,7 +48,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -67,7 +67,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -86,7 +86,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -105,7 +105,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -125,7 +125,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -144,7 +144,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -163,7 +163,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {
@@ -27,7 +27,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "jsonPayload": {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -31,7 +31,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -54,7 +54,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -77,7 +77,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -100,7 +100,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -123,7 +123,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -146,7 +146,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -169,7 +169,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -192,7 +192,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -215,7 +215,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -238,7 +238,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -261,7 +261,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -284,7 +284,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -307,7 +307,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -330,7 +330,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -353,7 +353,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -368,7 +368,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
@@ -396,7 +396,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -419,7 +419,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -442,7 +442,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -465,7 +465,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -488,7 +488,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -511,7 +511,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -534,7 +534,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -557,7 +557,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -580,7 +580,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -603,7 +603,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -626,7 +626,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -649,7 +649,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -672,7 +672,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -695,7 +695,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -718,7 +718,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -741,7 +741,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -756,7 +756,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
@@ -8,7 +8,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -31,7 +31,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -54,7 +54,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -77,7 +77,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -100,7 +100,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -123,7 +123,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -146,7 +146,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -169,7 +169,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -192,7 +192,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -215,7 +215,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -238,7 +238,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -261,7 +261,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -284,7 +284,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -307,7 +307,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -330,7 +330,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -353,7 +353,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -368,7 +368,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",
@@ -391,7 +391,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:36 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -414,7 +414,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /favicon.ico HTTP/1.1\" 200 3990",
@@ -437,7 +437,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:37 +0800] \"GET /lamp.png HTTP/1.1\" 200 51164",
@@ -460,7 +460,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:51 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -483,7 +483,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:52 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -506,7 +506,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -529,7 +529,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -552,7 +552,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -575,7 +575,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:53 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -598,7 +598,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -621,7 +621,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -644,7 +644,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -667,7 +667,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -690,7 +690,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -713,7 +713,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:53:54 +0800] \"GET / HTTP/1.1\" 200 1247",
@@ -736,7 +736,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.1 - - [26/Apr/2022:22:54:43 +0800] \"-\" 408 -",
@@ -751,7 +751,7 @@
             "type": "gce_instance",
             "labels": {
               "instance_id": "",
-              "zone": ""
+              "zone": "global"
             }
           },
           "textPayload": "127.0.0.2 - - [26/Apr/2022:22:54:38 +0800] \"GET / HTTP/1.1\" 200 4429",

--- a/exporter/collector/monitoredresource_test.go
+++ b/exporter/collector/monitoredresource_test.go
@@ -581,6 +581,139 @@ func TestResourceMetricsToMonitoringMonitoredResource(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "GCE instance without location",
+			resourceLabels: map[string]string{
+				"cloud.platform": "gcp_compute_engine",
+				"host.id":        "abc123",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type:   "gce_instance",
+				Labels: map[string]string{"instance_id": "abc123", "zone": "global"},
+			},
+		},
+		{
+			name: "K8s container without location",
+			resourceLabels: map[string]string{
+				"cloud.platform":     "gcp_kubernetes_engine",
+				"k8s.cluster.name":   "mycluster",
+				"k8s.namespace.name": "mynamespace",
+				"k8s.pod.name":       "mypod",
+				"k8s.container.name": "mycontainer",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"cluster_name":   "mycluster",
+					"container_name": "mycontainer",
+					"location":       "global",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+				},
+			},
+		},
+		{
+			name: "K8s pod without location",
+			resourceLabels: map[string]string{
+				"cloud.platform":     "gcp_kubernetes_engine",
+				"k8s.cluster.name":   "mycluster",
+				"k8s.namespace.name": "mynamespace",
+				"k8s.pod.name":       "mypod",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_pod",
+				Labels: map[string]string{
+					"cluster_name":   "mycluster",
+					"location":       "global",
+					"namespace_name": "mynamespace",
+					"pod_name":       "mypod",
+				},
+			},
+		},
+		{
+			name: "K8s node without location",
+			resourceLabels: map[string]string{
+				"cloud.platform":   "gcp_kubernetes_engine",
+				"k8s.cluster.name": "mycluster",
+				"k8s.node.name":    "mynode",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_node",
+				Labels: map[string]string{
+					"cluster_name": "mycluster",
+					"location":     "global",
+					"node_name":    "mynode",
+				},
+			},
+		},
+		{
+			name: "K8s cluster without location",
+			resourceLabels: map[string]string{
+				"cloud.platform":   "gcp_kubernetes_engine",
+				"k8s.cluster.name": "mycluster",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "k8s_cluster",
+				Labels: map[string]string{
+					"cluster_name": "mycluster",
+					"location":     "global",
+				},
+			},
+		},
+		{
+			name: "AWS ec2 instance without location",
+			resourceLabels: map[string]string{
+				"cloud.platform":   "aws_ec2",
+				"host.id":          "abc123",
+				"cloud.account.id": "myawsaccount",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "aws_ec2_instance",
+				Labels: map[string]string{
+					"aws_account": "myawsaccount",
+					"instance_id": "abc123",
+					"region":      "global",
+				},
+			},
+		},
+		{
+			name: "Gae Instance without location",
+			resourceLabels: map[string]string{
+				"cloud.provider": "gcp",
+				"cloud.platform": "gcp_app_engine",
+				"faas.instance":  "myinstanceid",
+				"faas.name":      "myhostname",
+				"faas.version":   "v1",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "gae_instance",
+				Labels: map[string]string{
+					"instance_id": "myinstanceid",
+					"location":    "global",
+					"module_id":   "myhostname",
+					"version_id":  "v1",
+				},
+			},
+		},
+		{
+			name: "Cloud Run Instance without location",
+			resourceLabels: map[string]string{
+				"cloud.provider": "gcp",
+				"cloud.platform": "gcp_cloud_run",
+				"faas.instance":  "myinstanceid",
+				"faas.name":      "myfaasname",
+				"faas.version":   "v1",
+			},
+			expectMr: &monitoredrespb.MonitoredResource{
+				Type: "generic_task",
+				Labels: map[string]string{
+					"job":       "myfaasname",
+					"location":  "global",
+					"namespace": "",
+					"task_id":   "myinstanceid",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/resourcemapping/resourcemapping.go
+++ b/internal/resourcemapping/resourcemapping.go
@@ -72,57 +72,77 @@ var (
 		otelKeys []string
 	}{
 		gceInstance: {
-			zone:       {otelKeys: []string{string(semconv.CloudAvailabilityZoneKey)}},
+			zone: {
+				otelKeys:        []string{string(semconv.CloudAvailabilityZoneKey)},
+				fallbackLiteral: "global",
+			},
 			instanceID: {otelKeys: []string{string(semconv.HostIDKey)}},
 		},
 		k8sContainer: {
-			location: {otelKeys: []string{
-				string(semconv.CloudAvailabilityZoneKey),
-				string(semconv.CloudRegionKey),
-			}},
+			location: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+				fallbackLiteral: "global",
+			},
 			clusterName:   {otelKeys: []string{string(semconv.K8SClusterNameKey)}},
 			namespaceName: {otelKeys: []string{string(semconv.K8SNamespaceNameKey)}},
 			podName:       {otelKeys: []string{string(semconv.K8SPodNameKey)}},
 			containerName: {otelKeys: []string{string(semconv.K8SContainerNameKey)}},
 		},
 		k8sPod: {
-			location: {otelKeys: []string{
-				string(semconv.CloudAvailabilityZoneKey),
-				string(semconv.CloudRegionKey),
-			}},
+			location: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+				fallbackLiteral: "global",
+			},
 			clusterName:   {otelKeys: []string{string(semconv.K8SClusterNameKey)}},
 			namespaceName: {otelKeys: []string{string(semconv.K8SNamespaceNameKey)}},
 			podName:       {otelKeys: []string{string(semconv.K8SPodNameKey)}},
 		},
 		k8sNode: {
-			location: {otelKeys: []string{
-				string(semconv.CloudAvailabilityZoneKey),
-				string(semconv.CloudRegionKey),
-			}},
+			location: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+				fallbackLiteral: "global",
+			},
 			clusterName: {otelKeys: []string{string(semconv.K8SClusterNameKey)}},
 			nodeName:    {otelKeys: []string{string(semconv.K8SNodeNameKey)}},
 		},
 		k8sCluster: {
-			location: {otelKeys: []string{
-				string(semconv.CloudAvailabilityZoneKey),
-				string(semconv.CloudRegionKey),
-			}},
+			location: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+				fallbackLiteral: "global",
+			},
 			clusterName: {otelKeys: []string{string(semconv.K8SClusterNameKey)}},
 		},
 		gaeInstance: {
-			location: {otelKeys: []string{
-				string(semconv.CloudAvailabilityZoneKey),
-				string(semconv.CloudRegionKey),
-			}},
+			location: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+				fallbackLiteral: "global",
+			},
 			gaeModuleID:  {otelKeys: []string{string(semconv.FaaSNameKey)}},
 			gaeVersionID: {otelKeys: []string{string(semconv.FaaSVersionKey)}},
 			instanceID:   {otelKeys: []string{string(semconv.FaaSInstanceKey)}},
 		},
 		gaeApp: {
-			location: {otelKeys: []string{
-				string(semconv.CloudAvailabilityZoneKey),
-				string(semconv.CloudRegionKey),
-			}},
+			location: {
+				otelKeys: []string{
+					string(semconv.CloudAvailabilityZoneKey),
+					string(semconv.CloudRegionKey),
+				},
+			},
 			gaeModuleID:  {otelKeys: []string{string(semconv.FaaSNameKey)}},
 			gaeVersionID: {otelKeys: []string{string(semconv.FaaSVersionKey)}},
 		},
@@ -133,6 +153,7 @@ var (
 					string(semconv.CloudAvailabilityZoneKey),
 					string(semconv.CloudRegionKey),
 				},
+				fallbackLiteral: "global",
 			},
 			awsAccount: {otelKeys: []string{string(semconv.CloudAccountIDKey)}},
 		},


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/789

Tested each monitored resource manually.  For each where I added a global fallback, the monitoring API will reject requests with an empty location, but accept requests with a "global" location.