### PR TITLE
Support exemplars from integer instruments

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -916,8 +916,15 @@ func (m *metricMapper) exemplar(ex pmetric.Exemplar, projectID string) *distribu
 			recordExemplarFailure(ctx, 1)
 		}
 	}
+	var val float64
+	switch ex.ValueType() {
+	case pmetric.ExemplarValueTypeDouble:
+		val = ex.DoubleValue()
+	case pmetric.ExemplarValueTypeInt:
+		val = float64(ex.IntValue())
+	}
 	return &distribution.Distribution_Exemplar{
-		Value:       ex.DoubleValue(),
+		Value:       val,
 		Timestamp:   timestamppb.New(ex.Timestamp().AsTime()),
 		Attachments: attachments,
 	}


### PR DESCRIPTION
We weren't properly checking the value type of exemplars, meaning we were sending a value of 0 for all int exemplars.