### PR TITLE
Add fixture with a histogram exemplar, and implement exemplar attachments in SDK

### DIFF
--- a/exporter/collector/integrationtest/testcases/conversion.go
+++ b/exporter/collector/integrationtest/testcases/conversion.go
@@ -244,7 +244,6 @@ func convertFloatExemplars(es pmetric.ExemplarSlice) []metricdata.Exemplar[float
 		}
 	}
 	return exemplars
-
 }
 
 func convertAttributes(attrs pcommon.Map) []attribute.KeyValue {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram.json
@@ -64,7 +64,7 @@
                       ],
                       "exemplars": [
                         {
-                          "asDouble": 1.1,
+                          "asDouble": 4.1,
                           "timeUnixNano": "1649443516286000000",
                           "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
                           "spanId": "84f9e8929bb1cd5b",
@@ -111,7 +111,7 @@
                       ],
                       "exemplars": [
                         {
-                          "asDouble": 10.5,
+                          "asDouble": 15.5,
                           "timeUnixNano": "1649443516286000000",
                           "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
                           "spanId": "84f9e8929bb1cd5b",
@@ -167,7 +167,7 @@
                       ],
                       "exemplars": [
                         {
-                          "asInt": 1,
+                          "asInt": 4,
                           "timeUnixNano": "1649443516286000000",
                           "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
                           "spanId": "84f9e8929bb1cd5b",
@@ -214,7 +214,7 @@
                       ],
                       "exemplars": [
                         {
-                          "asInt": 3,
+                          "asInt": 12,
                           "timeUnixNano": "1649443516286000000",
                           "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
                           "spanId": "84f9e8929bb1cd5b",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram.json
@@ -28,7 +28,110 @@
             "scope": {},
             "metrics": [
               {
-                "name": "simple.histogram",
+                "name": "simple.float64.histogram",
+                "unit": "s",
+                "histogram": {
+                  "dataPoints": [
+                    {
+                      "attributes": [
+                        {
+                          "key": "some.lemons",
+                          "value": {
+                            "stringValue": "13"
+                          }
+                        }
+                      ],
+                      "startTimeUnixNano": "1649443516286000000",
+                      "timeUnixNano": "1649443516286000000",
+                      "count": "1",
+                      "sum": 2.5,
+                      "bucketCounts": [
+                        "0",
+                        "0",
+                        "1",
+                        "0",
+                        "0",
+                        "0",
+                        "0"
+                      ],
+                      "explicitBounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ],
+                      "exemplars": [
+                        {
+                          "asDouble": 1.1,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "attributes": [
+                        {
+                          "key": "some.lemons",
+                          "value": {
+                            "stringValue": "10"
+                          }
+                        }
+                      ],
+                      "startTimeUnixNano": "1649443516286000000",
+                      "timeUnixNano": "1649443516286000000",
+                      "count": "2",
+                      "sum": 14.3,
+                      "bucketCounts": [
+                        "0",
+                        "0",
+                        "1",
+                        "0",
+                        "1",
+                        "0",
+                        "0"
+                      ],
+                      "explicitBounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ],
+                      "exemplars": [
+                        {
+                          "asDouble": 10.5,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                }
+              },
+              {
+                "name": "simple.int64.histogram",
                 "unit": "s",
                 "histogram": {
                   "dataPoints": [
@@ -111,7 +214,7 @@
                       ],
                       "exemplars": [
                         {
-                          "asDouble": 10.5,
+                          "asInt": 3,
                           "timeUnixNano": "1649443516286000000",
                           "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
                           "spanId": "84f9e8929bb1cd5b",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram.json
@@ -61,6 +61,22 @@
                         10,
                         20,
                         50
+                      ],
+                      "exemplars": [
+                        {
+                          "asInt": 1,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
                       ]
                     },
                     {
@@ -92,6 +108,22 @@
                         10,
                         20,
                         50
+                      ],
+                      "exemplars": [
+                        {
+                          "asDouble": 10.5,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
                       ]
                     }
                   ],

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -5,7 +5,155 @@
       "timeSeries": [
         {
           "metric": {
-            "type": "workload.googleapis.com/simple.histogram",
+            "type": "workload.googleapis.com/simple.float64.histogram",
+            "labels": {
+              "some_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "",
+              "task_id": "10.92.5.2:15692"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 2.5,
+                  "sumOfSquaredDeviation": 1,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 1.1,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/simple.float64.histogram",
+            "labels": {
+              "some_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "",
+              "task_id": "10.92.5.2:15692"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "2",
+                  "mean": 7.15,
+                  "sumOfSquaredDeviation": 74.945,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "1",
+                    "0",
+                    "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 10.5,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/simple.int64.histogram",
             "labels": {
               "some_lemons": "13"
             }
@@ -79,7 +227,7 @@
         },
         {
           "metric": {
-            "type": "workload.googleapis.com/simple.histogram",
+            "type": "workload.googleapis.com/simple.int64.histogram",
             "labels": {
               "some_lemons": "10"
             }
@@ -129,7 +277,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 10.5,
+                      "value": 3,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -158,8 +306,8 @@
     {
       "name": "projects/fakeprojectid",
       "metricDescriptor": {
-        "name": "simple.histogram",
-        "type": "workload.googleapis.com/simple.histogram",
+        "name": "simple.float64.histogram",
+        "type": "workload.googleapis.com/simple.float64.histogram",
         "labels": [
           {
             "key": "some_lemons"
@@ -168,7 +316,23 @@
         "metricKind": "CUMULATIVE",
         "valueType": "DISTRIBUTION",
         "unit": "s",
-        "displayName": "simple.histogram"
+        "displayName": "simple.float64.histogram"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "simple.int64.histogram",
+        "type": "workload.googleapis.com/simple.int64.histogram",
+        "labels": [
+          {
+            "key": "some_lemons"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "DISTRIBUTION",
+        "unit": "s",
+        "displayName": "simple.int64.histogram"
       }
     }
   ],
@@ -194,7 +358,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "2"
+                  "int64Value": "4"
                 }
               }
             ]
@@ -217,7 +381,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "1"
+                  "int64Value": "2"
                 }
               }
             ]

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -52,6 +52,24 @@
                     "0",
                     "0",
                     "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 1,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
                   ]
                 }
               }
@@ -108,6 +126,24 @@
                     "1",
                     "0",
                     "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 10.5,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
                   ]
                 }
               }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -55,7 +55,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 1.1,
+                      "value": 4.1,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -129,7 +129,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 10.5,
+                      "value": 15.5,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -203,7 +203,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 1,
+                      "value": 4,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -277,7 +277,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 3,
+                      "value": 12,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -56,7 +56,7 @@
                   "exemplars": [
                     {
                       "value": 4.1,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
@@ -130,7 +130,7 @@
                   "exemplars": [
                     {
                       "value": 15.5,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
@@ -204,7 +204,7 @@
                   "exemplars": [
                     {
                       "value": 4,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
@@ -278,7 +278,7 @@
                   "exemplars": [
                     {
                       "value": 12,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -57,7 +57,7 @@
                   "exemplars": [
                     {
                       "value": 4.1,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
@@ -132,7 +132,7 @@
                   "exemplars": [
                     {
                       "value": 15.5,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
@@ -207,7 +207,7 @@
                   "exemplars": [
                     {
                       "value": 4,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
@@ -282,7 +282,7 @@
                   "exemplars": [
                     {
                       "value": 12,
-                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "timestamp": "1970-01-01T00:00:00Z",
                       "attachments": [
                         {
                           "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -56,7 +56,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 1.1,
+                      "value": 4.1,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -131,7 +131,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 10.5,
+                      "value": 15.5,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -206,7 +206,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 1,
+                      "value": 4,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -281,7 +281,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 3,
+                      "value": 12,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -5,7 +5,157 @@
       "timeSeries": [
         {
           "metric": {
-            "type": "prometheus.googleapis.com/simple_histogram_seconds/histogram",
+            "type": "prometheus.googleapis.com/simple_float64_histogram_seconds/histogram",
+            "labels": {
+              "some_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 2.5,
+                  "sumOfSquaredDeviation": 1,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 1.1,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/simple_float64_histogram_seconds/histogram",
+            "labels": {
+              "some_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "2",
+                  "mean": 7.15,
+                  "sumOfSquaredDeviation": 74.945,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        1,
+                        2,
+                        5,
+                        10,
+                        20,
+                        50
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "1",
+                    "0",
+                    "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 10.5,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/simple_int64_histogram_seconds/histogram",
             "labels": {
               "some_lemons": "13"
             }
@@ -80,7 +230,7 @@
         },
         {
           "metric": {
-            "type": "prometheus.googleapis.com/simple_histogram_seconds/histogram",
+            "type": "prometheus.googleapis.com/simple_int64_histogram_seconds/histogram",
             "labels": {
               "some_lemons": "10"
             }
@@ -131,7 +281,7 @@
                   ],
                   "exemplars": [
                     {
-                      "value": 10.5,
+                      "value": 3,
                       "timestamp": "2022-04-08T18:45:16.286Z",
                       "attachments": [
                         {
@@ -205,7 +355,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "3"
+                  "int64Value": "5"
                 }
               }
             ]

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -53,6 +53,24 @@
                     "0",
                     "0",
                     "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 1,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
                   ]
                 }
               }
@@ -110,6 +128,24 @@
                     "1",
                     "0",
                     "0"
+                  ],
+                  "exemplars": [
+                    {
+                      "value": 10.5,
+                      "timestamp": "2022-04-08T18:45:16.286Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
                   ]
                 }
               }

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -21,7 +21,10 @@ require (
 	google.golang.org/protobuf v1.33.0
 )
 
-require google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
+require (
+	go.opentelemetry.io/otel/trace v1.23.1
+	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
+)
 
 require (
 	cloud.google.com/go/compute v1.23.0 // indirect
@@ -41,7 +44,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.23.1 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -754,9 +754,8 @@ func toDistributionExemplar[N int64 | float64](Exemplars []metricdata.Exemplar[N
 	for _, e := range Exemplars {
 		attachments := []*anypb.Any{}
 		if hasValidSpanContext(e) {
-			traceID, spanID := e.TraceID, e.SpanID
 			sctx, err := anypb.New(&monitoringpb.SpanContext{
-				SpanName: fmt.Sprintf("projects/%s/traces/%s/spans/%s", projectID, hex.EncodeToString(traceID[:]), hex.EncodeToString(spanID[:])),
+				SpanName: fmt.Sprintf("projects/%s/traces/%s/spans/%s", projectID, hex.EncodeToString(e.TraceID[:]), hex.EncodeToString(e.SpanID[:])),
 			})
 			if err == nil {
 				attachments = append(attachments, sctx)


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/806

This makes sure exemplar support, which was fixed in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/810 displays correctly in the UI for histograms