### PR TITLE
Make client auth extension public and implement component.Component

### DIFF
--- a/extension/googleclientauthextension/config.go
+++ b/extension/googleclientauthextension/config.go
@@ -54,7 +54,7 @@ var defaultScopes = []string{
 	"https://www.googleapis.com/auth/trace.append",
 }
 
-func createDefaultConfig() component.Config {
+func CreateDefaultConfig() component.Config {
 	return &Config{
 		Scopes: defaultScopes,
 	}

--- a/extension/googleclientauthextension/factory.go
+++ b/extension/googleclientauthextension/factory.go
@@ -32,13 +32,13 @@ import (
 func NewFactory() extension.Factory {
 	return extension.NewFactory(
 		metadata.Type,
-		createDefaultConfig,
-		createExtension,
+		CreateDefaultConfig,
+		CreateExtension,
 		metadata.ExtensionStability,
 	)
 }
 
-func createExtension(ctx context.Context, set extension.CreateSettings, cfg component.Config) (extension.Extension, error) {
+func CreateExtension(ctx context.Context, set extension.CreateSettings, cfg component.Config) (extension.Extension, error) {
 	config := cfg.(*Config)
 	creds, err := google.FindDefaultCredentials(ctx, config.Scopes...)
 	if err != nil {

--- a/extension/googleclientauthextension/factory.go
+++ b/extension/googleclientauthextension/factory.go
@@ -47,7 +47,7 @@ func CreateExtension(ctx context.Context, set extension.CreateSettings, cfg comp
 
 // clientAuthenticator supplies credentials from an oauth.TokenSource.
 type clientAuthenticator struct {
-	oauth.TokenSource
+	*oauth.TokenSource
 	config *Config
 }
 
@@ -66,7 +66,7 @@ func (ca *clientAuthenticator) Start(ctx context.Context, _ component.Host) erro
 	if config.QuotaProject == "" {
 		config.QuotaProject = quotaProjectFromCreds(creds)
 	}
-	ca.TokenSource = oauth.TokenSource{TokenSource: creds.TokenSource}
+	ca.TokenSource = &oauth.TokenSource{TokenSource: creds.TokenSource}
 	return nil
 }
 

--- a/extension/googleclientauthextension/factory_test.go
+++ b/extension/googleclientauthextension/factory_test.go
@@ -41,3 +41,21 @@ func TestCreateExtension(t *testing.T) {
 	assert.NotNil(t, ext)
 	assert.NoError(t, err)
 }
+
+func TestStart(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/fake_creds.json")
+	ext, err := NewFactory().CreateExtension(context.Background(), extension.CreateSettings{}, CreateDefaultConfig())
+	assert.NotNil(t, ext)
+	assert.NoError(t, err)
+	err = ext.Start(context.Background(), nil)
+	assert.NoError(t, err)
+}
+
+func TestStart_WithError(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/foo.json")
+	ext, err := NewFactory().CreateExtension(context.Background(), extension.CreateSettings{}, CreateDefaultConfig())
+	assert.NotNil(t, ext)
+	assert.NoError(t, err)
+	err = ext.Start(context.Background(), nil)
+	assert.Error(t, err)
+}

--- a/extension/googleclientauthextension/factory_test.go
+++ b/extension/googleclientauthextension/factory_test.go
@@ -37,7 +37,7 @@ func TestNewFactory(t *testing.T) {
 
 func TestCreateExtension(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/fake_creds.json")
-	ext, err := NewFactory().CreateExtension(context.Background(), extension.CreateSettings{}, createDefaultConfig())
+	ext, err := NewFactory().CreateExtension(context.Background(), extension.CreateSettings{}, CreateDefaultConfig())
 	assert.NotNil(t, ext)
 	assert.NoError(t, err)
 }

--- a/extension/googleclientauthextension/go.mod
+++ b/extension/googleclientauthextension/go.mod
@@ -7,7 +7,6 @@ require (
 	go.opentelemetry.io/collector/component v0.94.0
 	go.opentelemetry.io/collector/confmap v0.94.0
 	go.opentelemetry.io/collector/extension v0.94.0
-	go.opentelemetry.io/collector/extension/auth v0.94.0
 	golang.org/x/oauth2 v0.16.0
 	google.golang.org/grpc v1.61.0
 )

--- a/extension/googleclientauthextension/go.sum
+++ b/extension/googleclientauthextension/go.sum
@@ -63,8 +63,6 @@ go.opentelemetry.io/collector/confmap v0.94.0 h1:yjzdGPHCeae7VooJkgeOWO2Y3XFKwOI
 go.opentelemetry.io/collector/confmap v0.94.0/go.mod h1:pCT5UtcHaHVJ5BIILv1Z2VQyjZzmT9uTdBmC9+Z0AgA=
 go.opentelemetry.io/collector/extension v0.94.0 h1:8XspN+A1aQhN3vQb2reE4kYF7qSkKULKF++TE4VEA9o=
 go.opentelemetry.io/collector/extension v0.94.0/go.mod h1:G0+tNTYZf0D0d42tWKv8rILMi4YkalPw2qtXTn80SOU=
-go.opentelemetry.io/collector/extension/auth v0.94.0 h1:TJxKM9dArGnaz6DYO3ASYYBU/DIHfzr622BPtCY/Z04=
-go.opentelemetry.io/collector/extension/auth v0.94.0/go.mod h1:kL5FQQtUAUTs8ngP51ft1Guzn2czFZloG9lBANXekNM=
 go.opentelemetry.io/collector/pdata v1.1.0 h1:cE6Al1rQieUjMHro6p6cKwcu3sjHXGG59BZ3kRVUvsM=
 go.opentelemetry.io/collector/pdata v1.1.0/go.mod h1:IDkDj+B4Fp4wWOclBELN97zcb98HugJ8Q2gA4ZFsN8Q=
 go.opentelemetry.io/otel v1.23.1 h1:Za4UzOqJYS+MUczKI320AtqZHZb7EqxO00jAHE0jmQY=

--- a/extension/googleclientauthextension/grpc.go
+++ b/extension/googleclientauthextension/grpc.go
@@ -22,7 +22,7 @@ import (
 
 // perRPCCredentials returns gRPC credentials using the OAuth TokenSource, and adds
 // google metadata.
-func (ca clientAuthenticator) perRPCCredentials() (credentials.PerRPCCredentials, error) {
+func (ca clientAuthenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
 	return ca, nil
 }
 

--- a/extension/googleclientauthextension/grpc.go
+++ b/extension/googleclientauthextension/grpc.go
@@ -16,6 +16,7 @@ package googleclientauthextension // import "github.com/GoogleCloudPlatform/open
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/credentials"
 )
@@ -23,6 +24,9 @@ import (
 // perRPCCredentials returns gRPC credentials using the OAuth TokenSource, and adds
 // google metadata.
 func (ca clientAuthenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+	if ca.TokenSource == nil {
+		return nil, errors.New("not started")
+	}
 	return ca, nil
 }
 
@@ -30,6 +34,10 @@ func (ca clientAuthenticator) PerRPCCredentials() (credentials.PerRPCCredentials
 // Based on metadata added by the google go client:
 // https://github.com/googleapis/google-api-go-client/blob/113082d14d54f188d1b6c34c652e416592fc51b5/transport/grpc/dial.go#L224
 func (ca clientAuthenticator) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	if ca.TokenSource == nil {
+		return nil, errors.New("not started")
+	}
+
 	metadata, err := ca.TokenSource.GetRequestMetadata(ctx, uri...)
 	if err != nil {
 		return nil, err

--- a/extension/googleclientauthextension/grpc_test.go
+++ b/extension/googleclientauthextension/grpc_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestPerRPCCredentials(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/fake_creds.json")
 	ca := clientAuthenticator{config: &Config{
 		Project:      "my-project",
 		QuotaProject: "other-project",

--- a/extension/googleclientauthextension/grpc_test.go
+++ b/extension/googleclientauthextension/grpc_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googleclientauthextension // import "github.com/GoogleCloudPlatform/opentelemetry-operations-go/extension/googleclientauthextension"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPerRPCCredentials(t *testing.T) {
+	ca := clientAuthenticator{config: &Config{
+		Project:      "my-project",
+		QuotaProject: "other-project",
+	}}
+	err := ca.Start(context.Background(), nil)
+	assert.NoError(t, err)
+
+	perrpc, err := ca.PerRPCCredentials()
+	assert.NotNil(t, perrpc)
+	assert.NoError(t, err)
+}
+
+func TestPerRPCCredentialsNotStarted(t *testing.T) {
+	ca := clientAuthenticator{config: &Config{
+		Project:      "my-project",
+		QuotaProject: "other-project",
+	}}
+	perrpc, err := ca.PerRPCCredentials()
+	assert.Nil(t, perrpc)
+	assert.Error(t, err)
+}

--- a/extension/googleclientauthextension/http.go
+++ b/extension/googleclientauthextension/http.go
@@ -24,6 +24,9 @@ import (
 // roundTripper provides an HTTP RoundTripper which adds gcp credentials and
 // headers.
 func (ca *clientAuthenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+	if ca.TokenSource == nil {
+		return nil, errors.New("not started")
+	}
 	return &oauth2.Transport{
 		Source: ca,
 		Base: &parameterTransport{

--- a/extension/googleclientauthextension/http.go
+++ b/extension/googleclientauthextension/http.go
@@ -23,7 +23,7 @@ import (
 
 // roundTripper provides an HTTP RoundTripper which adds gcp credentials and
 // headers.
-func (ca *clientAuthenticator) roundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+func (ca *clientAuthenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
 	return &oauth2.Transport{
 		Source: ca,
 		Base: &parameterTransport{

--- a/extension/googleclientauthextension/http_test.go
+++ b/extension/googleclientauthextension/http_test.go
@@ -15,6 +15,7 @@
 package googleclientauthextension // import "github.com/GoogleCloudPlatform/opentelemetry-operations-go/extension/googleclientauthextension"
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -22,12 +23,32 @@ import (
 )
 
 func TestRoundTripper(t *testing.T) {
-	ca := clientAuthenticator{}
+	ca := clientAuthenticator{config: &Config{
+		Project:      "my-project",
+		QuotaProject: "other-project",
+	},
+	}
+	err := ca.Start(context.Background(), nil)
+	assert.NoError(t, err)
+
 	rt, err := ca.RoundTripper(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		return nil, nil
 	}))
 	assert.NotNil(t, rt)
 	assert.NoError(t, err)
+}
+
+func TestRoundTripperNotStarted(t *testing.T) {
+	ca := clientAuthenticator{config: &Config{
+		Project:      "my-project",
+		QuotaProject: "other-project",
+	}}
+
+	rt, err := ca.RoundTripper(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+	assert.Nil(t, rt)
+	assert.Error(t, err)
 }
 
 func TestRoundTrip(t *testing.T) {

--- a/extension/googleclientauthextension/http_test.go
+++ b/extension/googleclientauthextension/http_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestRoundTripper(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/fake_creds.json")
 	ca := clientAuthenticator{config: &Config{
 		Project:      "my-project",
 		QuotaProject: "other-project",

--- a/extension/googleclientauthextension/http_test.go
+++ b/extension/googleclientauthextension/http_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestRoundTripper(t *testing.T) {
 	ca := clientAuthenticator{}
-	rt, err := ca.roundTripper(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+	rt, err := ca.RoundTripper(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		return nil, nil
 	}))
 	assert.NotNil(t, rt)


### PR DESCRIPTION
Working on contributing this upstream (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31518), we will need to export some of the functions like CreateExtension and CreateDefaultConfig. This also implements the `component.Component` interface so the extension can be created without calling `google.FindDefaultCredentials()`, which can result in an immediate error if the credentials are not found. This enables lifecycle tests upstream.