### PR TITLE
Add MapMonitoredResource field to Log config.

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -183,6 +183,11 @@ type LogConfig struct {
 	// ErrorReportingType enables automatically parsing error logs to a json payload containing the
 	// type value for GCP Error Reporting. See https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text.
 	ErrorReportingType bool `mapstructure:"error_reporting_type"`
+	// MapMonitoredResource is not exposed as an option in the configuration, but
+	// can be used by other exporters to extend the functionality of this
+	// exporter. It allows overriding the function used to map otel resource to
+	// monitored resource.
+	MapMonitoredResource func(pcommon.Resource) *monitoredrespb.MonitoredResource
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.
@@ -194,6 +199,7 @@ func DefaultConfig() Config {
 		UserAgent: "opentelemetry-collector-contrib {{version}}",
 		LogConfig: LogConfig{
 			ServiceResourceLabels: true,
+			MapMonitoredResource:  defaultResourceToMonitoredResource,
 		},
 		MetricConfig: MetricConfig{
 			KnownDomains:                     domains,

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -168,6 +168,11 @@ type ResourceFilter struct {
 }
 
 type LogConfig struct {
+	// MapMonitoredResource is not exposed as an option in the configuration, but
+	// can be used by other exporters to extend the functionality of this
+	// exporter. It allows overriding the function used to map otel resource to
+	// monitored resource.
+	MapMonitoredResource func(pcommon.Resource) *monitoredrespb.MonitoredResource
 	// DefaultLogName sets the fallback log name to use when one isn't explicitly set
 	// for a log entry. If unset, logs without a log name will raise an error.
 	DefaultLogName string `mapstructure:"default_log_name"`
@@ -183,11 +188,6 @@ type LogConfig struct {
 	// ErrorReportingType enables automatically parsing error logs to a json payload containing the
 	// type value for GCP Error Reporting. See https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text.
 	ErrorReportingType bool `mapstructure:"error_reporting_type"`
-	// MapMonitoredResource is not exposed as an option in the configuration, but
-	// can be used by other exporters to extend the functionality of this
-	// exporter. It allows overriding the function used to map otel resource to
-	// monitored resource.
-	MapMonitoredResource func(pcommon.Resource) *monitoredrespb.MonitoredResource
 }
 
 // Known metric domains. Note: This is now configurable for advanced usages.
@@ -199,7 +199,7 @@ func DefaultConfig() Config {
 		UserAgent: "opentelemetry-collector-contrib {{version}}",
 		LogConfig: LogConfig{
 			ServiceResourceLabels: true,
-			MapMonitoredResource:  defaultResourceToMonitoredResource,
+			MapMonitoredResource:  defaultResourceToLoggingMonitoredResource,
 		},
 		MetricConfig: MetricConfig{
 			KnownDomains:                     domains,

--- a/exporter/collector/integrationtest/config/config_test.go
+++ b/exporter/collector/integrationtest/config/config_test.go
@@ -89,6 +89,7 @@ func TestLoadConfig(t *testing.T) {
 func sanitize(cfg *testExporterConfig) *testExporterConfig {
 	cfg.Config.MetricConfig.MapMonitoredResource = nil
 	cfg.Config.MetricConfig.GetMetricName = nil
+	cfg.Config.LogConfig.MapMonitoredResource = nil
 	return cfg
 }
 

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -278,7 +278,7 @@ func (l logMapper) createEntries(ld plog.Logs) (map[string][]*logpb.LogEntry, er
 	entries := make(map[string][]*logpb.LogEntry)
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
-		mr := defaultResourceToLoggingMonitoredResource(rl.Resource())
+		mr := l.cfg.LogConfig.MapMonitoredResource(rl.Resource())
 		extraResourceLabels := attributesToUnsanitizedLabels(filterAttributes(rl.Resource().Attributes(), l.cfg.LogConfig.ServiceResourceLabels, l.cfg.LogConfig.ResourceFilters))
 		projectID := l.cfg.ProjectID
 		// override project ID with gcp.project.id, if present


### PR DESCRIPTION
It is needed for users that want to use their own logs resource mapping method because their resource is not mapped in community.