### PR TITLE
Add support for BMS machines to the resource detection library

### DIFF
--- a/detectors/gcp/bms.go
+++ b/detectors/gcp/bms.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/detectors/gcp/bms.go
+++ b/detectors/gcp/bms.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+const (
+	bmsProjectIDEnv  = "BMS_PROJECT_ID"
+	bmsRegionEnv     = "BMS_REGION"
+	bmsInstanceIDEnv = "BMS_INSTANCE_ID"
+)
+
+// Use BMS_PROJECT_ID, BMS_REGION and BMS_INSTANCE_ID env vars as an indication that we are running on BMS.
+func (d *Detector) onBMS() bool {
+	projectID, projectIDExists := d.os.LookupEnv(bmsProjectIDEnv)
+	region, regionExists := d.os.LookupEnv(bmsRegionEnv)
+	instanceID, instanceIDExists := d.os.LookupEnv(bmsInstanceIDEnv)
+	return projectIDExists && regionExists && instanceIDExists && projectID != "" && region != "" && instanceID != ""
+}
+
+// BMSInstanceID returns the instance ID from the BMS_INSTANCE_ID environment variable.
+func (d *Detector) BMSInstanceID() (string, error) {
+	if instanceID, found := d.os.LookupEnv(bmsInstanceIDEnv); found {
+		return instanceID, nil
+	}
+	return "", errEnvVarNotFound
+}
+
+// BMSCloudRegion returns the region from the BMS_REGION environment variable.
+func (d *Detector) BMSCloudRegion() (string, error) {
+	if region, found := d.os.LookupEnv(bmsRegionEnv); found {
+		return region, nil
+	}
+	return "", errEnvVarNotFound
+}
+
+// BMSProjectID returns the project ID from the BMS_PROJECT_ID environment variable.
+func (d *Detector) BMSProjectID() (string, error) {
+	if project, found := d.os.LookupEnv(bmsProjectIDEnv); found {
+		return project, nil
+	}
+	return "", errEnvVarNotFound
+}

--- a/detectors/gcp/bms.go
+++ b/detectors/gcp/bms.go
@@ -20,32 +20,34 @@ const (
 	bmsInstanceIDEnv = "BMS_INSTANCE_ID"
 )
 
-// Use BMS_PROJECT_ID, BMS_REGION and BMS_INSTANCE_ID env vars as an indication that we are running on BMS.
-func (d *Detector) onBMS() bool {
+// onBareMetalSolution checks if the code is running on a Google Cloud Bare Metal Solution (BMS) by verifying
+// the presence and non-empty values of BMS_PROJECT_ID, BMS_REGION, and BMS_INSTANCE_ID environment variables.
+// For more information on Google Cloud Bare Metal Solution, see: https://cloud.google.com/bare-metal/docs
+func (d *Detector) onBareMetalSolution() bool {
 	projectID, projectIDExists := d.os.LookupEnv(bmsProjectIDEnv)
 	region, regionExists := d.os.LookupEnv(bmsRegionEnv)
 	instanceID, instanceIDExists := d.os.LookupEnv(bmsInstanceIDEnv)
 	return projectIDExists && regionExists && instanceIDExists && projectID != "" && region != "" && instanceID != ""
 }
 
-// BMSInstanceID returns the instance ID from the BMS_INSTANCE_ID environment variable.
-func (d *Detector) BMSInstanceID() (string, error) {
+// BareMetalSolutionInstanceID returns the instance ID from the BMS_INSTANCE_ID environment variable.
+func (d *Detector) BareMetalSolutionInstanceID() (string, error) {
 	if instanceID, found := d.os.LookupEnv(bmsInstanceIDEnv); found {
 		return instanceID, nil
 	}
 	return "", errEnvVarNotFound
 }
 
-// BMSCloudRegion returns the region from the BMS_REGION environment variable.
-func (d *Detector) BMSCloudRegion() (string, error) {
+// BareMetalSolutionCloudRegion returns the region from the BMS_REGION environment variable.
+func (d *Detector) BareMetalSolutionCloudRegion() (string, error) {
 	if region, found := d.os.LookupEnv(bmsRegionEnv); found {
 		return region, nil
 	}
 	return "", errEnvVarNotFound
 }
 
-// BMSProjectID returns the project ID from the BMS_PROJECT_ID environment variable.
-func (d *Detector) BMSProjectID() (string, error) {
+// BareMetalSolutionProjectID returns the project ID from the BMS_PROJECT_ID environment variable.
+func (d *Detector) BareMetalSolutionProjectID() (string, error) {
 	if project, found := d.os.LookupEnv(bmsProjectIDEnv); found {
 		return project, nil
 	}

--- a/detectors/gcp/bms_test.go
+++ b/detectors/gcp/bms_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/detectors/gcp/bms_test.go
+++ b/detectors/gcp/bms_test.go
@@ -20,62 +20,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBMSInstanceID(t *testing.T) {
+func TestBareMetalSolutionInstanceID(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{
 			bmsInstanceIDEnv: "my-host-123",
 		},
 	})
-	instanceID, err := d.BMSInstanceID()
+	instanceID, err := d.BareMetalSolutionInstanceID()
 	assert.NoError(t, err)
 	assert.Equal(t, instanceID, "my-host-123")
 }
 
-func TestBMSInstanceIDErr(t *testing.T) {
+func TestBareMetalSolutionInstanceIDErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{},
 	})
-	instanceID, err := d.BMSInstanceID()
+	instanceID, err := d.BareMetalSolutionInstanceID()
 	assert.Error(t, err)
 	assert.Equal(t, instanceID, "")
 }
 
-func TestBMSBMSCloudRegion(t *testing.T) {
+func TestBareMetalSolutionCloudRegion(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{
 			bmsRegionEnv: "us-central1",
 		},
 	})
-	region, err := d.BMSCloudRegion()
+	region, err := d.BareMetalSolutionCloudRegion()
 	assert.NoError(t, err)
 	assert.Equal(t, region, "us-central1")
 }
 
-func TestBMSCloudRegionErr(t *testing.T) {
+func TestBareMetalSolutionCloudRegionErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{},
 	})
-	region, err := d.BMSCloudRegion()
+	region, err := d.BareMetalSolutionCloudRegion()
 	assert.Error(t, err)
 	assert.Equal(t, region, "")
 }
 
-func TestBMSBMSProjectID(t *testing.T) {
+func TestBareMetalSolutionProjectID(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{
 			bmsProjectIDEnv: "my-test-project",
 		},
 	})
-	projectID, err := d.BMSProjectID()
+	projectID, err := d.BareMetalSolutionProjectID()
 	assert.NoError(t, err)
 	assert.Equal(t, projectID, "my-test-project")
 }
 
-func TestBMSProjectIDErr(t *testing.T) {
+func TestBareMetalSolutionProjectIDErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{},
 	})
-	projectID, err := d.BMSProjectID()
+	projectID, err := d.BareMetalSolutionProjectID()
 	assert.Error(t, err)
 	assert.Equal(t, projectID, "")
 }

--- a/detectors/gcp/bms_test.go
+++ b/detectors/gcp/bms_test.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBMSInstanceID(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{
+			bmsInstanceIDEnv: "my-host-123",
+		},
+	})
+	instanceID, err := d.BMSInstanceID()
+	assert.NoError(t, err)
+	assert.Equal(t, instanceID, "my-host-123")
+}
+
+func TestBMSInstanceIDErr(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{},
+	})
+	instanceID, err := d.BMSInstanceID()
+	assert.Error(t, err)
+	assert.Equal(t, instanceID, "")
+}
+
+func TestBMSBMSCloudRegion(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{
+			bmsRegionEnv: "us-central1",
+		},
+	})
+	region, err := d.BMSCloudRegion()
+	assert.NoError(t, err)
+	assert.Equal(t, region, "us-central1")
+}
+
+func TestBMSCloudRegionErr(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{},
+	})
+	region, err := d.BMSCloudRegion()
+	assert.Error(t, err)
+	assert.Equal(t, region, "")
+}
+
+func TestBMSBMSProjectID(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{
+			bmsProjectIDEnv: "my-test-project",
+		},
+	})
+	projectID, err := d.BMSProjectID()
+	assert.NoError(t, err)
+	assert.Equal(t, projectID, "my-test-project")
+}
+
+func TestBMSProjectIDErr(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{},
+	})
+	projectID, err := d.BMSProjectID()
+	assert.Error(t, err)
+	assert.Equal(t, projectID, "")
+}

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -40,14 +40,14 @@ const (
 	CloudFunctions
 	AppEngineStandard
 	AppEngineFlex
-	BMS
+	BareMetalSolution
 )
 
 // CloudPlatform returns the platform on which this program is running.
 func (d *Detector) CloudPlatform() Platform {
 	switch {
-	case d.onBMS():
-		return BMS
+	case d.onBareMetalSolution():
+		return BareMetalSolution
 	case d.onGKE():
 		return GKE
 	case d.onCloudFunctions():

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -40,11 +40,14 @@ const (
 	CloudFunctions
 	AppEngineStandard
 	AppEngineFlex
+	BMS
 )
 
 // CloudPlatform returns the platform on which this program is running.
 func (d *Detector) CloudPlatform() Platform {
 	switch {
+	case d.onBMS():
+		return BMS
 	case d.onGKE():
 		return GKE
 	case d.onCloudFunctions():

--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -90,6 +90,18 @@ func TestCloudPlatformCloudFunctions(t *testing.T) {
 	assert.Equal(t, platform, CloudFunctions)
 }
 
+func TestCloudPlatformBMS(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
+		Vars: map[string]string{
+			bmsInstanceIDEnv: "foo",
+			bmsProjectIDEnv:  "bar",
+			bmsRegionEnv:     "qux",
+		},
+	})
+	platform := d.CloudPlatform()
+	assert.Equal(t, platform, BMS)
+}
+
 func TestProjectID(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{
 		Project: "my-project",

--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -90,7 +90,7 @@ func TestCloudPlatformCloudFunctions(t *testing.T) {
 	assert.Equal(t, platform, CloudFunctions)
 }
 
-func TestCloudPlatformBMS(t *testing.T) {
+func TestCloudPlatformBareMetalSolution(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{
 			bmsInstanceIDEnv: "foo",
@@ -99,7 +99,7 @@ func TestCloudPlatformBMS(t *testing.T) {
 		},
 	})
 	platform := d.CloudPlatform()
-	assert.Equal(t, platform, BMS)
+	assert.Equal(t, platform, BareMetalSolution)
 }
 
 func TestProjectID(t *testing.T) {

--- a/detectors/gcp/gce_test.go
+++ b/detectors/gcp/gce_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/detectors/gcp/gce_test.go
+++ b/detectors/gcp/gce_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds support for BMS machines to the resource detection library.

I'm planning to upgrade the resource detection processor within the opentelemetry-collector-contrib repository to make use of this new BMS detector, aiming to enable native BMS support in the otel collector.

Due to the absence of a metadata server in the BMS environment, we rely on the presence of BMS_PROJECT_ID, BMS_REGION, and BMS_INSTANCE_ID  environment variables as an indication that the collector is running on BMS machines. Customers are expected to manually enter these variables into the Ops Agent's collector using the DefaultEnvironment parameter in the /etc/systemd/system.conf file.

