### PR TITLE
fix: flatten ValueTypeSlice to ValueTypeString

### DIFF
--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -129,6 +129,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -306,6 +311,11 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "process.owner": {
@@ -487,6 +497,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -666,6 +681,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -809,6 +829,11 @@
                   "value": "go version go1.19-pre4 cl/455575533 +12f49fe0ed linux/amd64"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.runtime.name": {
                 "stringValue": {
                   "value": "go"
@@ -944,6 +969,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1067,6 +1097,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -1194,6 +1229,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1288,6 +1328,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -1386,6 +1431,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1482,6 +1532,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1576,6 +1631,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -1727,6 +1787,11 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "process.owner": {
@@ -1908,6 +1973,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -2087,6 +2157,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -2245,6 +2320,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -2373,6 +2453,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -2505,6 +2590,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -2635,6 +2725,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -2729,6 +2824,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -131,7 +131,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -315,7 +315,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -499,7 +499,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -683,7 +683,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -831,7 +831,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.runtime.name": {
@@ -971,7 +971,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1101,7 +1101,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1231,7 +1231,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1332,7 +1332,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1433,7 +1433,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1534,7 +1534,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1635,7 +1635,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1791,7 +1791,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -1975,7 +1975,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2159,7 +2159,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2322,7 +2322,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2457,7 +2457,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2592,7 +2592,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2727,7 +2727,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2828,7 +2828,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -119,6 +119,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -127,11 +132,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -303,6 +303,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -311,11 +316,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -487,6 +487,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -495,11 +500,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -671,6 +671,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -679,11 +684,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -806,6 +806,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -827,11 +832,6 @@
               "process.runtime.description": {
                 "stringValue": {
                   "value": "go version go1.19-pre4 cl/455575533 +12f49fe0ed linux/amd64"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.runtime.name": {
@@ -936,6 +936,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -967,11 +972,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1066,6 +1066,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1097,11 +1102,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1196,6 +1196,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1227,11 +1232,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1297,6 +1297,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1328,11 +1333,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1398,6 +1398,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1429,11 +1434,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1499,6 +1499,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1530,11 +1535,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1600,6 +1600,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1631,11 +1636,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1779,6 +1779,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1787,11 +1792,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -1963,6 +1963,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1971,11 +1976,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2147,6 +2147,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2155,11 +2160,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2287,6 +2287,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2318,11 +2323,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2422,6 +2422,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2453,11 +2458,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2557,6 +2557,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2588,11 +2593,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2692,6 +2692,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2723,11 +2728,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2793,6 +2793,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2824,11 +2829,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -129,6 +129,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -306,6 +311,11 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "process.owner": {
@@ -487,6 +497,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -666,6 +681,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -809,6 +829,11 @@
                   "value": "go version go1.19-pre4 cl/455575533 +12f49fe0ed linux/amd64"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.runtime.name": {
                 "stringValue": {
                   "value": "go"
@@ -944,6 +969,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1067,6 +1097,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -1194,6 +1229,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1288,6 +1328,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -1386,6 +1431,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1482,6 +1532,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -1576,6 +1631,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -1727,6 +1787,11 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "process.owner": {
@@ -1908,6 +1973,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -2087,6 +2157,11 @@
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "process.owner": {
                 "stringValue": {
                   "value": "mikedame"
@@ -2245,6 +2320,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -2373,6 +2453,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {
@@ -2505,6 +2590,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -2635,6 +2725,11 @@
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
+                }
+              },
               "service.name": {
                 "stringValue": {
                   "value": "demo-client"
@@ -2729,6 +2824,11 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
+                }
+              },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "./main"
                 }
               },
               "service.name": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -131,7 +131,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -315,7 +315,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -499,7 +499,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -683,7 +683,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -831,7 +831,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.runtime.name": {
@@ -971,7 +971,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1101,7 +1101,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1231,7 +1231,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1332,7 +1332,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1433,7 +1433,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1534,7 +1534,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1635,7 +1635,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1791,7 +1791,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -1975,7 +1975,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2159,7 +2159,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2322,7 +2322,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2457,7 +2457,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2592,7 +2592,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2727,7 +2727,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2828,7 +2828,7 @@
               },
               "process.command_args": {
                 "stringValue": {
-                  "value": "./main"
+                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -119,6 +119,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -127,11 +132,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -303,6 +303,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -311,11 +316,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -487,6 +487,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -495,11 +500,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -671,6 +671,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -679,11 +684,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -806,6 +806,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -827,11 +832,6 @@
               "process.runtime.description": {
                 "stringValue": {
                   "value": "go version go1.19-pre4 cl/455575533 +12f49fe0ed linux/amd64"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.runtime.name": {
@@ -936,6 +936,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -967,11 +972,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1066,6 +1066,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1097,11 +1102,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1196,6 +1196,11 @@
                   "value": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1227,11 +1232,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1297,6 +1297,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1328,11 +1333,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1398,6 +1398,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1429,11 +1434,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1499,6 +1499,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1530,11 +1535,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1600,6 +1600,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1631,11 +1636,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -1779,6 +1779,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1787,11 +1792,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -1963,6 +1963,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -1971,11 +1976,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2147,6 +2147,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2155,11 +2160,6 @@
               "process.executable.path": {
                 "stringValue": {
                   "value": "/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server/main"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "process.owner": {
@@ -2287,6 +2287,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2318,11 +2323,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2422,6 +2422,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2453,11 +2458,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2557,6 +2557,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2588,11 +2593,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2692,6 +2692,11 @@
                   "value": "semver:0.33.0"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2723,11 +2728,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {
@@ -2793,6 +2793,11 @@
                   "value": "demo-client-tracer"
                 }
               },
+              "process.command_args": {
+                "stringValue": {
+                  "value": "[\"./main\"]"
+                }
+              },
               "process.executable.name": {
                 "stringValue": {
                   "value": "main"
@@ -2824,11 +2829,6 @@
               "process.runtime.version": {
                 "stringValue": {
                   "value": "go1.19-pre4 cl/455575533 +12f49fe0ed"
-                }
-              },
-              "process.command_args": {
-                "stringValue": {
-                  "value": "[\"./main\"]"
                 }
               },
               "service.name": {

--- a/exporter/collector/spandata.go
+++ b/exporter/collector/spandata.go
@@ -16,7 +16,6 @@ package collector
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -150,13 +149,8 @@ func pdataAttributesToOTAttributes(attrs pcommon.Map, resource pcommon.Resource)
 				otAttrs = append(otAttrs, attribute.Int64(k, v.Int()))
 			case pcommon.ValueTypeDouble:
 				otAttrs = append(otAttrs, attribute.Float64(k, v.Double()))
-			case pcommon.ValueTypeSlice:
-				slice := v.Slice()
-				stringArr := make([]string, 0, slice.Len())
-				for i := 0; i < slice.Len(); i++ {
-					stringArr = append(stringArr, slice.At(i).AsString())
-				}
-				otAttrs = append(otAttrs, attribute.String(k, strings.Join(stringArr, ",")))
+			default:
+				otAttrs = append(otAttrs, attribute.String(k, v.AsString()))
 			}
 			return true
 		})

--- a/exporter/collector/spandata.go
+++ b/exporter/collector/spandata.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -149,6 +150,13 @@ func pdataAttributesToOTAttributes(attrs pcommon.Map, resource pcommon.Resource)
 				otAttrs = append(otAttrs, attribute.Int64(k, v.Int()))
 			case pcommon.ValueTypeDouble:
 				otAttrs = append(otAttrs, attribute.Float64(k, v.Double()))
+			case pcommon.ValueTypeSlice:
+				slice := v.Slice()
+				stringArr := make([]string, 0, slice.Len())
+				for i := 0; i < slice.Len(); i++ {
+					stringArr = append(stringArr, slice.At(i).AsString())
+				}
+				otAttrs = append(otAttrs, attribute.String(k, strings.Join(stringArr, ",")))
 			}
 			return true
 		})

--- a/exporter/collector/spandata_test.go
+++ b/exporter/collector/spandata_test.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -89,6 +90,7 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 
 	gotOTSpanData := pdataResourceSpansToOTSpanData(rs)
 
+	jsonStr, _ := json.Marshal(strArr)
 	wantOTSpanData := &spanSnapshot{
 		spanContext: apitrace.NewSpanContext(apitrace.SpanContextConfig{
 			TraceID: apitrace.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
@@ -140,7 +142,7 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 			attribute.String("agent", "ocagent"),
 			attribute.Bool("cache_hit", true),
 			attribute.Int64("timeout_ns", 12e9),
-			attribute.String("header", "value1,value2"),
+			attribute.String("header", string(jsonStr)),
 		},
 		instrumentationLibrary: instrumentation.Library{
 			Name:    "test_il_name",

--- a/exporter/collector/spandata_test.go
+++ b/exporter/collector/spandata_test.go
@@ -85,12 +85,15 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 	span.Attributes().PutStr("agent", "ocagent")
 	span.Attributes().PutEmptySlice("header")
 	strArr := []any{"value1", "value2"}
-	headerValue, _ := span.Attributes().Get("header")
-	headerValue.Slice().FromRaw(strArr)
+	headerValue, found := span.Attributes().Get("header")
+	assert.True(t, found)
+	err := headerValue.Slice().FromRaw(strArr)
+	assert.NoError(t, err)
 
 	gotOTSpanData := pdataResourceSpansToOTSpanData(rs)
 
-	jsonStr, _ := json.Marshal(strArr)
+	jsonStr, err := json.Marshal(strArr)
+	assert.NoError(t, err)
 	wantOTSpanData := &spanSnapshot{
 		spanContext: apitrace.NewSpanContext(apitrace.SpanContextConfig{
 			TraceID: apitrace.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},

--- a/exporter/collector/spandata_test.go
+++ b/exporter/collector/spandata_test.go
@@ -82,6 +82,10 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 	span.Attributes().PutInt("timeout_ns", 12e9)
 	span.Attributes().PutInt("ping_count", 25)
 	span.Attributes().PutStr("agent", "ocagent")
+	span.Attributes().PutEmptySlice("header")
+	strArr := []any{"value1", "value2"}
+	headerValue, _ := span.Attributes().Get("header")
+	headerValue.Slice().FromRaw(strArr)
 
 	gotOTSpanData := pdataResourceSpansToOTSpanData(rs)
 
@@ -136,6 +140,7 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 			attribute.String("agent", "ocagent"),
 			attribute.Bool("cache_hit", true),
 			attribute.Int64("timeout_ns", 12e9),
+			attribute.String("header", "value1,value2"),
 		},
 		instrumentationLibrary: instrumentation.Library{
 			Name:    "test_il_name",


### PR DESCRIPTION
:wave: 

While working with the OpenTelemetry stack for Python as well as an OpenTelemetry Collector (Cloud Run Sidecar, per docs [here](https://github.com/GoogleCloudPlatform/opentelemetry-cloud-run)), I noticed a discrepancy in behavior.

GCP Cloud Trace doesn't support Slice/Array data types for Trace Attributes, which Python's `CloudTraceSpanExporter` handles by [flattening Slices to Strings](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/main/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/__init__.py#L536-L540C). However, the golang Collector Exporter currently silently drops any `Slice[T]` attribute. This results in some oddities when choosing how to send traces to GCP Cloud Trace, where any time a collector exports to GCP Cloud Trace you silently lose attributes you would otherwise receive in Cloud Trace.

This PR attempts to unify this behavior, so that the same behavior is observed whether using the in-process exporter or the googlecloud Collector exporter.