### PR TITLE
Use codecov secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,12 @@ jobs:
           cp coverage.txt $TEST_RESULTS
           cp coverage.html $TEST_RESULTS
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v4.2.0
         with:
           file: ./coverage.txt
           fail_ci_if_error: true
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Store coverage test output
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
See if this fixes our codecov upload issues.  This is what otel-go does, and what https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469 suggests