### PR TITLE
Update grpc example to allow long runs

### DIFF
--- a/example/trace/otlpgrpc/example.go
+++ b/example/trace/otlpgrpc/example.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/credentials/oauth"
 )
 
-var sustainedRun = flag.Bool("keepRunning", false, "Set to true for generating spans at a fixed rate for 2 hours. Default is false.")
+var keepRunning = flag.Bool("keepRunning", false, "Set to true for generating spans at a fixed rate indefinitely. Default is false.")
 
 func initTracer() (func(), error) {
 	ctx := context.Background()
@@ -75,17 +75,11 @@ func generateTestSpan(ctx context.Context, tr trace.Tracer, description string) 
 }
 
 func generateSpansAtFixedRate(ctx context.Context, tr trace.Tracer) {
-	fmt.Println("Generating 1 test span every 10 seconds for 2 hours")
-	totalDuration := 2 * time.Hour
-	endTime := time.Now().Add(totalDuration)
+	fmt.Println("Generating 1 test span every 10 seconds indefinitely")
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
 	for tick := range ticker.C {
-		if tick.After(endTime) {
-			fmt.Println("Total duration elapsed.")
-			break
-		}
 		go generateTestSpan(ctx, tr, fmt.Sprintf("span-%s", tick))
 	}
 	fmt.Println("Span generation complete.")
@@ -101,7 +95,7 @@ func main() {
 	tr := otel.Tracer("cloudtrace/example/client")
 
 	ctx := context.Background()
-	if *sustainedRun {
+	if *keepRunning {
 		generateSpansAtFixedRate(ctx, tr)
 	} else {
 		generateTestSpan(ctx, tr, "test span")


### PR DESCRIPTION
Updates the sample to add a `--keepRunning` flag that runs the sample program for 2 hours, generating a test span every 10 seconds. A successful run of this sample would verify that the per rpc credentials refresh is working as expected with the `otlpgrpctraceexporter`. 

### Testing
 - `go run example.go`
 - `go run example.go --keepRunning`
