### PR TITLE
Use the prometheus.type metric metadata to support double-writing unknown-typed metrics

### DIFF
--- a/exporter/collector/googlemanagedprometheus/go.mod
+++ b/exporter/collector/googlemanagedprometheus/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.99.0
+	github.com/prometheus/common v0.53.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/featuregate v1.6.0
 	go.opentelemetry.io/collector/pdata v1.6.0
@@ -21,6 +22,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/exporter/collector/googlemanagedprometheus/go.sum
+++ b/exporter/collector/googlemanagedprometheus/go.sum
@@ -27,6 +27,10 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometh
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.99.0/go.mod h1:sQID67FDKapC9OJNgVxcG7MscZRpWIfgWrSodEZGedo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_model v0.6.0 h1:k1v3CzpSRUTrKMppY35TLwPvxHqBu0bYgxZzqGIgaos=
+github.com/prometheus/client_model v0.6.0/go.mod h1:NTQHnmxFpouOD0DpvP4XujX3CdOAGQPoaGhyTchlyt8=
+github.com/prometheus/common v0.53.0 h1:U2pL9w9nmJwJDa4qqLQ3ZaePJ6ZTwt7cMD3AG3+aLCE=
+github.com/prometheus/common v0.53.0/go.mod h1:BrxBKv3FWBIGXw89Mg1AeBq7FSyRzXWI3l3e7W3RN5U=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/exporter/collector/googlemanagedprometheus/naming.go
+++ b/exporter/collector/googlemanagedprometheus/naming.go
@@ -25,6 +25,7 @@ import (
 
 // GetMetricName returns the metric name with GMP-specific suffixes. The.
 func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, error) {
+	unknown := isUnknown(metric)
 	// First, build a name that is compliant with prometheus conventions
 	compliantName := prometheus.BuildCompliantName(metric, "", c.AddMetricSuffixes)
 	// Second, ad the GMP-specific suffix
@@ -34,9 +35,9 @@ func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, e
 			// Non-monotonic sums are converted to GCM gauges
 			return compliantName + "/gauge", nil
 		}
-		return getUnknownMetricName(metric.Sum().DataPoints(), "/counter", "counter", metric.Name(), compliantName), nil
+		return getUnknownMetricName(metric.Sum().DataPoints(), unknown, "/counter", "counter", metric.Name(), compliantName), nil
 	case pmetric.MetricTypeGauge:
-		return getUnknownMetricName(metric.Gauge().DataPoints(), "/gauge", "", metric.Name(), compliantName), nil
+		return getUnknownMetricName(metric.Gauge().DataPoints(), unknown, "/gauge", "", metric.Name(), compliantName), nil
 	case pmetric.MetricTypeSummary:
 		// summaries are sent as the following series:
 		// * Sum: prometheus.googleapis.com/<baseName>_sum/summary:counter
@@ -60,35 +61,24 @@ func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, e
 // "/unknown" (eg, for Gauge) or "/unknown:{secondarySuffix}" (eg, "/unknown:counter" for Sum).
 // It also removes the "_total" suffix on an unknown counter, if this suffix was not present in
 // the original metric name before calling prometheus.BuildCompliantName(), which is hacky.
-// It is based on the untyped_prometheus_metric data point attribute, and behind a feature gate.
-func getUnknownMetricName(points pmetric.NumberDataPointSlice, suffix, secondarySuffix, originalName, compliantName string) string {
-	if !untypedDoubleExportFeatureGate.IsEnabled() {
-		return compliantName + suffix
-	}
-
+//
+//nolint:revive
+func getUnknownMetricName(points pmetric.NumberDataPointSlice, unknown bool, suffix, secondarySuffix, originalName, compliantName string) string {
 	nameTokens := strings.FieldsFunc(
 		originalName,
 		func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) },
 	)
 
-	untyped := false
 	newSuffix := suffix
-	for i := 0; i < points.Len(); i++ {
-		point := points.At(i)
-		if val, ok := point.Attributes().Get(GCPOpsAgentUntypedMetricKey); ok && val.AsString() == "true" {
-			untyped = true
-			// delete the special Ops Agent untyped attribute
-			point.Attributes().Remove(GCPOpsAgentUntypedMetricKey)
-			newSuffix = "/unknown"
-			if len(secondarySuffix) > 0 {
-				newSuffix = newSuffix + ":" + secondarySuffix
-			}
-			// even though we have the suffix, keep looping to remove the attribute from other points, if any
+	if unknown {
+		newSuffix = "/unknown"
+		if len(secondarySuffix) > 0 {
+			newSuffix = newSuffix + ":" + secondarySuffix
 		}
 	}
 
 	// de-normalize "_total" suffix for counters where not present on original metric name
-	if untyped && nameTokens[len(nameTokens)-1] != "total" && strings.HasSuffix(compliantName, "_total") {
+	if unknown && nameTokens[len(nameTokens)-1] != "total" && strings.HasSuffix(compliantName, "_total") {
 		compliantName = strings.TrimSuffix(compliantName, "_total")
 	}
 	return compliantName + newSuffix

--- a/exporter/collector/googlemanagedprometheus/naming.go
+++ b/exporter/collector/googlemanagedprometheus/naming.go
@@ -25,7 +25,6 @@ import (
 
 // GetMetricName returns the metric name with GMP-specific suffixes. The.
 func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, error) {
-	unknown := isUnknown(metric)
 	// First, build a name that is compliant with prometheus conventions
 	compliantName := prometheus.BuildCompliantName(metric, "", c.AddMetricSuffixes)
 	// Second, ad the GMP-specific suffix
@@ -35,9 +34,9 @@ func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, e
 			// Non-monotonic sums are converted to GCM gauges
 			return compliantName + "/gauge", nil
 		}
-		return getUnknownMetricName(metric.Sum().DataPoints(), unknown, "/counter", "counter", metric.Name(), compliantName), nil
+		return getUnknownMetricName(metric, metric.Sum().DataPoints(), "/counter", "counter", compliantName), nil
 	case pmetric.MetricTypeGauge:
-		return getUnknownMetricName(metric.Gauge().DataPoints(), unknown, "/gauge", "", metric.Name(), compliantName), nil
+		return getUnknownMetricName(metric, metric.Gauge().DataPoints(), "/gauge", "", compliantName), nil
 	case pmetric.MetricTypeSummary:
 		// summaries are sent as the following series:
 		// * Sum: prometheus.googleapis.com/<baseName>_sum/summary:counter
@@ -61,25 +60,23 @@ func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, e
 // "/unknown" (eg, for Gauge) or "/unknown:{secondarySuffix}" (eg, "/unknown:counter" for Sum).
 // It also removes the "_total" suffix on an unknown counter, if this suffix was not present in
 // the original metric name before calling prometheus.BuildCompliantName(), which is hacky.
-//
-//nolint:revive
-func getUnknownMetricName(points pmetric.NumberDataPointSlice, unknown bool, suffix, secondarySuffix, originalName, compliantName string) string {
+func getUnknownMetricName(metric pmetric.Metric, points pmetric.NumberDataPointSlice, suffix, secondarySuffix, compliantName string) string {
 	nameTokens := strings.FieldsFunc(
-		originalName,
+		metric.Name(),
 		func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) },
 	)
 
 	newSuffix := suffix
-	if unknown {
+	if isUnknown(metric) {
 		newSuffix = "/unknown"
 		if len(secondarySuffix) > 0 {
 			newSuffix = newSuffix + ":" + secondarySuffix
 		}
-	}
 
-	// de-normalize "_total" suffix for counters where not present on original metric name
-	if unknown && nameTokens[len(nameTokens)-1] != "total" && strings.HasSuffix(compliantName, "_total") {
-		compliantName = strings.TrimSuffix(compliantName, "_total")
+		// de-normalize "_total" suffix for counters where not present on original metric name
+		if nameTokens[len(nameTokens)-1] != "total" && strings.HasSuffix(compliantName, "_total") {
+			compliantName = strings.TrimSuffix(compliantName, "_total")
+		}
 	}
 	return compliantName + newSuffix
 }

--- a/exporter/collector/googlemanagedprometheus/naming_test.go
+++ b/exporter/collector/googlemanagedprometheus/naming_test.go
@@ -166,54 +166,12 @@ func TestGetMetricName(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			desc:     "untyped gauge with feature gate disabled does nothing",
-			baseName: "bar",
-			metric: func(m pmetric.Metric) {
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, false)
-				m.SetName("bar")
-				m.SetEmptyGauge()
-				m.Gauge().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
-			},
-			expected: "bar/gauge",
-		},
-		{
-			desc:     "untyped sum with gcp.untypedDoubleExport disabled only normalizes",
-			baseName: "bar",
-			metric: func(m pmetric.Metric) {
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, false)
-				m.SetName("bar")
-				m.SetEmptySum()
-				m.Sum().SetIsMonotonic(true)
-				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
-			},
-			expected: "bar_total/counter",
-		},
-		{
-			desc:     "untyped sum with feature gates disabled does nothing",
-			baseName: "bar",
-			metric: func(m pmetric.Metric) {
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set("pkg.translator.prometheus.NormalizeName", false)
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, false)
-				m.SetName("bar")
-				m.SetEmptySum()
-				m.Sum().SetIsMonotonic(true)
-				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
-			},
-			expected: "bar/counter",
-		},
-		{
 			desc:     "untyped gauge with feature gate enabled returns unknown",
 			baseName: "bar",
 			metric: func(m pmetric.Metric) {
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
 				m.SetName("bar")
+				m.Metadata().PutStr("prometheus.type", "unknown")
 				m.SetEmptyGauge()
-				m.Gauge().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			expected: "bar/unknown",
 		},
@@ -221,12 +179,10 @@ func TestGetMetricName(t *testing.T) {
 			desc:     "untyped sum with feature gate enabled returns unknown:counter",
 			baseName: "bar",
 			metric: func(m pmetric.Metric) {
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
 				m.SetName("bar")
+				m.Metadata().PutStr("prometheus.type", "unknown")
 				m.SetEmptySum()
 				m.Sum().SetIsMonotonic(true)
-				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			expected: "bar/unknown:counter",
 		},
@@ -235,13 +191,11 @@ func TestGetMetricName(t *testing.T) {
 			baseName: "bar",
 			metric: func(m pmetric.Metric) {
 				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
-				//nolint:errcheck
 				featuregate.GlobalRegistry().Set("pkg.translator.prometheus.NormalizeName", true)
 				m.SetName("bar")
+				m.Metadata().PutStr("prometheus.type", "unknown")
 				m.SetEmptySum()
 				m.Sum().SetIsMonotonic(true)
-				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			expected: "bar/unknown:counter",
 		},
@@ -250,14 +204,11 @@ func TestGetMetricName(t *testing.T) {
 			baseName: "bar.total.total.total.total",
 			metric: func(m pmetric.Metric) {
 				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
-				//nolint:errcheck
 				featuregate.GlobalRegistry().Set("pkg.translator.prometheus.NormalizeName", true)
 				m.SetName("bar.total.total.total.total")
+				m.Metadata().PutStr("prometheus.type", "unknown")
 				m.SetEmptySum()
 				m.Sum().SetIsMonotonic(true)
-				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
-				m.Sum().DataPoints().AppendEmpty().Attributes().PutStr(GCPOpsAgentUntypedMetricKey, "true")
 			},
 			// prometheus name normalization removes all preexisting "total"s before appending its own
 			expected: "bar_total/unknown:counter",
@@ -266,8 +217,6 @@ func TestGetMetricName(t *testing.T) {
 			desc:     "normal sum without total and feature gate enabled + name normalization adds _total",
 			baseName: "foo",
 			metric: func(m pmetric.Metric) {
-				//nolint:errcheck
-				featuregate.GlobalRegistry().Set(gcpUntypedDoubleExportGateKey, true)
 				//nolint:errcheck
 				featuregate.GlobalRegistry().Set("pkg.translator.prometheus.NormalizeName", true)
 				m.SetName("foo")

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -21,7 +21,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.99.0
 	go.opentelemetry.io/collector/featuregate v1.6.0
 	go.opentelemetry.io/collector/otelcol v0.99.0
-	go.opentelemetry.io/collector/pdata v1.6.0
+	go.opentelemetry.io/collector/pdata v1.6.1-0.20240426134529-31528ce81d44
 	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/sdk v1.25.0
 	go.opentelemetry.io/otel/sdk/metric v1.25.0
@@ -75,7 +75,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.52.3 // indirect
+	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/prometheus v0.39.1 // indirect
 	github.com/shirou/gopsutil/v3 v3.24.3 // indirect

--- a/exporter/collector/integrationtest/go.sum
+++ b/exporter/collector/integrationtest/go.sum
@@ -144,8 +144,8 @@ github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdU
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
-github.com/prometheus/common v0.52.3 h1:5f8uj6ZwHSscOGNdIQg6OiZv/ybiK2CO2q2drVZAQSA=
-github.com/prometheus/common v0.52.3/go.mod h1:BrxBKv3FWBIGXw89Mg1AeBq7FSyRzXWI3l3e7W3RN5U=
+github.com/prometheus/common v0.53.0 h1:U2pL9w9nmJwJDa4qqLQ3ZaePJ6ZTwt7cMD3AG3+aLCE=
+github.com/prometheus/common v0.53.0/go.mod h1:BrxBKv3FWBIGXw89Mg1AeBq7FSyRzXWI3l3e7W3RN5U=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/prometheus v0.39.1 h1:abZM6A+sKAv2eKTbRIaHq4amM/nT07MuxRm0+QTaTj0=
@@ -233,8 +233,8 @@ go.opentelemetry.io/collector/featuregate v1.6.0 h1:1Q0tt/GPx+PRBGAE7kNJaWLIXYNV
 go.opentelemetry.io/collector/featuregate v1.6.0/go.mod h1:w7nUODKxEi3FLf1HslCiE6YWtMtOOrMnSwsDam8Mg9w=
 go.opentelemetry.io/collector/otelcol v0.99.0 h1:sQOyZQP68UqwqlNC1/hMm9lIbxS0PY9vnHubn7Qpp7w=
 go.opentelemetry.io/collector/otelcol v0.99.0/go.mod h1:MwUkATYB4wCj1gnKI+/LvC9QjE6VAjdRaa66GNZ/IS8=
-go.opentelemetry.io/collector/pdata v1.6.0 h1:ZIByleLu7ZfHkfPuL8xIMb9M4Gv1R6568LAjhNOO9zY=
-go.opentelemetry.io/collector/pdata v1.6.0/go.mod h1:pQv6AJO6wDUDxrPxhNaj3JdSzaOIo5glTGL1b4h4KTg=
+go.opentelemetry.io/collector/pdata v1.6.1-0.20240426134529-31528ce81d44 h1:57G8Dw6hLfVi6IfoQC03uUM34nwFkbJEeIeMeEU9wE0=
+go.opentelemetry.io/collector/pdata v1.6.1-0.20240426134529-31528ce81d44/go.mod h1:pQv6AJO6wDUDxrPxhNaj3JdSzaOIo5glTGL1b4h4KTg=
 go.opentelemetry.io/collector/pdata/testdata v0.99.0 h1:/cEg4jdR3ntR3kZ0XjSelaBnm7GNSsFF1K3VK+ZHvL8=
 go.opentelemetry.io/collector/pdata/testdata v0.99.0/go.mod h1:YzEkHFLPsxeNI2gv6UQvvn73nsgRNxMRnBpY63qvdsg=
 go.opentelemetry.io/collector/processor v0.99.0 h1:A6xaGNybbHn/FDLVeDY2ZmU5S6F8y4si91IKIUHzPm8=

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -350,11 +350,7 @@ var MetricsTestCases = []TestCase{
 		Name:                 "[GMP] Untyped Gauge becomes a GCM Gauge and a Cumulative with /unknown and /unknown:counter suffixes",
 		OTLPInputFixturePath: "testdata/fixtures/metrics/untyped_gauge.json",
 		ExpectFixturePath:    "testdata/fixtures/metrics/untyped_gauge_gmp_expect.json",
-		ConfigureCollector: func(cfg *collector.Config) {
-			configureGMPCollector(cfg)
-			//nolint:errcheck
-			featuregate.GlobalRegistry().Set("gcp.untypedDoubleExport", true)
-		},
+		ConfigureCollector:   configureGMPCollector,
 		// prometheus_target is not supported by the SDK
 		SkipForSDK: true,
 	},

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge.json
@@ -38,12 +38,6 @@
                                     "value": {
                                        "stringValue": "13"
                                     }
-                                 },
-                                 {
-                                    "key": "prometheus.googleapis.com/internal/untyped_metric",
-                                    "value": {
-                                       "stringValue": "true"
-                                    }
                                  }
                               ],
                               "startTimeUnixNano": "1649443416286000000",
@@ -51,7 +45,15 @@
                               "asDouble": 3
                            }
                         ]
-                     }
+                     },
+                     "metadata": [
+                        {
+                           "key": "prometheus.type",
+                           "value": {
+                              "stringValue": "unknown"
+                           }
+                        }
+                     ]
                   }
                ]
             }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
@@ -7,8 +7,7 @@
           "metric": {
             "type": "workload.googleapis.com/fake_untyped_metric",
             "labels": {
-              "ex_com_lemons_untyped": "13",
-              "prometheus_googleapis_com_internal_untyped_metric": "true"
+              "ex_com_lemons_untyped": "13"
             }
           },
           "resource": {
@@ -45,9 +44,6 @@
         "labels": [
           {
             "key": "ex_com_lemons_untyped"
-          },
-          {
-            "key": "prometheus_googleapis_com_internal_untyped_metric"
           }
         ],
         "metricKind": "GAUGE",


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32605

This removes the `gcp.untypedDoubleExport` feature gate, as it is no longer needed.

## Specification

From https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#gauges-1

> An [OpenTelemetry Gauge](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#gauge) MUST be converted to a Prometheus Unknown-typed metric if the prometheus.type key of [metric.metadata](https://github.com/open-telemetry/opentelemetry-proto/blob/c451441d7b73f702d1647574c730daf7786f188c/opentelemetry/proto/metrics/v1/metrics.proto#L199) is unknown. Otherwise, it MUST be converted to a Prometheus Gauge.