### PR TITLE
Run e2e tests on GAE standard

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -33,11 +33,11 @@ steps:
     env: ["PROJECT_ID=$PROJECT_ID"]
     args:
       - cloud-functions-gen2
-      - --runtime=go121
+      - --runtime=go122
       - --functionsource=/workspace/e2e-test-server/cloud_functions/function-source.zip
       - --entrypoint=HandleCloudFunction
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.19.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.19.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,24 +13,28 @@
 # limitations under the License.
 
 steps:
-  # Wait for the image to exist
-  - name: "docker"
-    id: wait-for-image
-    entrypoint: "sh"
-    timeout: 3m
-    env: ["_TEST_SERVER_IMAGE=${_TEST_SERVER_IMAGE}"]
+  # Vendor dependencies, and zip the code.
+  - name: golang:1.22.2
+    id: zip-code
+    entrypoint: /bin/bash
     args:
-      - e2e-test-server/wait-for-image.sh
+      - '-c'
+      - |
+         apt-get update && \
+         apt-get install zip --assume-yes && \
+         cd e2e-test-server/ && \
+         go mod vendor && \
+         zip -r appsource *
 
   # Run the test
   - name: $_TEST_RUNNER_IMAGE
-    id: run-tests-gce
+    id: run-tests-gae-standard
     dir: /
     env: ["PROJECT_ID=$PROJECT_ID"]
     args:
-      - gce
-      - --image=$_TEST_SERVER_IMAGE
-
+      - gae-standard
+      - --runtime=go122
+      - --appsource=/workspace/e2e-test-server/appsource.zip
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
   _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.19.0

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -30,9 +30,9 @@ steps:
     args:
       - gae
       - --image=$_TEST_SERVER_IMAGE
-      - --runtime=go118
+      - --runtime=go122
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.19.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -32,5 +32,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.19.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -34,5 +34,5 @@ steps:
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.19.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}


### PR DESCRIPTION
- Add GAE standard cloud build yaml file. This is mostly copied from the existing Cloud Function config.
- Bump test runner image across other yamls
- Bump go runtime versions to 1.22 in e2e tests.

Tests are passing and you can see the correct GAE standard zone in the resourceDetectionTrace scenario 
![image](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/assets/1510004/9f5c71b6-7358-4fcc-9713-0e4258b4f039)
