### PR TITLE
Bump go to v1.22.3 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "1.22.2"
+  DEFAULT_GO_VERSION: "1.22.3"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.22.2", "1.21"]
+        go-version: ["1.22.3", "1.21"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         arch: ["386", amd64]
         exclude:

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -14,7 +14,7 @@
 
 steps:
   # Vendor dependencies, and zip the code.
-  - name: golang:1.22.2
+  - name: golang:1.22.3
     id: zip-code
     entrypoint: /bin/bash
     args:

--- a/cloudbuild-integration-tests.yaml
+++ b/cloudbuild-integration-tests.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - name: golang:1.22.2
+  - name: golang:1.22.3
     env: ["SECOND_PROJECT_ID=opentelemetry-ops-e2e-2"]
     args: ["make", "integrationtest"]
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/e2e-test-server/Dockerfile
+++ b/e2e-test-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2 as builder
+FROM golang:1.22.3 as builder
 
 WORKDIR /workspace/e2e-test-server/
 


### PR DESCRIPTION
Fixes the lint failure: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/actions/runs/8996115363/job/24712113944?pr=848