### PR TITLE
Add host.id as a fallback for instance

### DIFF
--- a/exporter/collector/googlemanagedprometheus/monitoredresource.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource.go
@@ -71,6 +71,7 @@ var promTargetKeys = map[string][]string{
 		semconv.AttributeServiceInstanceID,
 		semconv.AttributeFaaSInstance,
 		semconv.AttributeK8SPodName,
+		semconv.AttributeHostID,
 	},
 }
 

--- a/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
@@ -336,6 +336,26 @@ func TestMapToPrometheusTarget(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Attributes from GCE with instance ID override",
+			resourceLabels: map[string]string{
+				"cloud.platform":      "gcp_compute_engine",
+				"cloud.region":        "us-central1",
+				"service.name":        "service-name",
+				"service.instance.id": "service-instance-id",
+				"host.id":             "1234759430923053489543203",
+			},
+			expected: &monitoredrespb.MonitoredResource{
+				Type: "prometheus_target",
+				Labels: map[string]string{
+					"location":  "us-central1",
+					"cluster":   "__gce__",
+					"namespace": "",
+					"job":       "service-name",
+					"instance":  "service-instance-id",
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			r := pcommon.NewResource()

--- a/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
@@ -320,10 +320,10 @@ func TestMapToPrometheusTarget(t *testing.T) {
 		{
 			desc: "Attributes from GCE with environment label",
 			resourceLabels: map[string]string{
-				"cloud.platform":      "gcp_compute_engine",
-				"cloud.region":        "us-central1",
-				"service.name":        "service-name",
-				"service.instance.id": "1234759430923053489543203",
+				"cloud.platform": "gcp_compute_engine",
+				"cloud.region":   "us-central1",
+				"service.name":   "service-name",
+				"host.id":        "1234759430923053489543203",
 			},
 			expected: &monitoredrespb.MonitoredResource{
 				Type: "prometheus_target",


### PR DESCRIPTION
This will prevent users from getting a blank `instance` label for GMP when running on GCE.

FYI @quentinmit @ridwanmsharif @jefferbrecht