### PR TITLE
Add support for exponential histograms in the GMP exporter

### DIFF
--- a/exporter/collector/googlemanagedprometheus/naming.go
+++ b/exporter/collector/googlemanagedprometheus/naming.go
@@ -50,6 +50,8 @@ func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, e
 		}
 		return compliantName + "/summary", nil
 	case pmetric.MetricTypeHistogram:
+		fallthrough
+	case pmetric.MetricTypeExponentialHistogram:
 		return compliantName + "/histogram", nil
 	default:
 		return "", fmt.Errorf("unsupported metric datatype: %v", metric.Type())

--- a/exporter/collector/googlemanagedprometheus/naming_test.go
+++ b/exporter/collector/googlemanagedprometheus/naming_test.go
@@ -157,13 +157,13 @@ func TestGetMetricName(t *testing.T) {
 			expected: "hello/histogram",
 		},
 		{
-			desc:     "other",
-			baseName: "other",
+			desc:     "exponential histogram",
+			baseName: "hello",
 			metric: func(m pmetric.Metric) {
-				m.SetName("other")
+				m.SetName("hello")
 				m.SetEmptyExponentialHistogram()
 			},
-			expectErr: true,
+			expected: "hello/histogram",
 		},
 		{
 			desc:     "untyped gauge with feature gate enabled returns unknown",

--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -387,6 +387,14 @@ var MetricsTestCases = []TestCase{
 		SkipForSDK: true,
 	},
 	{
+		Name:                 "[GMP] Exponential Histogram becomes a GCM Distribution with exponential bucketOptions and a /histogram suffix",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/exponential_histogram.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/exponential_histogram_gmp_expect.json",
+		ConfigureCollector:   configureGMPCollector,
+		// prometheus_target is not supported by the SDK
+		SkipForSDK: true,
+	},
+	{
 		Name:                 "[GMP] Summary becomes a GCM Cumulative for sum/count, Gauges for quantiles",
 		OTLPInputFixturePath: "testdata/fixtures/metrics/summary.json",
 		ExpectFixturePath:    "testdata/fixtures/metrics/summary_gmp_expect.json",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram.json
@@ -1,7 +1,28 @@
 {
   "resourceMetrics": [
     {
-      "resource": {},
+      "resource": {
+        "attributes": [
+          {
+            "key": "cloud.availability_zone",
+            "value": {
+              "stringValue": "us-central1-c"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "demo"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "10.92.5.2:15692"
+            }
+          }
+        ]
+      },
       "scopeMetrics": [
         {
           "scope": {},

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
@@ -8,11 +8,12 @@
             "type": "workload.googleapis.com/durationhist"
           },
           "resource": {
-            "type": "generic_node",
+            "type": "generic_task",
             "labels": {
-              "location": "global",
+              "job": "demo",
+              "location": "us-central1-c",
               "namespace": "",
-              "node_id": ""
+              "task_id": "10.92.5.2:15692"
             }
           },
           "metricKind": "CUMULATIVE",
@@ -162,11 +163,12 @@
             "type": "workload.googleapis.com/foohist"
           },
           "resource": {
-            "type": "generic_node",
+            "type": "generic_task",
             "labels": {
-              "location": "global",
+              "job": "demo",
+              "location": "us-central1-c",
               "namespace": "",
-              "node_id": ""
+              "task_id": "10.92.5.2:15692"
             }
           },
           "metricKind": "CUMULATIVE",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
@@ -5,15 +5,220 @@
       "timeSeries": [
         {
           "metric": {
-            "type": "prometheus.googleapis.com/target_info/gauge"
+            "type": "prometheus.googleapis.com/durationhist_seconds/histogram"
           },
           "resource": {
             "type": "prometheus_target",
             "labels": {
               "cluster": "",
-              "instance": "",
-              "job": "",
-              "location": "",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "10000",
+                  "mean": 198.4636328211394,
+                  "bucketOptions": {
+                    "exponentialBuckets": {
+                      "numFiniteBuckets": 113,
+                      "growthFactor": 1.0442737824274138,
+                      "scale": 98.70149282610706
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "646",
+                    "736",
+                    "733",
+                    "639",
+                    "606",
+                    "585",
+                    "480",
+                    "481",
+                    "411",
+                    "436",
+                    "366",
+                    "304",
+                    "309",
+                    "270",
+                    "226",
+                    "210",
+                    "238",
+                    "169",
+                    "181",
+                    "178",
+                    "149",
+                    "132",
+                    "131",
+                    "117",
+                    "109",
+                    "89",
+                    "107",
+                    "80",
+                    "78",
+                    "75",
+                    "56",
+                    "73",
+                    "59",
+                    "51",
+                    "46",
+                    "53",
+                    "22",
+                    "31",
+                    "35",
+                    "24",
+                    "23",
+                    "31",
+                    "18",
+                    "8",
+                    "16",
+                    "12",
+                    "15",
+                    "13",
+                    "12",
+                    "12",
+                    "12",
+                    "7",
+                    "7",
+                    "7",
+                    "9",
+                    "5",
+                    "4",
+                    "4",
+                    "8",
+                    "6",
+                    "3",
+                    "1",
+                    "4",
+                    "2",
+                    "2",
+                    "4",
+                    "5",
+                    "1",
+                    "2",
+                    "2",
+                    "1",
+                    "0",
+                    "1",
+                    "2",
+                    "2",
+                    "1",
+                    "0",
+                    "0",
+                    "2",
+                    "1",
+                    "2",
+                    "1",
+                    "0",
+                    "2",
+                    "0",
+                    "0",
+                    "2",
+                    "0",
+                    "1",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "1",
+                    "0",
+                    "1",
+                    "0"
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/foohist_seconds/histogram"
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": ""
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "7",
+                  "mean": 1.7857142857142858,
+                  "bucketOptions": {
+                    "exponentialBuckets": {
+                      "numFiniteBuckets": 3,
+                      "growthFactor": 4,
+                      "scale": 0.25
+                    }
+                  },
+                  "bucketCounts": [
+                    "2",
+                    "1",
+                    "3",
+                    "1",
+                    "0"
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "prometheus.googleapis.com/target_info/gauge",
+            "labels": {
+              "cloud_availability_zone": "us-central1-c"
+            }
+          },
+          "resource": {
+            "type": "prometheus_target",
+            "labels": {
+              "cluster": "",
+              "instance": "10.92.5.2:15692",
+              "job": "demo",
+              "location": "us-central1-c",
               "namespace": ""
             }
           },
@@ -55,7 +260,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "1"
+                  "int64Value": "3"
                 }
               }
             ]
@@ -410,5 +615,6 @@
         }
       }
     ]
-  }
+  },
+  "userAgent": "opentelemetry-collector-contrib latest grpc-go/1.63.2"
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/841

This does not currently include support for PromQL on exponential histograms written to GMP, which should come later.  Exponential histograms sent with the GMP exporter will need to be visualized using the query builder or MQL.