### PR TITLE
PoC: Support zero-bucket histograms

### DIFF
--- a/exporter/collector/integrationtest/testcases/testcases_metrics.go
+++ b/exporter/collector/integrationtest/testcases/testcases_metrics.go
@@ -113,6 +113,17 @@ var MetricsTestCases = []TestCase{
 		},
 	},
 	{
+		Name:                 "Zero-Bucket Histogram becomes a GCM Distribution",
+		OTLPInputFixturePath: "testdata/fixtures/metrics/histogram_zero_bucket.json",
+		ExpectFixturePath:    "testdata/fixtures/metrics/histogram_zero_bucket_expect.json",
+		ConfigureCollector: func(cfg *collector.Config) {
+			cfg.MetricConfig.ServiceResourceLabels = false
+			cfg.MetricConfig.InstrumentationLibraryLabels = true
+			cfg.MetricConfig.EnableSumOfSquaredDeviation = true
+		},
+		SkipForSDK: true,
+	},
+	{
 		Name:                 "Exponential Histogram becomes a GCM Distribution with exponential bucketOptions",
 		OTLPInputFixturePath: "testdata/fixtures/metrics/exponential_histogram.json",
 		ExpectFixturePath:    "testdata/fixtures/metrics/exponential_histogram_expect.json",

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket.json
@@ -28,7 +28,7 @@
             "scope": {},
             "metrics": [
               {
-                "name": "simple.float64.histogram",
+                "name": "zero.float64.histogram",
                 "unit": "s",
                 "histogram": {
                   "dataPoints": [
@@ -97,7 +97,7 @@
                 }
               },
               {
-                "name": "simple.int64.histogram",
+                "name": "zero.int64.histogram",
                 "unit": "s",
                 "histogram": {
                   "dataPoints": [

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket.json
@@ -1,0 +1,173 @@
+{
+    "resourceMetrics": [
+      {
+        "resource": {
+          "attributes": [
+            {
+              "key": "cloud.availability_zone",
+              "value": {
+                "stringValue": "us-central1-c"
+              }
+            },
+            {
+              "key": "service.name",
+              "value": {
+                "stringValue": "demo"
+              }
+            },
+            {
+              "key": "service.instance.id",
+              "value": {
+                "stringValue": "10.92.5.2:15692"
+              }
+            }
+          ]
+        },
+        "scopeMetrics": [
+          {
+            "scope": {},
+            "metrics": [
+              {
+                "name": "simple.float64.histogram",
+                "unit": "s",
+                "histogram": {
+                  "dataPoints": [
+                    {
+                      "attributes": [
+                        {
+                          "key": "some.lemons",
+                          "value": {
+                            "stringValue": "13"
+                          }
+                        }
+                      ],
+                      "startTimeUnixNano": "1649443516286000000",
+                      "timeUnixNano": "1649443516286000000",
+                      "count": "1",
+                      "sum": 2.5,
+                      "exemplars": [
+                        {
+                          "asDouble": 4.1,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "attributes": [
+                        {
+                          "key": "some.lemons",
+                          "value": {
+                            "stringValue": "10"
+                          }
+                        }
+                      ],
+                      "startTimeUnixNano": "1649443516286000000",
+                      "timeUnixNano": "1649443516286000000",
+                      "count": "2",
+                      "sum": 14.3,
+                      "exemplars": [
+                        {
+                          "asDouble": 15.5,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                }
+              },
+              {
+                "name": "simple.int64.histogram",
+                "unit": "s",
+                "histogram": {
+                  "dataPoints": [
+                    {
+                      "attributes": [
+                        {
+                          "key": "some.lemons",
+                          "value": {
+                            "stringValue": "13"
+                          }
+                        }
+                      ],
+                      "startTimeUnixNano": "1649443516286000000",
+                      "timeUnixNano": "1649443516286000000",
+                      "count": "1",
+                      "sum": 2,
+                      "exemplars": [
+                        {
+                          "asInt": 4,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "attributes": [
+                        {
+                          "key": "some.lemons",
+                          "value": {
+                            "stringValue": "10"
+                          }
+                        }
+                      ],
+                      "startTimeUnixNano": "1649443516286000000",
+                      "timeUnixNano": "1649443516286000000",
+                      "count": "2",
+                      "sum": 14,
+                      "exemplars": [
+                        {
+                          "asInt": 12,
+                          "timeUnixNano": "1649443516286000000",
+                          "traceId": "2499d13df7b35ae93dfa3d6ddc01da74",
+                          "spanId": "84f9e8929bb1cd5b",
+                          "filteredAttributes": [
+                            {
+                              "key": "filtered.attribute",
+                              "value": {
+                                "stringValue": "foobar"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
@@ -1,0 +1,375 @@
+{
+  "createMetricDescriptorRequests": [
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "simple.float64.histogram",
+        "type": "workload.googleapis.com/simple.float64.histogram",
+        "labels": [
+          {
+            "key": "some_lemons"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "DISTRIBUTION",
+        "unit": "s",
+        "displayName": "simple.float64.histogram"
+      }
+    },
+    {
+      "name": "projects/fakeprojectid",
+      "metricDescriptor": {
+        "name": "simple.int64.histogram",
+        "type": "workload.googleapis.com/simple.int64.histogram",
+        "labels": [
+          {
+            "key": "some_lemons"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "valueType": "DISTRIBUTION",
+        "unit": "s",
+        "displayName": "simple.int64.histogram"
+      }
+    }
+  ],
+  "selfObservabilityMetrics": {
+    "createTimeSeriesRequests": [
+      {
+        "name": "projects/myproject",
+        "timeSeries": [
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "2"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "createMetricDescriptorRequests": [
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            },
+            {
+              "key": "grpc_client_status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of RPCs by method and status.",
+          "displayName": "OpenCensus/grpc.io/client/completed_rpcs"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes received per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/received_bytes_per_rpc"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "ms",
+          "description": "Distribution of round-trip latency, by method.",
+          "displayName": "OpenCensus/grpc.io/client/roundtrip_latency"
+        }
+      },
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+          "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+          "labels": [
+            {
+              "key": "grpc_client_method"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "unit": "By",
+          "description": "Distribution of bytes sent per RPC, by method.",
+          "displayName": "OpenCensus/grpc.io/client/sent_bytes_per_rpc"
+        }
+      }
+    ]
+  }
+}

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
@@ -34,6 +34,9 @@
                   "bucketOptions": {
                     "explicitBuckets": {}
                   },
+                  "bucketCounts": [
+                    "1"
+                  ],
                   "exemplars": [
                     {
                       "value": 4.1,
@@ -89,6 +92,9 @@
                   "bucketOptions": {
                     "explicitBuckets": {}
                   },
+                  "bucketCounts": [
+                    "2"
+                  ],
                   "exemplars": [
                     {
                       "value": 15.5,
@@ -144,6 +150,9 @@
                   "bucketOptions": {
                     "explicitBuckets": {}
                   },
+                  "bucketCounts": [
+                    "1"
+                  ],
                   "exemplars": [
                     {
                       "value": 4,
@@ -199,6 +208,9 @@
                   "bucketOptions": {
                     "explicitBuckets": {}
                   },
+                  "bucketCounts": [
+                    "2"
+                  ],
                   "exemplars": [
                     {
                       "value": 12,

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
@@ -1,4 +1,231 @@
 {
+  "createTimeSeriesRequests": [
+    {
+      "name": "projects/fakeprojectid",
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/simple.float64.histogram",
+            "labels": {
+              "some_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "",
+              "task_id": "10.92.5.2:15692"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 2.5,
+                  "bucketOptions": {
+                    "explicitBuckets": {}
+                  },
+                  "exemplars": [
+                    {
+                      "value": 4.1,
+                      "timestamp": "1970-01-01T00:00:00Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/simple.float64.histogram",
+            "labels": {
+              "some_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "",
+              "task_id": "10.92.5.2:15692"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "2",
+                  "mean": 7.15,
+                  "bucketOptions": {
+                    "explicitBuckets": {}
+                  },
+                  "exemplars": [
+                    {
+                      "value": 15.5,
+                      "timestamp": "1970-01-01T00:00:00Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/simple.int64.histogram",
+            "labels": {
+              "some_lemons": "13"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "",
+              "task_id": "10.92.5.2:15692"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 2,
+                  "bucketOptions": {
+                    "explicitBuckets": {}
+                  },
+                  "exemplars": [
+                    {
+                      "value": 4,
+                      "timestamp": "1970-01-01T00:00:00Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        },
+        {
+          "metric": {
+            "type": "workload.googleapis.com/simple.int64.histogram",
+            "labels": {
+              "some_lemons": "10"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "demo",
+              "location": "us-central1-c",
+              "namespace": "",
+              "task_id": "10.92.5.2:15692"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "count": "2",
+                  "mean": 7,
+                  "bucketOptions": {
+                    "explicitBuckets": {}
+                  },
+                  "exemplars": [
+                    {
+                      "value": 12,
+                      "timestamp": "1970-01-01T00:00:00Z",
+                      "attachments": [
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.SpanContext",
+                          "spanName": "projects/fakeprojectid/traces/2499d13df7b35ae93dfa3d6ddc01da74/spans/84f9e8929bb1cd5b"
+                        },
+                        {
+                          "@type": "type.googleapis.com/google.monitoring.v3.DroppedLabels",
+                          "label": {
+                            "filtered_attribute": "foobar"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "unit": "s"
+        }
+      ]
+    }
+  ],
   "createMetricDescriptorRequests": [
     {
       "name": "projects/fakeprojectid",
@@ -40,6 +267,28 @@
         "timeSeries": [
           {
             "metric": {
+              "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+              "labels": {
+                "status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "4"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor",
@@ -63,9 +312,92 @@
           },
           {
             "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries",
+                "grpc_client_status": "OK"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "int64Value": "1"
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/received_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
               }
             },
             "resource": {
@@ -237,9 +569,183 @@
           },
           {
             "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          0.01,
+                          0.05,
+                          0.1,
+                          0.3,
+                          0.6,
+                          0.8,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          8,
+                          10,
+                          13,
+                          16,
+                          20,
+                          25,
+                          30,
+                          40,
+                          50,
+                          65,
+                          80,
+                          100,
+                          130,
+                          160,
+                          200,
+                          250,
+                          300,
+                          400,
+                          500,
+                          650,
+                          800,
+                          1000,
+                          2000,
+                          5000,
+                          10000,
+                          20000,
+                          50000,
+                          100000
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
               "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
               "labels": {
                 "grpc_client_method": "google.monitoring.v3.MetricService/CreateMetricDescriptor"
+              }
+            },
+            "resource": {
+              "type": "global"
+            },
+            "points": [
+              {
+                "interval": {
+                  "endTime": "1970-01-01T00:00:00Z",
+                  "startTime": "1970-01-01T00:00:00Z"
+                },
+                "value": {
+                  "distributionValue": {
+                    "bucketOptions": {
+                      "explicitBuckets": {
+                        "bounds": [
+                          0,
+                          1024,
+                          2048,
+                          4096,
+                          16384,
+                          65536,
+                          262144,
+                          1048576,
+                          4194304,
+                          16777216,
+                          67108864,
+                          268435456,
+                          1073741824,
+                          4294967296
+                        ]
+                      }
+                    },
+                    "bucketCounts": [
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0",
+                      "0"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "metric": {
+              "type": "custom.googleapis.com/opencensus/grpc.io/client/sent_bytes_per_rpc",
+              "labels": {
+                "grpc_client_method": "google.monitoring.v3.MetricService/CreateTimeSeries"
               }
             },
             "resource": {
@@ -299,6 +805,23 @@
       }
     ],
     "createMetricDescriptorRequests": [
+      {
+        "name": "projects/myproject",
+        "metricDescriptor": {
+          "name": "projects/myproject/metricDescriptors/custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+          "type": "custom.googleapis.com/opencensus/googlecloudmonitoring/point_count",
+          "labels": [
+            {
+              "key": "status"
+            }
+          ],
+          "metricKind": "CUMULATIVE",
+          "valueType": "INT64",
+          "unit": "1",
+          "description": "Count of metric points written to Cloud Monitoring.",
+          "displayName": "OpenCensus/googlecloudmonitoring/point_count"
+        }
+      },
       {
         "name": "projects/myproject",
         "metricDescriptor": {
@@ -371,5 +894,6 @@
         }
       }
     ]
-  }
+  },
+  "userAgent": "opentelemetry-collector-contrib latest grpc-go/1.63.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_zero_bucket_expect.json
@@ -5,7 +5,7 @@
       "timeSeries": [
         {
           "metric": {
-            "type": "workload.googleapis.com/simple.float64.histogram",
+            "type": "workload.googleapis.com/zero.float64.histogram",
             "labels": {
               "some_lemons": "13"
             }
@@ -32,9 +32,14 @@
                   "count": "1",
                   "mean": 2.5,
                   "bucketOptions": {
-                    "explicitBuckets": {}
+                    "explicitBuckets": {
+                      "bounds": [
+                        0
+                      ]
+                    }
                   },
                   "bucketCounts": [
+                    "0",
                     "1"
                   ],
                   "exemplars": [
@@ -63,7 +68,7 @@
         },
         {
           "metric": {
-            "type": "workload.googleapis.com/simple.float64.histogram",
+            "type": "workload.googleapis.com/zero.float64.histogram",
             "labels": {
               "some_lemons": "10"
             }
@@ -90,9 +95,14 @@
                   "count": "2",
                   "mean": 7.15,
                   "bucketOptions": {
-                    "explicitBuckets": {}
+                    "explicitBuckets": {
+                      "bounds": [
+                        0
+                      ]
+                    }
                   },
                   "bucketCounts": [
+                    "0",
                     "2"
                   ],
                   "exemplars": [
@@ -121,7 +131,7 @@
         },
         {
           "metric": {
-            "type": "workload.googleapis.com/simple.int64.histogram",
+            "type": "workload.googleapis.com/zero.int64.histogram",
             "labels": {
               "some_lemons": "13"
             }
@@ -148,9 +158,14 @@
                   "count": "1",
                   "mean": 2,
                   "bucketOptions": {
-                    "explicitBuckets": {}
+                    "explicitBuckets": {
+                      "bounds": [
+                        0
+                      ]
+                    }
                   },
                   "bucketCounts": [
+                    "0",
                     "1"
                   ],
                   "exemplars": [
@@ -179,7 +194,7 @@
         },
         {
           "metric": {
-            "type": "workload.googleapis.com/simple.int64.histogram",
+            "type": "workload.googleapis.com/zero.int64.histogram",
             "labels": {
               "some_lemons": "10"
             }
@@ -206,9 +221,14 @@
                   "count": "2",
                   "mean": 7,
                   "bucketOptions": {
-                    "explicitBuckets": {}
+                    "explicitBuckets": {
+                      "bounds": [
+                        0
+                      ]
+                    }
                   },
                   "bucketCounts": [
+                    "0",
                     "2"
                   ],
                   "exemplars": [
@@ -242,8 +262,8 @@
     {
       "name": "projects/fakeprojectid",
       "metricDescriptor": {
-        "name": "simple.float64.histogram",
-        "type": "workload.googleapis.com/simple.float64.histogram",
+        "name": "zero.float64.histogram",
+        "type": "workload.googleapis.com/zero.float64.histogram",
         "labels": [
           {
             "key": "some_lemons"
@@ -252,14 +272,14 @@
         "metricKind": "CUMULATIVE",
         "valueType": "DISTRIBUTION",
         "unit": "s",
-        "displayName": "simple.float64.histogram"
+        "displayName": "zero.float64.histogram"
       }
     },
     {
       "name": "projects/fakeprojectid",
       "metricDescriptor": {
-        "name": "simple.int64.histogram",
-        "type": "workload.googleapis.com/simple.int64.histogram",
+        "name": "zero.int64.histogram",
+        "type": "workload.googleapis.com/zero.int64.histogram",
         "labels": [
           {
             "key": "some_lemons"
@@ -268,7 +288,7 @@
         "metricKind": "CUMULATIVE",
         "valueType": "DISTRIBUTION",
         "unit": "s",
-        "displayName": "simple.int64.histogram"
+        "displayName": "zero.int64.histogram"
       }
     }
   ],

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
@@ -5,6 +5,44 @@
       "timeSeries": [
         {
           "metric": {
+            "type": "workload.googleapis.com/kv_prober_write_latency",
+            "labels": {
+              "service_instance_id": "0.0.0.0:2112",
+              "service_name": "otel-collector"
+            }
+          },
+          "resource": {
+            "type": "generic_task",
+            "labels": {
+              "job": "otel-collector",
+              "location": "global",
+              "namespace": "",
+              "task_id": "0.0.0.0:2112"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DISTRIBUTION",
+          "points": [
+            {
+              "interval": {
+                "endTime": "1970-01-01T00:00:00Z",
+                "startTime": "1970-01-01T00:00:00Z"
+              },
+              "value": {
+                "distributionValue": {
+                  "bucketOptions": {
+                    "explicitBuckets": {}
+                  },
+                  "bucketCounts": [
+                    "0"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "metric": {
             "type": "workload.googleapis.com/up",
             "labels": {
               "service_instance_id": "0.0.0.0:2112",
@@ -296,7 +334,7 @@
                   "startTime": "1970-01-01T00:00:00Z"
                 },
                 "value": {
-                  "int64Value": "5"
+                  "int64Value": "6"
                 }
               }
             ]

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
@@ -31,9 +31,14 @@
               "value": {
                 "distributionValue": {
                   "bucketOptions": {
-                    "explicitBuckets": {}
+                    "explicitBuckets": {
+                      "bounds": [
+                        0
+                      ]
+                    }
                   },
                   "bucketCounts": [
+                    "0",
                     "0"
                   ]
                 }

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -980,6 +980,9 @@ func (m *metricMapper) histogramPoint(point pmetric.HistogramDataPoint, projectI
 			deviation += float64(counts[len(counts)-1]) * (middleOfInfBucket - mean) * (middleOfInfBucket - mean)
 		}
 	}
+	if len(counts) == 0 {
+		counts = []int64{int64(point.Count())}
+	}
 
 	return &monitoringpb.TypedValue{
 		Value: &monitoringpb.TypedValue_DistributionValue{


### PR DESCRIPTION
The current collector exporter silently drops histograms without buckets.