### PR TITLE
Update CI go version to 1.22.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "1.22.3"
+  DEFAULT_GO_VERSION: "1.22.4"
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates CI to address vulnerability: 

```sh
Vulnerability #1: GO-2024-2887
    Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in
    net/netip
  More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net/netip@go1.22.3
    Fixed in: net/netip@go1.22.4
```

Revealed in lint checks for PR #858 