### PR TITLE
prepare for v1.24.0/v0.48.0 (#858)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "1.22.3"
+  DEFAULT_GO_VERSION: "1.22.4"
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.0
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.6.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.48.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 )
 
@@ -18,9 +18,9 @@ require (
 	cloud.google.com/go/functions v1.15.1 // indirect
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/trace v1.10.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.23.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.23.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.0
 
 require (
 	cloud.google.com/go/pubsub v1.33.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.23.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.25.0
 	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/sdk v1.25.0
@@ -20,8 +20,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/trace v1.10.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.23.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/metric/exponential_histogram/go.mod
+++ b/example/metric/exponential_histogram/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.22.0
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.25.0
 	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/metric v1.25.0
@@ -18,8 +18,8 @@ require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/monitoring v1.15.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.23.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/metric/otlpgrpc/go.mod
+++ b/example/metric/otlpgrpc/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.23.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/example/metric/sdk/go.mod
+++ b/example/metric/sdk/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.22.0
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.25.0
 	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/metric v1.25.0
@@ -17,8 +17,8 @@ require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/monitoring v1.15.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.23.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -5,8 +5,8 @@ go 1.21
 toolchain go1.22.0
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.23.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.48.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.50.0
 	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/sdk v1.25.0
@@ -17,7 +17,7 @@ require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.10.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -6,8 +6,8 @@ require (
 	cloud.google.com/go/logging v1.9.0
 	cloud.google.com/go/monitoring v1.18.0
 	cloud.google.com/go/trace v1.10.5
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.23.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/go-cmp v0.6.0

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -9,11 +9,11 @@ require (
 	cloud.google.com/go/monitoring v1.18.0
 	cloud.google.com/go/trace v1.10.5
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.47.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.47.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.47.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.47.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.48.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.48.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
@@ -37,7 +37,7 @@ require (
 	cloud.google.com/go/compute v1.24.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/longrunning v0.5.5 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.23.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.117 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -228,7 +228,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -412,7 +412,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -596,7 +596,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -765,7 +765,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -895,7 +895,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1025,7 +1025,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1155,7 +1155,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1271,7 +1271,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1372,7 +1372,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1473,7 +1473,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1574,7 +1574,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1704,7 +1704,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1888,7 +1888,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2072,7 +2072,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2241,7 +2241,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2376,7 +2376,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2511,7 +2511,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2646,7 +2646,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2767,7 +2767,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -228,7 +228,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -412,7 +412,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -596,7 +596,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -765,7 +765,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -895,7 +895,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1025,7 +1025,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1155,7 +1155,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1271,7 +1271,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1372,7 +1372,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1473,7 +1473,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1574,7 +1574,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1704,7 +1704,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1888,7 +1888,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2072,7 +2072,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2241,7 +2241,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2376,7 +2376,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2511,7 +2511,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2646,7 +2646,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2767,7 +2767,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.23.0"
+                  "value": "opentelemetry-go 1.25.0; google-cloud-trace-exporter 1.24.0"
                 }
               },
               "g.co/r/generic_node/location": {

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.0
 
 require (
 	cloud.google.com/go/monitoring v1.15.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.47.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0
 	github.com/googleapis/gax-go/v2 v2.11.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.25.0

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.47.0"
+	return "0.48.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.0
 
 require (
 	cloud.google.com/go/trace v1.10.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.47.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/sdk v1.25.0

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.23.0"
+	return "1.24.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.23.0"
-	unstable = "0.47.0"
+	stable   = "1.24.0"
+	unstable = "0.48.0"
 )
 
 var stableModules = map[string]struct{}{


### PR DESCRIPTION
* Update CI go version to 1.22.4 (#859)

* prepare for v1.24.0/v0.48.0


PR #858 was merged to a branch named `pre-release`. It needs to be merged in main