### PR TITLE
fix(googleclientauth/idtoken): use metadata server when credential json is not available

### DIFF
--- a/extension/googleclientauthextension/factory.go
+++ b/extension/googleclientauthextension/factory.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/idtoken"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/credentials/oauth"
 )
 
@@ -67,10 +68,16 @@ func (ca *clientAuthenticator) Start(ctx context.Context, _ component.Host) erro
 func (ca *clientAuthenticator) newTokenSource(ctx context.Context, creds *google.Credentials) (oauth2.TokenSource, error) {
 	switch ca.config.TokenType {
 	case idToken:
+		opts := []option.ClientOption{}
+
+		if len(creds.JSON) > 0 {
+			opts = append(opts, idtoken.WithCredentialsJSON(creds.JSON))
+		}
+
 		return idtoken.NewTokenSource(
 			ctx,
 			ca.config.Audience,
-			idtoken.WithCredentialsJSON(creds.JSON),
+			opts...,
 		)
 	default:
 		return creds.TokenSource, nil

--- a/extension/googleclientauthextension/factory_test.go
+++ b/extension/googleclientauthextension/factory_test.go
@@ -21,7 +21,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/extension"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/idtoken"
 )
+
+type mockIDTokenSource struct {
+	token string
+}
+
+func (ts *mockIDTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{
+		AccessToken: ts.token,
+	}, nil
+}
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := CreateDefaultConfig()
@@ -52,4 +65,64 @@ func TestStart_WithError(t *testing.T) {
 	assert.NoError(t, err)
 	err = ext.Start(context.Background(), nil)
 	assert.Error(t, err)
+}
+
+func TestStart_WithNoProjectError(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	ext, err := CreateExtension(context.Background(), extension.Settings{}, CreateDefaultConfig())
+	assert.NotNil(t, ext)
+	assert.NoError(t, err)
+	err = ext.Start(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestStart_idtoken(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/fake_creds.json")
+	ca := &clientAuthenticator{
+		config: &Config{
+			Project:   "my-project",
+			Scopes:    defaultScopes,
+			TokenType: idToken,
+			Audience:  "my-audience",
+		},
+		newIDTokenSource: func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
+			// opts should have idtoken.WithCredentialsJSON
+			assert.Len(t, opts, 1)
+
+			return &mockIDTokenSource{token: "dummy token"}, nil
+		},
+	}
+	err := ca.Start(context.Background(), nil)
+	assert.NoError(t, err)
+
+	token, err := ca.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, "dummy token", token.AccessToken)
+}
+
+func Test_newTokenSource_idtokenWithoutCredsJSON(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	ca := &clientAuthenticator{
+		config: &Config{
+			Project:   "my-project",
+			Scopes:    defaultScopes,
+			TokenType: idToken,
+			Audience:  "my-audience",
+		},
+		newIDTokenSource: func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
+			// opts should have no item
+			assert.Len(t, opts, 0)
+
+			return &mockIDTokenSource{token: "dummy token"}, nil
+		},
+	}
+	ts, err := ca.newTokenSource(context.Background(), &google.Credentials{
+		ProjectID: "my-project",
+	})
+	assert.NotNil(t, ts)
+	assert.NoError(t, err)
+
+	token, err := ts.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, "dummy token", token.AccessToken)
 }

--- a/extension/googleclientauthextension/grpc_test.go
+++ b/extension/googleclientauthextension/grpc_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/idtoken"
 )
 
 func TestPerRPCCredentials(t *testing.T) {
@@ -38,11 +39,14 @@ func TestPerRPCCredentials(t *testing.T) {
 
 func TestPerRPCCredentialsWithIDToken(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "testdata/fake_isa_creds.json")
-	ca := clientAuthenticator{config: &Config{
-		Project:   "my-project",
-		TokenType: idToken,
-		Audience:  "http://example.com",
-	}}
+	ca := clientAuthenticator{
+		config: &Config{
+			Project:   "my-project",
+			TokenType: idToken,
+			Audience:  "http://example.com",
+		},
+		newIDTokenSource: idtoken.NewTokenSource,
+	}
 	err := ca.Start(context.Background(), nil)
 	assert.NoError(t, err)
 

--- a/extension/googleclientauthextension/http_test.go
+++ b/extension/googleclientauthextension/http_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/idtoken"
 )
 
 func TestRoundTripper(t *testing.T) {
@@ -49,6 +50,7 @@ func TestRoundTripperWithIDToken(t *testing.T) {
 			TokenType: idToken,
 			Audience:  "http://example.com",
 		},
+		newIDTokenSource: idtoken.NewTokenSource,
 	}
 	err := ca.Start(context.Background(), nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
`googleclientauth` extension with `id_token` mode works correctly when credential.json is specified.
However, the current implementation doesn't work correctly with the metadata server.

This PR fixes its behavior.
I confirmed that it works correctly on Cloud Run.