### PR TITLE
Support k8s on GCE in resource detector

### DIFF
--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -52,6 +52,16 @@ func TestCloudPlatformGKE(t *testing.T) {
 	assert.Equal(t, platform, GKE)
 }
 
+func TestCloudPlatformK8sNotGKE(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataProvider{Err: fmt.Errorf("foo")}, &FakeOSProvider{
+		Vars: map[string]string{
+			k8sServiceHostEnv: "foo",
+		},
+	})
+	platform := d.CloudPlatform()
+	assert.Equal(t, platform, UnknownPlatform)
+}
+
 func TestCloudPlatformGCE(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataProvider{}, &FakeOSProvider{
 		Vars: map[string]string{},

--- a/detectors/gcp/gke.go
+++ b/detectors/gcp/gke.go
@@ -31,8 +31,15 @@ const (
 )
 
 func (d *Detector) onGKE() bool {
+	// Check if we are on k8s first
 	_, found := d.os.LookupEnv(k8sServiceHostEnv)
-	return found
+	if !found {
+		return false
+	}
+	// If we are on k8s, make sure that we are actually on GKE, and not a
+	// different managed k8s platform.
+	_, err := d.GKEClusterName()
+	return err == nil
 }
 
 // GKEHostID returns the instance ID of the instance on which this program is running.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/856.

This adds adds an additional check for the cluster name from the GKE metadata server to ensure we are actually running on GKE, and not k8s on GCE.