### PR TITLE
fix presubmit tests

### DIFF
--- a/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
+++ b/exporter/collector/googlemanagedprometheus/monitoredresource_test.go
@@ -215,7 +215,7 @@ func TestMapToPrometheusTarget(t *testing.T) {
 					"cluster":   "123901490g90fd89080943",
 					"namespace": "mynamespace",
 					"job":       "mycronjob",
-					"instance":  "mypod",
+					"instance":  "mypod/mycontainer",
 				},
 			},
 		},


### PR DESCRIPTION
I merged https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/878 and https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/877 without rebasing, and it broke presubmits.  This fixes the newly added test case.