### PR TITLE
Add benchmarks for areas of the collector exporter with high memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,8 @@ test:
 .PHONY: test-bench
 test-bench:
 	set -e; for dir in $(ALL_GO_FILES_DIRS); do \
-	echo "go test -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=. in $${dir}"; \
-	(cd "$${dir}" && $(GOTEST) -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=.); \
+	echo "go test -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -test.benchmem -bench=. in $${dir}"; \
+	(cd "$${dir}" && $(GOTEST) -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -test.benchmem -bench=.); \
 	done
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,13 @@ test:
 	(cd "$${dir}" && $(GOTEST) ./...); \
 	done
 
+.PHONY: test-bench
+test-bench:
+	set -e; for dir in $(ALL_GO_FILES_DIRS); do \
+	echo "go test -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=. in $${dir}"; \
+	(cd "$${dir}" && $(GOTEST) -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=.); \
+	done
+
 .PHONY: lint
 lint: $(GOLANGCI_LINT) $(MISSPELL) govulncheck
 	set -e; for dir in $(ALL_GO_MOD_DIRS); do \

--- a/exporter/collector/benchmark_test.go
+++ b/exporter/collector/benchmark_test.go
@@ -23,7 +23,7 @@ import (
 
 func BenchmarkAttributesToLabels(b *testing.B) {
 	attr := pcommon.NewMap()
-	attr.FromRaw(map[string]interface{}{
+	assert.NoError(b, attr.FromRaw(map[string]interface{}{
 		"a": true,
 		"b": false,
 		"c": int64(12),
@@ -32,7 +32,7 @@ func BenchmarkAttributesToLabels(b *testing.B) {
 		"f": []byte{0xde, 0xad, 0xbe, 0xef},
 		"g": []interface{}{"x", nil, "y"},
 		"h": map[string]interface{}{"a": "b"},
-	})
+	}))
 	b.ReportAllocs()
 	b.ResetTimer()
 

--- a/exporter/collector/benchmark_test.go
+++ b/exporter/collector/benchmark_test.go
@@ -33,7 +33,6 @@ func BenchmarkAttributesToLabels(b *testing.B) {
 		"g": []interface{}{"x", nil, "y"},
 		"h": map[string]interface{}{"a": "b"},
 	}))
-	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/exporter/collector/benchmark_test.go
+++ b/exporter/collector/benchmark_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func BenchmarkAttributesToLabels(b *testing.B) {
+	attr := pcommon.NewMap()
+	attr.FromRaw(map[string]interface{}{
+		"a": true,
+		"b": false,
+		"c": int64(12),
+		"d": 12.3,
+		"e": nil,
+		"f": []byte{0xde, 0xad, 0xbe, 0xef},
+		"g": []interface{}{"x", nil, "y"},
+		"h": map[string]interface{}{"a": "b"},
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		assert.Len(b, attributesToLabels(attr), 8)
+	}
+}

--- a/exporter/collector/internal/datapointstorage/benchmark_test.go
+++ b/exporter/collector/internal/datapointstorage/benchmark_test.go
@@ -51,7 +51,6 @@ func BenchmarkIdentifier(b *testing.B) {
 		"ding":  "dong",
 	}
 
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Identifier(monitoredResource, extraLabels, metric, attrs)

--- a/exporter/collector/internal/datapointstorage/benchmark_test.go
+++ b/exporter/collector/internal/datapointstorage/benchmark_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datapointstorage
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+func BenchmarkIdentifier(b *testing.B) {
+	metric := pmetric.NewMetric()
+	metric.SetName("custom.googleapis.com/test.metric")
+	attrs := pcommon.NewMap()
+	attrs.PutStr("string", "strval")
+	attrs.PutBool("bool", true)
+	attrs.PutInt("int", 123)
+	attrs.PutInt("int1", 123)
+	attrs.PutInt("int2", 123)
+	attrs.PutInt("int3", 123)
+	attrs.PutInt("int4", 123)
+	attrs.PutInt("int5", 123)
+	monitoredResource := &monitoredrespb.MonitoredResource{
+		Type: "k8s_container",
+		Labels: map[string]string{
+			"location":  "us-central1-b",
+			"project":   "project-foo",
+			"cluster":   "cluster-foo",
+			"pod":       "pod-foo",
+			"namespace": "namespace-foo",
+			"container": "container-foo",
+		},
+	}
+	extraLabels := map[string]string{
+		"foo":   "bar",
+		"hello": "world",
+		"ding":  "dong",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Identifier(monitoredResource, extraLabels, metric, attrs)
+	}
+}

--- a/exporter/collector/internal/normalization/benchmark_test.go
+++ b/exporter/collector/internal/normalization/benchmark_test.go
@@ -41,7 +41,6 @@ func BenchmarkNormalizeNumberDataPoint(b *testing.B) {
 	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
 	var ok bool
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, ok = normalizer.NormalizeNumberDataPoint(newPoint, id)
@@ -69,7 +68,6 @@ func BenchmarkNormalizeHistogramDataPoint(b *testing.B) {
 	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
 	var ok bool
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, ok = normalizer.NormalizeHistogramDataPoint(newPoint, id)
@@ -101,7 +99,6 @@ func BenchmarkNormalizeExopnentialHistogramDataPoint(b *testing.B) {
 	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
 	var ok bool
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, ok = normalizer.NormalizeExponentialHistogramDataPoint(newPoint, id)
@@ -127,7 +124,6 @@ func BenchmarkNormalizeSummaryDataPoint(b *testing.B) {
 	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
 	var ok bool
-	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, ok = normalizer.NormalizeSummaryDataPoint(newPoint, id)

--- a/exporter/collector/internal/normalization/benchmark_test.go
+++ b/exporter/collector/internal/normalization/benchmark_test.go
@@ -1,0 +1,144 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file excepoint in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalization
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func BenchmarkNormalizeNumberDataPoint(b *testing.B) {
+	shutdown := make(chan struct{})
+	defer close(shutdown)
+	normalizer := NewStandardNormalizer(shutdown, zap.NewNop())
+	startPoint := pmetric.NewNumberDataPoint()
+	startPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	startPoint.SetIntValue(12)
+	startPoint.Exemplars().AppendEmpty().SetIntValue(0)
+	addAttributes(startPoint.Attributes())
+	id := "abc123"
+	// ensure each run is the same by skipping the first call, which will populate caches
+	normalizer.NormalizeNumberDataPoint(startPoint, id)
+	newPoint := pmetric.NewNumberDataPoint()
+	startPoint.CopyTo(newPoint)
+	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	var ok bool
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, ok = normalizer.NormalizeNumberDataPoint(newPoint, id)
+		assert.True(b, ok)
+	}
+}
+
+func BenchmarkNormalizeHistogramDataPoint(b *testing.B) {
+	shutdown := make(chan struct{})
+	defer close(shutdown)
+	normalizer := NewStandardNormalizer(shutdown, zap.NewNop())
+	startPoint := pmetric.NewHistogramDataPoint()
+	startPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	startPoint.SetCount(2)
+	startPoint.SetSum(10.1)
+	startPoint.BucketCounts().FromRaw([]uint64{1, 1})
+	startPoint.ExplicitBounds().FromRaw([]float64{1, 2})
+	startPoint.Exemplars().AppendEmpty().SetIntValue(0)
+	addAttributes(startPoint.Attributes())
+	id := "abc123"
+	// ensure each run is the same by skipping the first call, which will populate caches
+	normalizer.NormalizeHistogramDataPoint(startPoint, id)
+	newPoint := pmetric.NewHistogramDataPoint()
+	startPoint.CopyTo(newPoint)
+	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	var ok bool
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, ok = normalizer.NormalizeHistogramDataPoint(newPoint, id)
+		assert.True(b, ok)
+	}
+}
+
+func BenchmarkNormalizeExopnentialHistogramDataPoint(b *testing.B) {
+	shutdown := make(chan struct{})
+	defer close(shutdown)
+	normalizer := NewStandardNormalizer(shutdown, zap.NewNop())
+	startPoint := pmetric.NewExponentialHistogramDataPoint()
+	startPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	startPoint.SetCount(4)
+	startPoint.SetSum(10.1)
+	startPoint.SetScale(1)
+	startPoint.SetZeroCount(1)
+	startPoint.Exemplars().AppendEmpty().SetIntValue(0)
+	startPoint.Positive().BucketCounts().FromRaw([]uint64{1, 1})
+	startPoint.Positive().SetOffset(1)
+	startPoint.Negative().BucketCounts().FromRaw([]uint64{1, 1})
+	startPoint.Negative().SetOffset(1)
+	addAttributes(startPoint.Attributes())
+	id := "abc123"
+	// ensure each run is the same by skipping the first call, which will populate caches
+	normalizer.NormalizeExponentialHistogramDataPoint(startPoint, id)
+	newPoint := pmetric.NewExponentialHistogramDataPoint()
+	startPoint.CopyTo(newPoint)
+	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	var ok bool
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, ok = normalizer.NormalizeExponentialHistogramDataPoint(newPoint, id)
+		assert.True(b, ok)
+	}
+}
+
+func BenchmarkNormalizeSummaryDataPoint(b *testing.B) {
+	shutdown := make(chan struct{})
+	defer close(shutdown)
+	normalizer := NewStandardNormalizer(shutdown, zap.NewNop())
+	startPoint := pmetric.NewSummaryDataPoint()
+	startPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	startPoint.SetCount(2)
+	startPoint.SetSum(10.1)
+	startPoint.QuantileValues().AppendEmpty().SetValue(1)
+	addAttributes(startPoint.Attributes())
+	id := "abc123"
+	// ensure each run is the same by skipping the first call, which will populate caches
+	normalizer.NormalizeSummaryDataPoint(startPoint, id)
+	newPoint := pmetric.NewSummaryDataPoint()
+	startPoint.CopyTo(newPoint)
+	newPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	var ok bool
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, ok = normalizer.NormalizeSummaryDataPoint(newPoint, id)
+		assert.True(b, ok)
+	}
+}
+
+func addAttributes(attrs pcommon.Map) {
+	attrs.PutStr("str", "val")
+	attrs.PutBool("bool", true)
+	attrs.PutInt("int", 10)
+	attrs.PutDouble("double", 1.2)
+	attrs.PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+}


### PR DESCRIPTION
I added a `test-bench` target to the makefile to run these benchmarks.

Output of `make test-bench`

```
go test -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=. in ./exporter/collector
goos: linux
goarch: amd64
pkg: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector
cpu: AMD EPYC 7B12
BenchmarkAttributesToLabels
BenchmarkAttributesToLabels-24    	     429	      2596 ns/op	     959 B/op	      19 allocs/op
```

```
go test -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=. in ./exporter/collector/internal/datapointstorage
goos: linux
goarch: amd64
pkg: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/datapointstorage
cpu: AMD EPYC 7B12
BenchmarkIdentifier
BenchmarkIdentifier-24    	     196	      6420 ns/op	    2226 B/op	      47 allocs/op
```

```
go test -run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=. in ./exporter/collector/internal/normalization
goos: linux
goarch: amd64
pkg: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization
cpu: AMD EPYC 7B12
BenchmarkNormalizeNumberDataPoint
BenchmarkNormalizeNumberDataPoint-24                  	    1671	       705.3 ns/op	     400 B/op	      10 allocs/op
BenchmarkNormalizeHistogramDataPoint
BenchmarkNormalizeHistogramDataPoint-24               	    1393	       941.7 ns/op	     528 B/op	      13 allocs/op
BenchmarkNormalizeExopnentialHistogramDataPoint
BenchmarkNormalizeExopnentialHistogramDataPoint-24    	     891	      1228 ns/op	     592 B/op	      14 allocs/op
BenchmarkNormalizeSummaryDataPoint
BenchmarkNormalizeSummaryDataPoint-24                 	    1915	       564.2 ns/op	     320 B/op	       8 allocs/op
```