### PR TITLE
Switch to uint64 hash for identifier

### DIFF
--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -211,9 +211,11 @@ func (c *Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
 	return true
 }
 
+// Use the same constants as Prometheus uses for hashing:
+// https://github.com/prometheus/prometheus/blob/282fb1632ad62a82401a230f486538a72384faf0/model/labels/labels_common.go#L32
 var (
 	itemSep = []byte{'\xfe'} // Used between identifiers
-	KVsep   = []byte{'\xff'} // Used between map keys and values
+	kvSep   = []byte{'\xff'} // Used between map keys and values
 )
 
 // Identifier returns the unique string identifier for a metric.
@@ -244,8 +246,8 @@ func hashOfMap(h hash.Hash64, m map[string]string) {
 	sort.Strings(keys)
 	for _, key := range keys {
 		h.Write([]byte(key))
-		h.Write(KVsep)
+		h.Write(kvSep)
 		h.Write([]byte(m[key]))
-		h.Write(KVsep)
+		h.Write(kvSep)
 	}
 }

--- a/exporter/collector/internal/datapointstorage/datapointcache.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache.go
@@ -15,9 +15,9 @@
 package datapointstorage
 
 import (
-	"fmt"
+	"hash"
+	"hash/fnv"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,10 +30,10 @@ import (
 const gcInterval = 20 * time.Minute
 
 type Cache struct {
-	numberCache               map[string]usedNumberPoint
-	summaryCache              map[string]usedSummaryPoint
-	histogramCache            map[string]usedHistogramPoint
-	exponentialHistogramCache map[string]usedExponentialHistogramPoint
+	numberCache               map[uint64]usedNumberPoint
+	summaryCache              map[uint64]usedSummaryPoint
+	histogramCache            map[uint64]usedHistogramPoint
+	exponentialHistogramCache map[uint64]usedExponentialHistogramPoint
 	numberLock                sync.RWMutex
 	summaryLock               sync.RWMutex
 	histogramLock             sync.RWMutex
@@ -63,10 +63,10 @@ type usedExponentialHistogramPoint struct {
 // NewCache instantiates a cache and starts background processes.
 func NewCache(shutdown <-chan struct{}) *Cache {
 	c := &Cache{
-		numberCache:               make(map[string]usedNumberPoint),
-		summaryCache:              make(map[string]usedSummaryPoint),
-		histogramCache:            make(map[string]usedHistogramPoint),
-		exponentialHistogramCache: make(map[string]usedExponentialHistogramPoint),
+		numberCache:               make(map[uint64]usedNumberPoint),
+		summaryCache:              make(map[uint64]usedSummaryPoint),
+		histogramCache:            make(map[uint64]usedHistogramPoint),
+		exponentialHistogramCache: make(map[uint64]usedExponentialHistogramPoint),
 	}
 	go func() {
 		ticker := time.NewTicker(gcInterval)
@@ -79,7 +79,7 @@ func NewCache(shutdown <-chan struct{}) *Cache {
 
 // GetNumberDataPoint retrieves the point associated with the identifier, and whether
 // or not it was found.
-func (c *Cache) GetNumberDataPoint(identifier string) (pmetric.NumberDataPoint, bool) {
+func (c *Cache) GetNumberDataPoint(identifier uint64) (pmetric.NumberDataPoint, bool) {
 	c.numberLock.RLock()
 	defer c.numberLock.RUnlock()
 	point, found := c.numberCache[identifier]
@@ -90,7 +90,7 @@ func (c *Cache) GetNumberDataPoint(identifier string) (pmetric.NumberDataPoint, 
 }
 
 // SetNumberDataPoint assigns the point to the identifier in the cache.
-func (c *Cache) SetNumberDataPoint(identifier string, point pmetric.NumberDataPoint) {
+func (c *Cache) SetNumberDataPoint(identifier uint64, point pmetric.NumberDataPoint) {
 	c.numberLock.Lock()
 	defer c.numberLock.Unlock()
 	c.numberCache[identifier] = usedNumberPoint{point, atomic.NewBool(true)}
@@ -98,7 +98,7 @@ func (c *Cache) SetNumberDataPoint(identifier string, point pmetric.NumberDataPo
 
 // GetSummaryDataPoint retrieves the point associated with the identifier, and whether
 // or not it was found.
-func (c *Cache) GetSummaryDataPoint(identifier string) (pmetric.SummaryDataPoint, bool) {
+func (c *Cache) GetSummaryDataPoint(identifier uint64) (pmetric.SummaryDataPoint, bool) {
 	c.summaryLock.RLock()
 	defer c.summaryLock.RUnlock()
 	point, found := c.summaryCache[identifier]
@@ -109,7 +109,7 @@ func (c *Cache) GetSummaryDataPoint(identifier string) (pmetric.SummaryDataPoint
 }
 
 // SetSummaryDataPoint assigns the point to the identifier in the cache.
-func (c *Cache) SetSummaryDataPoint(identifier string, point pmetric.SummaryDataPoint) {
+func (c *Cache) SetSummaryDataPoint(identifier uint64, point pmetric.SummaryDataPoint) {
 	c.summaryLock.Lock()
 	defer c.summaryLock.Unlock()
 	c.summaryCache[identifier] = usedSummaryPoint{point, atomic.NewBool(true)}
@@ -117,7 +117,7 @@ func (c *Cache) SetSummaryDataPoint(identifier string, point pmetric.SummaryData
 
 // GetHistogramDataPoint retrieves the point associated with the identifier, and whether
 // or not it was found.
-func (c *Cache) GetHistogramDataPoint(identifier string) (pmetric.HistogramDataPoint, bool) {
+func (c *Cache) GetHistogramDataPoint(identifier uint64) (pmetric.HistogramDataPoint, bool) {
 	c.histogramLock.RLock()
 	defer c.histogramLock.RUnlock()
 	point, found := c.histogramCache[identifier]
@@ -128,7 +128,7 @@ func (c *Cache) GetHistogramDataPoint(identifier string) (pmetric.HistogramDataP
 }
 
 // SetHistogramDataPoint assigns the point to the identifier in the cache.
-func (c *Cache) SetHistogramDataPoint(identifier string, point pmetric.HistogramDataPoint) {
+func (c *Cache) SetHistogramDataPoint(identifier uint64, point pmetric.HistogramDataPoint) {
 	c.histogramLock.Lock()
 	defer c.histogramLock.Unlock()
 	c.histogramCache[identifier] = usedHistogramPoint{point, atomic.NewBool(true)}
@@ -136,7 +136,7 @@ func (c *Cache) SetHistogramDataPoint(identifier string, point pmetric.Histogram
 
 // GetExponentialHistogramDataPoint retrieves the point associated with the identifier, and whether
 // or not it was found.
-func (c *Cache) GetExponentialHistogramDataPoint(identifier string) (pmetric.ExponentialHistogramDataPoint, bool) {
+func (c *Cache) GetExponentialHistogramDataPoint(identifier uint64) (pmetric.ExponentialHistogramDataPoint, bool) {
 	c.exponentialHistogramLock.RLock()
 	defer c.exponentialHistogramLock.RUnlock()
 	point, found := c.exponentialHistogramCache[identifier]
@@ -147,7 +147,7 @@ func (c *Cache) GetExponentialHistogramDataPoint(identifier string) (pmetric.Exp
 }
 
 // SetExponentialHistogramDataPoint assigns the point to the identifier in the cache.
-func (c *Cache) SetExponentialHistogramDataPoint(identifier string, point pmetric.ExponentialHistogramDataPoint) {
+func (c *Cache) SetExponentialHistogramDataPoint(identifier uint64, point pmetric.ExponentialHistogramDataPoint) {
 	c.exponentialHistogramLock.Lock()
 	defer c.exponentialHistogramLock.Unlock()
 	c.exponentialHistogramCache[identifier] = usedExponentialHistogramPoint{point, atomic.NewBool(true)}
@@ -212,27 +212,57 @@ func (c *Cache) gc(shutdown <-chan struct{}, tickerCh <-chan time.Time) bool {
 }
 
 // Identifier returns the unique string identifier for a metric.
-func Identifier(resource *monitoredrespb.MonitoredResource, extraLabels map[string]string, metric pmetric.Metric, attributes pcommon.Map) string {
-	var b strings.Builder
+func Identifier(resource *monitoredrespb.MonitoredResource, extraLabels map[string]string, metric pmetric.Metric, attributes pcommon.Map) (uint64, error) {
+	var err error
+	h := fnv.New64()
 
-	// Resource identifiers
-	if resource != nil {
-		fmt.Fprintf(&b, "%v", resource.GetLabels())
+	_, err = h.Write([]byte(resource.GetType()))
+	if err != nil {
+		return 0, err
+	}
+	_, err = h.Write([]byte(metric.Name()))
+	if err != nil {
+		return 0, err
 	}
 
-	// Instrumentation library labels and additional resource labels
-	fmt.Fprintf(&b, " - %v", extraLabels)
-
-	// Metric identifiers
-	fmt.Fprintf(&b, " - %s -", metric.Name())
-	attrsIds := make([]string, 0, attributes.Len())
+	attrs := make(map[string]string)
 	attributes.Range(func(k string, v pcommon.Value) bool {
-		attrsIds = append(attrsIds, k+"="+v.AsString())
+		attrs[k] = v.AsString()
 		return true
 	})
-	if len(attrsIds) > 0 {
-		sort.Strings(attrsIds)
-		fmt.Fprint(&b, " "+strings.Join(attrsIds, " "))
+
+	err = hashOfMap(h, extraLabels)
+	if err != nil {
+		return 0, err
 	}
-	return b.String()
+
+	err = hashOfMap(h, attrs)
+	if err != nil {
+		return 0, err
+	}
+
+	err = hashOfMap(h, resource.GetLabels())
+	if err != nil {
+		return 0, err
+	}
+	return h.Sum64(), err
+}
+
+func hashOfMap(h hash.Hash64, m map[string]string) error {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		_, err := h.Write([]byte(key))
+		if err != nil {
+			return err
+		}
+		_, err = h.Write([]byte(m[key]))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/exporter/collector/internal/datapointstorage/datapointcache_test.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache_test.go
@@ -261,19 +261,15 @@ func TestIdentifier(t *testing.T) {
 	metricWithName := pmetric.NewMetric()
 	metricWithName.SetName("custom.googleapis.com/test.metric")
 	dpWithAttributes := pmetric.NewNumberDataPoint()
-	dpWithAttributes.Attributes().PutStr("string", "strval")
-	dpWithAttributes.Attributes().PutBool("bool", true)
-	dpWithAttributes.Attributes().PutInt("int", 123)
+	dpWithAttributes.Attributes().PutStr("foo", "bar")
 	monitoredResource := &monitoredrespb.MonitoredResource{
 		Type: "generic_task",
 		Labels: map[string]string{
-			"location": "us-central1-b",
-			"project":  "project-foo",
+			"foo": "bar",
 		},
 	}
 	extraLabels := map[string]string{
-		"foo":   "bar",
-		"hello": "world",
+		"foo": "bar",
 	}
 	for _, tc := range []struct {
 		resource    *monitoredrespb.MonitoredResource
@@ -285,39 +281,39 @@ func TestIdentifier(t *testing.T) {
 	}{
 		{
 			desc:   "empty",
-			want:   14695981039346656037,
+			want:   16303200508382005237,
 			metric: pmetric.NewMetric(),
 			labels: pmetric.NewNumberDataPoint().Attributes(),
 		},
 		{
 			desc:   "with name",
-			want:   4430695870278802542,
+			want:   9745949301560396956,
 			metric: metricWithName,
 			labels: pmetric.NewNumberDataPoint().Attributes(),
 		},
 		{
 			desc:   "with attributes",
-			want:   12689322622784691089,
+			want:   2247677448538243046,
 			metric: pmetric.NewMetric(),
 			labels: dpWithAttributes.Attributes(),
 		},
 		{
 			desc:     "with resource",
-			want:     10341971859444782974,
+			want:     4344837656395061793,
 			resource: monitoredResource,
 			metric:   pmetric.NewMetric(),
 			labels:   pmetric.NewNumberDataPoint().Attributes(),
 		},
 		{
 			desc:        "with extra labels",
-			want:        5179797973592387646,
+			want:        4054966704305404600,
 			metric:      pmetric.NewMetric(),
 			labels:      pmetric.NewNumberDataPoint().Attributes(),
 			extraLabels: extraLabels,
 		},
 		{
 			desc:        "with all",
-			want:        322569983349436668,
+			want:        2679814683341169356,
 			metric:      metricWithName,
 			labels:      dpWithAttributes.Attributes(),
 			extraLabels: extraLabels,

--- a/exporter/collector/internal/datapointstorage/datapointcache_test.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache_test.go
@@ -327,8 +327,7 @@ func TestIdentifier(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			origLabels := pcommon.NewMap()
 			tc.labels.CopyTo(origLabels)
-			got, err := Identifier(tc.resource, tc.extraLabels, tc.metric, tc.labels)
-			assert.NoError(t, err)
+			got := Identifier(tc.resource, tc.extraLabels, tc.metric, tc.labels)
 			if tc.want != got {
 				t.Errorf("Identifier() = %d; want %d", got, tc.want)
 			}

--- a/exporter/collector/internal/normalization/benchmark_test.go
+++ b/exporter/collector/internal/normalization/benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkNormalizeNumberDataPoint(b *testing.B) {
 	startPoint.SetIntValue(12)
 	startPoint.Exemplars().AppendEmpty().SetIntValue(0)
 	addAttributes(startPoint.Attributes())
-	id := "abc123"
+	id := uint64(12345)
 	// ensure each run is the same by skipping the first call, which will populate caches
 	normalizer.NormalizeNumberDataPoint(startPoint, id)
 	newPoint := pmetric.NewNumberDataPoint()
@@ -60,7 +60,7 @@ func BenchmarkNormalizeHistogramDataPoint(b *testing.B) {
 	startPoint.ExplicitBounds().FromRaw([]float64{1, 2})
 	startPoint.Exemplars().AppendEmpty().SetIntValue(0)
 	addAttributes(startPoint.Attributes())
-	id := "abc123"
+	id := uint64(12345)
 	// ensure each run is the same by skipping the first call, which will populate caches
 	normalizer.NormalizeHistogramDataPoint(startPoint, id)
 	newPoint := pmetric.NewHistogramDataPoint()
@@ -91,7 +91,7 @@ func BenchmarkNormalizeExopnentialHistogramDataPoint(b *testing.B) {
 	startPoint.Negative().BucketCounts().FromRaw([]uint64{1, 1})
 	startPoint.Negative().SetOffset(1)
 	addAttributes(startPoint.Attributes())
-	id := "abc123"
+	id := uint64(12345)
 	// ensure each run is the same by skipping the first call, which will populate caches
 	normalizer.NormalizeExponentialHistogramDataPoint(startPoint, id)
 	newPoint := pmetric.NewExponentialHistogramDataPoint()
@@ -116,7 +116,7 @@ func BenchmarkNormalizeSummaryDataPoint(b *testing.B) {
 	startPoint.SetSum(10.1)
 	startPoint.QuantileValues().AppendEmpty().SetValue(1)
 	addAttributes(startPoint.Attributes())
-	id := "abc123"
+	id := uint64(12345)
 	// ensure each run is the same by skipping the first call, which will populate caches
 	normalizer.NormalizeSummaryDataPoint(startPoint, id)
 	newPoint := pmetric.NewSummaryDataPoint()

--- a/exporter/collector/internal/normalization/disabled_normalizer.go
+++ b/exporter/collector/internal/normalization/disabled_normalizer.go
@@ -34,7 +34,7 @@ func NewDisabledNormalizer() Normalizer {
 type disabledNormalizer struct{}
 
 // NormalizeExponentialHistogramDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, _ string) (pmetric.ExponentialHistogramDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, _ uint64) (pmetric.ExponentialHistogramDataPoint, bool) {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
 		// Make a copy so we don't mutate underlying data.
@@ -48,7 +48,7 @@ func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetri
 }
 
 // NormalizeHistogramDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, _ string) (pmetric.HistogramDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, _ uint64) (pmetric.HistogramDataPoint, bool) {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
 		// Make a copy so we don't mutate underlying data.
@@ -62,7 +62,7 @@ func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.Histogram
 }
 
 // NormalizeNumberDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, _ string) (pmetric.NumberDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, _ uint64) (pmetric.NumberDataPoint, bool) {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
 		// Make a copy so we don't mutate underlying data.
@@ -76,7 +76,7 @@ func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPo
 }
 
 // NormalizeSummaryDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, _ string) (pmetric.SummaryDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, _ uint64) (pmetric.SummaryDataPoint, bool) {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
 		// Make a copy so we don't mutate underlying data.

--- a/exporter/collector/internal/normalization/standard_normalizer.go
+++ b/exporter/collector/internal/normalization/standard_normalizer.go
@@ -47,7 +47,7 @@ type standardNormalizer struct {
 	log           *zap.Logger
 }
 
-func (s *standardNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier string) (pmetric.ExponentialHistogramDataPoint, bool) {
+func (s *standardNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier uint64) (pmetric.ExponentialHistogramDataPoint, bool) {
 	start, hasStart := s.startCache.GetExponentialHistogramDataPoint(identifier)
 	if !hasStart {
 		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
@@ -152,7 +152,7 @@ func subtractExponentialBuckets(a, b pmetric.ExponentialHistogramDataPointBucket
 	return newBuckets
 }
 
-func (s *standardNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier string) (pmetric.HistogramDataPoint, bool) {
+func (s *standardNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier uint64) (pmetric.HistogramDataPoint, bool) {
 	start, hasStart := s.startCache.GetHistogramDataPoint(identifier)
 	if !hasStart {
 		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
@@ -258,7 +258,7 @@ func bucketBoundariesEqual(a, b pcommon.Float64Slice) bool {
 
 // NormalizeNumberDataPoint normalizes a cumulative, monotonic sum.
 // It returns the normalized point, and true if the point should be kept.
-func (s *standardNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier string) (pmetric.NumberDataPoint, bool) {
+func (s *standardNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier uint64) (pmetric.NumberDataPoint, bool) {
 	start, hasStart := s.startCache.GetNumberDataPoint(identifier)
 	if !hasStart {
 		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
@@ -341,7 +341,7 @@ func subtractNumberDataPoint(a, b pmetric.NumberDataPoint) pmetric.NumberDataPoi
 	return newPoint
 }
 
-func (s *standardNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier string) (pmetric.SummaryDataPoint, bool) {
+func (s *standardNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier uint64) (pmetric.SummaryDataPoint, bool) {
 	start, hasStart := s.startCache.GetSummaryDataPoint(identifier)
 	if !hasStart {
 		if point.StartTimestamp() == 0 || !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {

--- a/exporter/collector/internal/normalization/types.go
+++ b/exporter/collector/internal/normalization/types.go
@@ -22,14 +22,14 @@ import (
 type Normalizer interface {
 	// NormalizeExponentialHistogramDataPoint normalizes an exponential histogram.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier string) (pmetric.ExponentialHistogramDataPoint, bool)
+	NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier uint64) (pmetric.ExponentialHistogramDataPoint, bool)
 	// NormalizeHistogramDataPoint normalizes a cumulative histogram.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier string) (pmetric.HistogramDataPoint, bool)
+	NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier uint64) (pmetric.HistogramDataPoint, bool)
 	// NormalizeNumberDataPoint normalizes a cumulative, monotonic sum.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier string) (pmetric.NumberDataPoint, bool)
+	NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier uint64) (pmetric.NumberDataPoint, bool)
 	// NormalizeSummaryDataPoint normalizes a summary.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier string) (pmetric.SummaryDataPoint, bool)
+	NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier uint64) (pmetric.SummaryDataPoint, bool)
 }

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -875,7 +875,11 @@ func (m *metricMapper) summaryPointToTimeSeries(
 		return nil
 	}
 	// Normalize the summary point.
-	metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+	metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+	if err != nil {
+		m.obs.log.Debug("Failed to get identifier for summary metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
+		return nil
+	}
 	normalizedPoint, keep := m.normalizer.NormalizeSummaryDataPoint(point, metricIdentifier)
 	if !keep {
 		return nil
@@ -1148,7 +1152,11 @@ func (m *metricMapper) histogramToTimeSeries(
 	}
 	if hist.AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
 		// Normalize cumulative histogram points.
-		metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+		metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+		if err != nil {
+			m.obs.log.Debug("Failed to get identifier for histogram metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
+			return nil
+		}
 		normalizedPoint, keep := m.normalizer.NormalizeHistogramDataPoint(point, metricIdentifier)
 		if !keep {
 			return nil
@@ -1202,7 +1210,11 @@ func (m *metricMapper) exponentialHistogramToTimeSeries(
 	}
 	if exponentialHist.AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
 		// Normalize the histogram point.
-		metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+		metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+		if err != nil {
+			m.obs.log.Debug("Failed to get identifier for exponential histogram metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
+			return nil
+		}
 		normalizedPoint, keep := m.normalizer.NormalizeExponentialHistogramDataPoint(point, metricIdentifier)
 		if !keep {
 			return nil
@@ -1257,7 +1269,11 @@ func (m *metricMapper) sumPointToTimeSeries(
 	}
 	if sum.IsMonotonic() {
 		if sum.AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-			metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+			metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
+			if err != nil {
+				m.obs.log.Debug("Failed to get identifier for sum metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
+				return nil
+			}
 			normalizedPoint, keep := m.normalizer.NormalizeNumberDataPoint(point, metricIdentifier)
 			if !keep {
 				return nil

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -875,11 +875,7 @@ func (m *metricMapper) summaryPointToTimeSeries(
 		return nil
 	}
 	// Normalize the summary point.
-	metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
-	if err != nil {
-		m.obs.log.Debug("Failed to get identifier for summary metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
-		return nil
-	}
+	metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
 	normalizedPoint, keep := m.normalizer.NormalizeSummaryDataPoint(point, metricIdentifier)
 	if !keep {
 		return nil
@@ -1152,11 +1148,7 @@ func (m *metricMapper) histogramToTimeSeries(
 	}
 	if hist.AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
 		// Normalize cumulative histogram points.
-		metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
-		if err != nil {
-			m.obs.log.Debug("Failed to get identifier for histogram metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
-			return nil
-		}
+		metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
 		normalizedPoint, keep := m.normalizer.NormalizeHistogramDataPoint(point, metricIdentifier)
 		if !keep {
 			return nil
@@ -1210,11 +1202,7 @@ func (m *metricMapper) exponentialHistogramToTimeSeries(
 	}
 	if exponentialHist.AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
 		// Normalize the histogram point.
-		metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
-		if err != nil {
-			m.obs.log.Debug("Failed to get identifier for exponential histogram metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
-			return nil
-		}
+		metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
 		normalizedPoint, keep := m.normalizer.NormalizeExponentialHistogramDataPoint(point, metricIdentifier)
 		if !keep {
 			return nil
@@ -1269,11 +1257,7 @@ func (m *metricMapper) sumPointToTimeSeries(
 	}
 	if sum.IsMonotonic() {
 		if sum.AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-			metricIdentifier, err := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
-			if err != nil {
-				m.obs.log.Debug("Failed to get identifier for sum metric. Dropping the metric.", zap.Error(err), zap.Any("metric", metric))
-				return nil
-			}
+			metricIdentifier := datapointstorage.Identifier(resource, extraLabels, metric, point.Attributes())
 			normalizedPoint, keep := m.normalizer.NormalizeNumberDataPoint(point, metricIdentifier)
 			if !keep {
 				return nil


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/datapointstorage
cpu: AMD EPYC 7B12
             │ bench2.txt  │             bench3.txt             │
             │   sec/op    │   sec/op     vs base               │
Identifier-2   4.805µ ± 4%   2.539µ ± 0%  -47.16% (p=0.002 n=6)

             │ bench2.txt  │            bench3.txt             │
             │    B/op     │    B/op     vs base               │
Identifier-2   2208.0 ± 0%   632.0 ± 0%  -71.38% (p=0.002 n=6)

             │ bench2.txt │            bench3.txt            │
             │ allocs/op  │ allocs/op   vs base              │
Identifier-2   47.00 ± 0%   44.00 ± 0%  -6.38% (p=0.002 n=6)
```
I'm still working on testing edge cases to make sure identifiers don't collide.