### PR TITLE
Optimize normalization caching and copying

### DIFF
--- a/exporter/collector/internal/datapointstorage/datapointcache_test.go
+++ b/exporter/collector/internal/datapointstorage/datapointcache_test.go
@@ -67,7 +67,7 @@ func TestGC(t *testing.T) {
 	fakeTicker := make(chan time.Time)
 	id := uint64(12345)
 
-	c.SetNumberDataPoint(id, pmetric.NumberDataPoint{})
+	c.SetNumberDataPoint(id, pmetric.NewNumberDataPoint())
 
 	// bar exists since we just set it
 	usedPoint, found := c.numberCache[id]

--- a/exporter/collector/internal/normalization/standard_normalizer.go
+++ b/exporter/collector/internal/normalization/standard_normalizer.go
@@ -129,7 +129,7 @@ func subtractExponentialHistogramDataPoint(a, b pmetric.ExponentialHistogramData
 	a.Negative().BucketCounts().FromRaw(subtractExponentialBuckets(a.Negative(), b.Negative()))
 }
 
-// subtractExponentialBuckets returns a - b.
+// subtractExponentialBuckets subtracts b from a.
 func subtractExponentialBuckets(a, b pmetric.ExponentialHistogramDataPointBuckets) []uint64 {
 	newBuckets := make([]uint64, a.BucketCounts().Len())
 	offsetDiff := int(a.Offset() - b.Offset())
@@ -213,7 +213,7 @@ func lessThanHistogramDataPoint(a, b pmetric.HistogramDataPoint) bool {
 	return a.Count() < b.Count() || a.Sum() < b.Sum()
 }
 
-// subtractHistogramDataPoint returns a - b.
+// subtractHistogramDataPoint subtracts b from a.
 func subtractHistogramDataPoint(a, b pmetric.HistogramDataPoint) {
 	// Use the timestamp from the normalization point
 	a.SetStartTimestamp(b.Timestamp())


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/888

### Changes

This avoids creating new cached elements, updates existing cached datapoints if they are already there, and only copies the required fields into the cache.  In particular, not storing attributes lowers memory usage significantly. The benchmark difference is:

```
goos: linux
goarch: amd64
pkg: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                              │   main.txt   │            mincache.txt            │
                                              │    sec/op    │   sec/op     vs base               │
NormalizeNumberDataPoint-2                       606.5n ± 7%   585.2n ± 3%        ~ (p=0.132 n=6)
NormalizeHistogramDataPoint-2                    727.2n ± 3%   684.4n ± 7%   -5.89% (p=0.041 n=6)
NormalizeExopnentialHistogramDataPoint-2         776.1n ± 4%   801.5n ± 3%   +3.28% (p=0.009 n=6)
NormalizeSummaryDataPoint-2                      552.4n ± 5%   331.3n ± 2%  -40.02% (p=0.002 n=6)
ResetNormalizeNumberDataPoint-2                  904.4n ± 2%   591.8n ± 3%  -34.57% (p=0.002 n=6)
ResetNormalizeHistogramDataPoint-2              1198.5n ± 4%   868.4n ± 6%  -27.54% (p=0.002 n=6)
ResetNormalizeExponentialHistogramDataPoint-2    949.9n ± 4%   651.4n ± 3%  -31.43% (p=0.002 n=6)
ResetNormalizeSummaryDataPoint-2                 859.9n ± 4%   383.6n ± 3%  -55.39% (p=0.002 n=6)
geomean                                          799.8n        584.7n       -26.89%

                                              │  main.txt   │              mincache.txt              │
                                              │    B/op     │    B/op     vs base                    │
NormalizeNumberDataPoint-2                       16.00 ± 0%   16.00 ± 0%         ~ (p=1.000 n=6) ¹
NormalizeHistogramDataPoint-2                    32.00 ± 0%   32.00 ± 0%         ~ (p=1.000 n=6) ¹
NormalizeExopnentialHistogramDataPoint-2         48.00 ± 0%   48.00 ± 0%         ~ (p=1.000 n=6) ¹
NormalizeSummaryDataPoint-2                      16.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
ResetNormalizeNumberDataPoint-2                 128.00 ± 0%   16.00 ± 0%   -87.50% (p=0.002 n=6)
ResetNormalizeHistogramDataPoint-2              256.00 ± 0%   64.00 ± 0%   -75.00% (p=0.002 n=6)
ResetNormalizeExponentialHistogramDataPoint-2   256.00 ± 0%   16.00 ± 0%   -93.75% (p=0.002 n=6)
ResetNormalizeSummaryDataPoint-2                 128.0 ± 0%     0.0 ± 0%  -100.00% (p=0.002 n=6)
geomean                                          67.33                    ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                              │  main.txt  │              mincache.txt              │
                                              │ allocs/op  │ allocs/op   vs base                    │
NormalizeNumberDataPoint-2                      2.000 ± 0%   2.000 ± 0%         ~ (p=1.000 n=6) ¹
NormalizeHistogramDataPoint-2                   3.000 ± 0%   3.000 ± 0%         ~ (p=1.000 n=6) ¹
NormalizeExopnentialHistogramDataPoint-2        4.000 ± 0%   4.000 ± 0%         ~ (p=1.000 n=6) ¹
NormalizeSummaryDataPoint-2                     1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
ResetNormalizeNumberDataPoint-2                 4.000 ± 0%   1.000 ± 0%   -75.00% (p=0.002 n=6)
ResetNormalizeHistogramDataPoint-2              7.000 ± 0%   4.000 ± 0%   -42.86% (p=0.002 n=6)
ResetNormalizeExponentialHistogramDataPoint-2   4.000 ± 0%   1.000 ± 0%   -75.00% (p=0.002 n=6)
ResetNormalizeSummaryDataPoint-2                4.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
geomean                                         3.191                    ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

Note that this primarily improves the "reset" benchmarks.  This is because we only store things in the cache when a reset happens.  This is primarily capturing the fact that we are re-using data points, rather than making new ones.