### PR TITLE
Update go version used in CI to 1.23.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 env:
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "1.22.5"
+  DEFAULT_GO_VERSION: "1.23.1"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.22.3", "1.21"]
+        go-version: ["1.23.1", "1.22.5", "1.21"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         arch: ["386", amd64]
         exclude:

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -14,7 +14,7 @@
 
 steps:
   # Vendor dependencies, and zip the code.
-  - name: golang:1.22.3
+  - name: golang:1.23.1
     id: zip-code
     entrypoint: /bin/bash
     args:

--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -14,7 +14,7 @@
 
 steps:
   # Vendor dependencies, and zip the code.
-  - name: golang:1.22.2
+  - name: golang:1.23.1
     id: zip-code
     entrypoint: /bin/bash
     args:

--- a/cloudbuild-integration-tests.yaml
+++ b/cloudbuild-integration-tests.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - name: golang:1.22.3
+  - name: golang:1.23.1
     env: ["SECOND_PROJECT_ID=opentelemetry-ops-e2e-2"]
     args: ["make", "integrationtest"]
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/e2e-test-server/Dockerfile
+++ b/e2e-test-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.3 as builder
+FROM golang:1.23.1 as builder
 
 WORKDIR /workspace/e2e-test-server/
 


### PR DESCRIPTION
This adds support for go 1.23.1, and also fixes the govulncheck presubmit failure