### PR TITLE
Make the collector exporter mutate data, and remove unnecessary CopyTo

### DIFF
--- a/exporter/collector/internal/normalization/benchmark_test.go
+++ b/exporter/collector/internal/normalization/benchmark_test.go
@@ -40,7 +40,7 @@ func BenchmarkNormalizeNumberDataPoint(b *testing.B) {
 		b.StopTimer()
 		newPoint := testNumberDataPoint()
 		b.StartTimer()
-		_, ok = normalizer.NormalizeNumberDataPoint(newPoint, id)
+		ok = normalizer.NormalizeNumberDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }
@@ -61,7 +61,7 @@ func BenchmarkNormalizeHistogramDataPoint(b *testing.B) {
 		b.StopTimer()
 		newPoint := testHistogramDataPoint()
 		b.StartTimer()
-		_, ok = normalizer.NormalizeHistogramDataPoint(newPoint, id)
+		ok = normalizer.NormalizeHistogramDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }
@@ -82,7 +82,7 @@ func BenchmarkNormalizeExopnentialHistogramDataPoint(b *testing.B) {
 		b.StopTimer()
 		newPoint := testExponentialHistogramDataPoint()
 		b.StartTimer()
-		_, ok = normalizer.NormalizeExponentialHistogramDataPoint(newPoint, id)
+		ok = normalizer.NormalizeExponentialHistogramDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }
@@ -103,7 +103,7 @@ func BenchmarkNormalizeSummaryDataPoint(b *testing.B) {
 		b.StopTimer()
 		newPoint := testSummaryDataPoint()
 		b.StartTimer()
-		_, ok = normalizer.NormalizeSummaryDataPoint(newPoint, id)
+		ok = normalizer.NormalizeSummaryDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }

--- a/exporter/collector/internal/normalization/benchmark_test.go
+++ b/exporter/collector/internal/normalization/benchmark_test.go
@@ -127,7 +127,7 @@ func BenchmarkResetNormalizeNumberDataPoint(b *testing.B) {
 		newPoint := testNumberDataPoint()
 		newPoint.SetIntValue(int64(b.N - i))
 		b.StartTimer()
-		_, ok = normalizer.NormalizeNumberDataPoint(newPoint, id)
+		ok = normalizer.NormalizeNumberDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }
@@ -151,7 +151,7 @@ func BenchmarkResetNormalizeHistogramDataPoint(b *testing.B) {
 		newPoint := testHistogramDataPoint()
 		newPoint.SetSum(float64(b.N - i))
 		b.StartTimer()
-		_, ok = normalizer.NormalizeHistogramDataPoint(newPoint, id)
+		ok = normalizer.NormalizeHistogramDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }
@@ -175,7 +175,7 @@ func BenchmarkResetNormalizeExponentialHistogramDataPoint(b *testing.B) {
 		newPoint := testExponentialHistogramDataPoint()
 		newPoint.SetSum(float64(b.N - i))
 		b.StartTimer()
-		_, ok = normalizer.NormalizeExponentialHistogramDataPoint(newPoint, id)
+		ok = normalizer.NormalizeExponentialHistogramDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }
@@ -199,7 +199,7 @@ func BenchmarkResetNormalizeSummaryDataPoint(b *testing.B) {
 		newPoint := testSummaryDataPoint()
 		newPoint.SetSum(float64(b.N - i))
 		b.StartTimer()
-		_, ok = normalizer.NormalizeSummaryDataPoint(newPoint, id)
+		ok = normalizer.NormalizeSummaryDataPoint(newPoint, id)
 		assert.True(b, ok)
 	}
 }

--- a/exporter/collector/internal/normalization/disabled_normalizer.go
+++ b/exporter/collector/internal/normalization/disabled_normalizer.go
@@ -34,57 +34,41 @@ func NewDisabledNormalizer() Normalizer {
 type disabledNormalizer struct{}
 
 // NormalizeExponentialHistogramDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, _ uint64) (pmetric.ExponentialHistogramDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
-		// Make a copy so we don't mutate underlying data.
-		newPoint := pmetric.NewExponentialHistogramDataPoint()
-		point.CopyTo(newPoint)
 		// StartTime = Timestamp - 1 ms
-		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
-		return newPoint, true
+		point.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
 	}
-	return point, true
+	return true
 }
 
 // NormalizeHistogramDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, _ uint64) (pmetric.HistogramDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
-		// Make a copy so we don't mutate underlying data.
-		newPoint := pmetric.NewHistogramDataPoint()
-		point.CopyTo(newPoint)
 		// StartTime = Timestamp - 1 ms
-		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
-		return newPoint, true
+		point.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
 	}
-	return point, true
+	return true
 }
 
 // NormalizeNumberDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, _ uint64) (pmetric.NumberDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
-		// Make a copy so we don't mutate underlying data.
-		newPoint := pmetric.NewNumberDataPoint()
-		point.CopyTo(newPoint)
 		// StartTime = Timestamp - 1 ms
-		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
-		return newPoint, true
+		point.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
 	}
-	return point, true
+	return true
 }
 
 // NormalizeSummaryDataPoint returns the point without normalizing.
-func (d *disabledNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, _ uint64) (pmetric.SummaryDataPoint, bool) {
+func (d *disabledNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
-		// Make a copy so we don't mutate underlying data.
-		newPoint := pmetric.NewSummaryDataPoint()
-		point.CopyTo(newPoint)
 		// StartTime = Timestamp - 1 ms
-		newPoint.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
-		return newPoint, true
+		point.SetStartTimestamp(pcommon.Timestamp(uint64(point.Timestamp()) - uint64(time.Millisecond)))
 	}
-	return point, true
+	return true
 }

--- a/exporter/collector/internal/normalization/disabled_normalizer.go
+++ b/exporter/collector/internal/normalization/disabled_normalizer.go
@@ -33,7 +33,8 @@ func NewDisabledNormalizer() Normalizer {
 
 type disabledNormalizer struct{}
 
-// NormalizeExponentialHistogramDataPoint returns the point without normalizing.
+// NormalizeExponentialHistogramDataPoint ensures the start time is before the
+// end time, but does not normalize points.
 func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
@@ -43,7 +44,8 @@ func (d *disabledNormalizer) NormalizeExponentialHistogramDataPoint(point pmetri
 	return true
 }
 
-// NormalizeHistogramDataPoint returns the point without normalizing.
+// NormalizeHistogramDataPoint ensures the start time is before the
+// end time, but does not normalize points.
 func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
@@ -53,7 +55,8 @@ func (d *disabledNormalizer) NormalizeHistogramDataPoint(point pmetric.Histogram
 	return true
 }
 
-// NormalizeNumberDataPoint returns the point without normalizing.
+// NormalizeNumberDataPoint ensures the start time is before the
+// end time, but does not normalize points.
 func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.
@@ -63,7 +66,8 @@ func (d *disabledNormalizer) NormalizeNumberDataPoint(point pmetric.NumberDataPo
 	return true
 }
 
-// NormalizeSummaryDataPoint returns the point without normalizing.
+// NormalizeSummaryDataPoint ensures the start time is before the
+// end time, but does not normalize points.
 func (d *disabledNormalizer) NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, _ uint64) bool {
 	if !point.StartTimestamp().AsTime().Before(point.Timestamp().AsTime()) {
 		// Handle explicit reset points.

--- a/exporter/collector/internal/normalization/types.go
+++ b/exporter/collector/internal/normalization/types.go
@@ -22,14 +22,14 @@ import (
 type Normalizer interface {
 	// NormalizeExponentialHistogramDataPoint normalizes an exponential histogram.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier uint64) (pmetric.ExponentialHistogramDataPoint, bool)
+	NormalizeExponentialHistogramDataPoint(point pmetric.ExponentialHistogramDataPoint, identifier uint64) bool
 	// NormalizeHistogramDataPoint normalizes a cumulative histogram.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier uint64) (pmetric.HistogramDataPoint, bool)
+	NormalizeHistogramDataPoint(point pmetric.HistogramDataPoint, identifier uint64) bool
 	// NormalizeNumberDataPoint normalizes a cumulative, monotonic sum.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier uint64) (pmetric.NumberDataPoint, bool)
+	NormalizeNumberDataPoint(point pmetric.NumberDataPoint, identifier uint64) bool
 	// NormalizeSummaryDataPoint normalizes a summary.
 	// It returns the normalized point, and true if the point should be kept.
-	NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier uint64) (pmetric.SummaryDataPoint, bool)
+	NormalizeSummaryDataPoint(point pmetric.SummaryDataPoint, identifier uint64) bool
 }

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -395,17 +395,13 @@ func (l logMapper) getLogName(log plog.LogRecord) (string, error) {
 }
 
 func (l logMapper) logToSplitEntries(
-	log plog.LogRecord,
+	logRecord plog.LogRecord,
 	mr *monitoredrespb.MonitoredResource,
 	logLabels map[string]string,
 	processTime time.Time,
 	logName string,
 	projectID string,
 ) ([]*logpb.LogEntry, error) {
-	// make a copy in case we mutate the record
-	logRecord := plog.NewLogRecord()
-	log.CopyTo(logRecord)
-
 	ts := logRecord.Timestamp().AsTime()
 	if logRecord.Timestamp() == 0 || ts.IsZero() {
 		// if timestamp is unset, fall back to observed_time_unix_nano as recommended


### PR DESCRIPTION
Looking at https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/890#issuecomment-2344718704

This change makes the collector exporter now mutate data.  We were doing multiple layers additional copying in our exporter to prevent mutating data, but it is likely better for us to just be a mutating exporter, and let the framework handle it.

This keeps the collector code clean, and should have better CPU/Memory usage (even after the additional copy) since we are copying fewer times.

Benchmarks (including those added in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/893):

```
goos: linux
goarch: amd64
pkg: github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/internal/normalization
cpu: AMD EPYC 7B12
                                              │   main.txt    │             mutating.txt              │
                                              │    sec/op     │    sec/op     vs base                 │
NormalizeNumberDataPoint-2                      1845.0n ± ∞ ¹   532.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeHistogramDataPoint-2                   2314.0n ± ∞ ¹   615.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeExopnentialHistogramDataPoint-2        2071.0n ± ∞ ¹   673.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeSummaryDataPoint-2                     1718.0n ± ∞ ¹   465.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeNumberDataPoint-2                 2094.0n ± ∞ ¹   826.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeHistogramDataPoint-2               2.565µ ± ∞ ¹   1.043µ ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeExponentialHistogramDataPoint-2   2148.0n ± ∞ ¹   869.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeSummaryDataPoint-2                1775.0n ± ∞ ¹   836.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                          2.049µ         709.9n        -65.36%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                              │   main.txt   │             mutating.txt             │
                                              │     B/op     │    B/op      vs base                 │
NormalizeNumberDataPoint-2                      408.00 ± ∞ ¹   16.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeHistogramDataPoint-2                   536.00 ± ∞ ¹   32.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeExopnentialHistogramDataPoint-2        600.00 ± ∞ ¹   48.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeSummaryDataPoint-2                     320.00 ± ∞ ¹   16.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeNumberDataPoint-2                  504.0 ± ∞ ¹   128.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeHistogramDataPoint-2               745.0 ± ∞ ¹   256.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeExponentialHistogramDataPoint-2    792.0 ± ∞ ¹   256.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeSummaryDataPoint-2                 432.0 ± ∞ ¹   128.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                          520.6         67.33        -87.07%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                              │   main.txt   │             mutating.txt             │
                                              │  allocs/op   │  allocs/op   vs base                 │
NormalizeNumberDataPoint-2                      10.000 ± ∞ ¹   2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeHistogramDataPoint-2                   13.000 ± ∞ ¹   3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeExopnentialHistogramDataPoint-2        14.000 ± ∞ ¹   4.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
NormalizeSummaryDataPoint-2                      8.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeNumberDataPoint-2                 12.000 ± ∞ ¹   4.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeHistogramDataPoint-2              17.000 ± ∞ ¹   7.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeExponentialHistogramDataPoint-2   14.000 ± ∞ ¹   4.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
ResetNormalizeSummaryDataPoint-2                11.000 ± ∞ ¹   4.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                          12.09         3.191        -73.61%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```