### PR TITLE
Add links to quickstart and observability overview to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 This repository contains the source code of 2 packages of OpenTelemetry exporters to [Google Cloud Trace](https://cloud.google.com/trace) and [Google Cloud Monitoring](https://cloud.google.com/monitoring).
 
+To get started with instrumentation in Google Cloud, see [Generate traces and metrics with
+Go](https://cloud.google.com/stackdriver/docs/instrumentation/setup/go).
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit [Instrumentation and
+observability](https://cloud.google.com/stackdriver/docs/instrumentation/overview).
+
 ## OpenTelemetry Google Cloud Trace Exporter
 
 OpenTelemetry Google Cloud Trace Exporter allow the user to send collected traces and spans to Google Cloud.

--- a/exporter/metric/README.md
+++ b/exporter/metric/README.md
@@ -3,7 +3,14 @@
 [![Docs](https://godoc.org/github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric?status.svg)](https://pkg.go.dev/github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric)
 [![Apache License][license-image]][license-url]
 
-OpenTelemetry Google Cloud Monitoring Exporter allow the user to send collected metrics to Google Cloud.
+OpenTelemetry Google Cloud Monitoring Exporter allows the user to send collected metrics to Google Cloud.
+
+To get started with instrumentation in Google Cloud, see [Generate traces and metrics with
+Go](https://cloud.google.com/stackdriver/docs/instrumentation/setup/go).
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit [Instrumentation and
+observability](https://cloud.google.com/stackdriver/docs/instrumentation/overview).
 
 [Google Cloud Monitoring](https://cloud.google.com/monitoring) provides visibility into the performance, uptime, and overall health of cloud-powered applications. It collects metrics, events, and metadata from Google Cloud, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others. Operations ingests that data and generates insights via dashboards, charts, and alerts. Cloud Monitoring alerting helps you collaborate by integrating with Slack, PagerDuty, and more.
 

--- a/exporter/trace/README.md
+++ b/exporter/trace/README.md
@@ -5,6 +5,13 @@
 
 OpenTelemetry Google Cloud Trace Exporter allows the user to send collected traces and spans to Google Cloud.
 
+To get started with instrumentation in Google Cloud, see [Generate traces and metrics with
+Go](https://cloud.google.com/stackdriver/docs/instrumentation/setup/go).
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit [Instrumentation and
+observability](https://cloud.google.com/stackdriver/docs/instrumentation/overview).
+
 [Google Cloud Trace](https://cloud.google.com/trace) is a distributed tracing backend system. It helps developers to gather timing data needed to troubleshoot latency problems in microservice & monolithic architectures. It manages both the collection and lookup of gathered trace data.
 
 This exporter package assumes your application is [already instrumented](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/net/http/otelhttp/example/client/client.go) with the OpenTelemetry SDK. Once you get ready to export OpenTelemetry data, you can add this exporter to your application.

--- a/propagator/README.md
+++ b/propagator/README.md
@@ -6,6 +6,13 @@ This package contains Trace Context Propagators for use with [Google Cloud
 Trace](https://cloud.google.com/trace) that make it compatible with
 [OpenTelemetry](http://opentelemetry.io). 
 
+To get started with instrumentation in Google Cloud, see [Generate traces and metrics with
+Go](https://cloud.google.com/stackdriver/docs/instrumentation/setup/go).
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit [Instrumentation and
+observability](https://cloud.google.com/stackdriver/docs/instrumentation/overview).
+
 There are two available propagators in this package:
 
 ### `CloudTraceOneWayPropagator` (Recommended)


### PR DESCRIPTION
Added to the root README and those for the SDK exporters and propagators which appear on https://pkg.go.dev.
