### PR TITLE
Fix bug where grpc self-observability metrics were not added

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -257,7 +257,15 @@ func setVersionInUserAgent(cfg *Config, version string) {
 }
 
 func generateClientOptions(ctx context.Context, clientCfg *ClientConfig, cfg *Config, scopes []string, meterProvider metric.MeterProvider) ([]option.ClientOption, error) {
-	var copts []option.ClientOption
+	// Disable the built-in telemetry so we have full control over the telemetry produced.
+	copts := []option.ClientOption{
+		option.WithTelemetryDisabled(),
+		option.WithGRPCDialOption(otelgrpc.DialOption(otelgrpc.Options{
+			MetricsOptions: otelgrpc.MetricsOptions{
+				MeterProvider: meterProvider,
+			},
+		})),
+	}
 	// grpc.WithUserAgent is used by the Trace exporter, but not the Metric exporter (see comment below)
 	if cfg.UserAgent != "" {
 		copts = append(copts, option.WithGRPCDialOption(grpc.WithUserAgent(cfg.UserAgent)))

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.2
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.2
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.109.0
 	go.opentelemetry.io/collector/exporter v0.109.0
@@ -50,7 +51,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect

--- a/exporter/collector/integrationtest/integration_selfobs_test.go
+++ b/exporter/collector/integrationtest/integration_selfobs_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integrationtest
+// +build integrationtest
+
+package integrationtest
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+
+	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	exporter, err := mexporter.New(mexporter.WithProjectID(os.Getenv("PROJECT_ID")))
+	if err != nil {
+		log.Fatalf("Failed to create self-obs exporter: %v", err)
+	}
+	version4Uuid, err := uuid.NewRandom()
+	if err != nil {
+		log.Fatalf("Failed to create uuid for resource: %v", err)
+	}
+	res, err := resource.New(
+		ctx,
+		resource.WithTelemetrySDK(),
+		resource.WithFromEnv(),
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String("integrationtest"),
+			semconv.ServiceInstanceIDKey.String(version4Uuid.String()),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create self-obs resource: %v", err)
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+	)
+	defer mp.Shutdown(ctx)
+	otel.SetMeterProvider(mp)
+	m.Run()
+}

--- a/exporter/collector/integrationtest/logs_integration_test.go
+++ b/exporter/collector/integrationtest/logs_integration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
@@ -49,7 +49,7 @@ func createLogsExporter(
 		ctx,
 		cfg,
 		logger,
-		noop.NewMeterProvider(),
+		otel.GetMeterProvider(),
 		"latest",
 		duration,
 	)

--- a/exporter/collector/integrationtest/metrics_integration_test.go
+++ b/exporter/collector/integrationtest/metrics_integration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
@@ -48,7 +48,7 @@ func createMetricsExporter(
 		ctx,
 		cfg,
 		logger,
-		noop.NewMeterProvider(),
+		otel.GetMeterProvider(),
 		"latest",
 		collector.DefaultTimeout,
 	)

--- a/exporter/collector/integrationtest/traces_integration_test.go
+++ b/exporter/collector/integrationtest/traces_integration_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/integrationtest/testcases"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 )
 
@@ -43,7 +43,7 @@ func createTracesExporter(
 		ctx,
 		cfg,
 		logger,
-		noop.NewMeterProvider(),
+		otel.GetMeterProvider(),
 		"latest",
 		collector.DefaultTimeout,
 	)


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/885, I only added grpc observability metrics when insecure = true.  This passed our tests that use a local, fake grpc server, but didn't work for the general case.

It turns out that the metrics were _actually_ coming from the client library, which enables opencensus metrics by default.  After the OC bridge was removed, those metrics disappeared.

This PR adds grpc metrics for the non-insecure case.

TESTED=checked that the e2e test project contains grpc self-obs metrics