### PR TITLE
Remove dependency on prometheus translation package

### DIFF
--- a/exporter/collector/googlemanagedprometheus/go.mod
+++ b/exporter/collector/googlemanagedprometheus/go.mod
@@ -3,7 +3,6 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/colle
 go 1.22.0
 
 require (
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.109.0
 	github.com/prometheus/common v0.53.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/featuregate v1.15.0
@@ -17,6 +16,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/exporter/collector/googlemanagedprometheus/go.sum
+++ b/exporter/collector/googlemanagedprometheus/go.sum
@@ -1,3 +1,4 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,10 +22,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.109.0 h1:3a/Y3/uaLVdu/1QHjxgaCZu8dI6VLffI9N6j80oiAbw=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.109.0/go.mod h1:kIh6tdityVjMYBjsLld/44IEcr7vnNQ6kfH9KYym74Y=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.109.0 h1:MXfuYf9ygtz77RvORnGPcD8WwcyBq0LOCv1mdJ89UsE=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.109.0/go.mod h1:T+WCLIq5mgjeliV9fBkkGIID4b132RZ9INtR8xv8nhY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.6.0 h1:k1v3CzpSRUTrKMppY35TLwPvxHqBu0bYgxZzqGIgaos=

--- a/exporter/collector/googlemanagedprometheus/naming.go
+++ b/exporter/collector/googlemanagedprometheus/naming.go
@@ -19,14 +19,12 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-// GetMetricName returns the metric name with GMP-specific suffixes. The.
-func (c Config) GetMetricName(baseName string, metric pmetric.Metric) (string, error) {
-	// First, build a name that is compliant with prometheus conventions
-	compliantName := prometheus.BuildCompliantName(metric, "", c.AddMetricSuffixes)
+// GetMetricName returns the GMP-specific suffix. baseName includes type (e.g. summary) suffixes.
+// compliantName is the name of the metric with any sanitization already performed.
+func GetMetricName(baseName, compliantName string, metric pmetric.Metric) (string, error) {
 	// Second, ad the GMP-specific suffix
 	switch metric.Type() {
 	case pmetric.MetricTypeSum:

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.3
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.109.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.109.0
 	go.opentelemetry.io/collector/exporter v0.109.0
@@ -67,7 +68,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.109.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.20.3 // indirect


### PR DESCRIPTION
We can move this logic into collector-contrib until the translation package is stabilized.

This unblocks https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35904

See exporter/collector/integrationtest/testcases/testcases_metrics.go for the change we would need to make in contrib after this.

cc @ArthurSens