### PR TITLE
Setup gcbrun bot for renovate

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,9 @@
+# Config reference:
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution
+
+trustedContributors:
+  - renovate-bot
+annotations:
+  # Automatically run Cloud Build tests
+  - type: comment
+    text: /gcbrun


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/601

This adds the `/gcbrun` comment to renovate PRs so I don't have to do it myself.