### PR TITLE
Ungroup the otel collector and otel SDK dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,8 +34,13 @@
       },
       {
         "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/**"],
-        "groupName": "go.opentelemetry.io"
+        "matchPackageNames": ["go.opentelemetry.io/collector/**", "github.com/open-telemetry/opentelemetry-collector-contrib/**"],
+        "groupName": "go.opentelemetry.io/collector"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchPackageNames": ["go.opentelemetry.io/otel/**", "go.opentelemetry.io/contrib/**"],
+        "groupName": "go.opentelemetry.io/otel"
       }
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -29,18 +29,19 @@
         "groupName": "golang.org/x"
       },
       {
-        "matchPackageNames": ["cloud.google.com/go/**"],
+        "matchPackageNames": ["cloud.google.com/go**"],
         "groupName": "cloud.google.com/go"
       },
       {
         "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/collector/**", "github.com/open-telemetry/opentelemetry-collector-contrib/**"],
+        "matchPackageNames": ["go.opentelemetry.io/collector**", "github.com/open-telemetry/opentelemetry-collector-contrib**"],
         "groupName": "go.opentelemetry.io/collector"
       },
       {
         "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/otel/**", "go.opentelemetry.io/contrib/**"],
+        "matchPackageNames": ["go.opentelemetry.io/otel**", "go.opentelemetry.io/contrib**"],
         "groupName": "go.opentelemetry.io/otel"
       }
     ]
   }
+  


### PR DESCRIPTION
These currently are unlikely to succeed because of the size.  Split them to make this more reasonable.