### PR TITLE
Restore trailing slashes to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,17 +29,17 @@
         "groupName": "golang.org/x"
       },
       {
-        "matchPackageNames": ["cloud.google.com/go**"],
-        "groupName": "cloud.google.com/go"
+        "matchPackageNames": ["cloud.google.com/**"],
+        "groupName": "cloud.google.com"
       },
       {
         "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/collector**", "github.com/open-telemetry/opentelemetry-collector-contrib**"],
+        "matchPackageNames": ["go.opentelemetry.io/collector/**", "github.com/open-telemetry/opentelemetry-collector-contrib/**"],
         "groupName": "go.opentelemetry.io/collector"
       },
       {
         "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/otel**", "go.opentelemetry.io/contrib**"],
+        "matchPackageNames": ["go.opentelemetry.io/otel", "go.opentelemetry.io/otel/**", "go.opentelemetry.io/contrib/**"],
         "groupName": "go.opentelemetry.io/otel"
       }
     ]


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/965 seems to have broken grouped updates