### PR TITLE
Remove remaining testing and usage of go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.23.1", "1.22.5", "1.21"]
+        go-version: ["1.23.1", "1.22.5"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         arch: ["386", amd64]
         exclude:

--- a/Makefile
+++ b/Makefile
@@ -157,9 +157,9 @@ lint: $(GOLANGCI_LINT) $(MISSPELL) govulncheck
 	done
 	$(MISSPELL) -w $(ALL_DOCS)
 	set -e; for dir in $(ALL_GO_MOD_DIRS) $(TOOLS_MOD_DIR); do \
-	  echo "go mod tidy -compat=1.21 in $${dir}"; \
+	  echo "go mod tidy -compat=1.22 in $${dir}"; \
 	  (cd "$${dir}" && \
-	    go mod tidy -compat=1.21); \
+	    go mod tidy -compat=1.22); \
 	done
 
 generate: $(STRINGER) $(PROTOC)
@@ -198,7 +198,7 @@ govulncheck/%: | $(GOVULNCHECK)
 
 .PHONY: gotidy
 gotidy:
-	$(MAKE) for-all-mod CMD="go mod tidy -compat=1.21"
+	$(MAKE) for-all-mod CMD="go mod tidy -compat=1.22"
 
 .PHONY: update-dep
 update-dep:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go
 
-go 1.21
+go 1.22
 
 retract (
 	v1.8.0


### PR DESCRIPTION
Almost everything was using go 1.22 already as the minimum version.  This drops 1.21 tests and updates go mod compatibility versions.