### PR TITLE
Update some go dependencies to v1.23.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 env:
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "1.23.1"
+  DEFAULT_GO_VERSION: "1.23.6"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.23.1", "1.22.5"]
+        go-version: ["1.23.6", "1.22.5"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         arch: ["386", amd64]
         exclude:

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -14,7 +14,7 @@
 
 steps:
   # Vendor dependencies, and zip the code.
-  - name: golang:1.23.1
+  - name: golang:1.23.6
     id: zip-code
     entrypoint: /bin/bash
     args:

--- a/cloudbuild-integration-tests.yaml
+++ b/cloudbuild-integration-tests.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - name: golang:1.23.1
+  - name: golang:1.23.6
     env: ["SECOND_PROJECT_ID=opentelemetry-ops-e2e-2"]
     args: ["make", "integrationtest"]
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -2,7 +2,7 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp
 
 go 1.22
 
-toolchain go1.23.4
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/e2e-test-server/Dockerfile
+++ b/e2e-test-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.5 as builder
+FROM golang:1.23.6 as builder
 
 WORKDIR /workspace/e2e-test-server/
 


### PR DESCRIPTION
Fixes vulnerability presubmits.  Supersedes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/1000

App engine doesn't appear to support that version yet, so i didn't update it.