### PR TITLE
exporter/metric: add WithMetricClient option

### DIFF
--- a/exporter/metric/cloudmonitoring_test.go
+++ b/exporter/metric/cloudmonitoring_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"fmt"
+	"testing"
+
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+)
+
+func TestNew(t *testing.T) {
+	cl := &monitoring.MetricClient{}
+	tcs := []struct {
+		desc               string
+		opts               []Option
+		verifyExporterFunc func(*metricExporter) error
+	}{
+		{
+			desc: "WithMetricClient sets the client",
+			opts: []Option{WithMonitoringClient(cl)},
+			verifyExporterFunc: func(e *metricExporter) error {
+				if e.client != cl {
+					return fmt.Errorf("client mismatch, got = %p, want = %p", e.client, cl)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "WithMetricClient overrides WithMetricClientOptions",
+			opts: []Option{WithMonitoringClient(cl), WithMonitoringClientOptions()},
+			verifyExporterFunc: func(e *metricExporter) error {
+				if e.client != cl {
+					return fmt.Errorf("client mismatch, got = %p, want = %p", e.client, cl)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := append(tc.opts, WithProjectID("some-project-id"))
+			e, err := New(opts...)
+			if err != nil {
+				t.Fatalf("New(): %v", err)
+			}
+			exp, ok := e.(*metricExporter)
+			if !ok {
+				t.Fatal("unexpected type mismatch")
+			}
+			if err := tc.verifyExporterFunc(exp); err != nil {
+				t.Fatalf("failed to verify exporter: %v", err)
+			}
+		})
+	}
+}

--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -106,25 +106,29 @@ func newMetricExporter(o *options) (*metricExporter, error) {
 		return nil, errBlankProjectID
 	}
 
-	clientOpts := append([]option.ClientOption{option.WithGRPCDialOption(grpc.WithUserAgent(userAgent))}, o.monitoringClientOptions...)
-	ctx := o.context
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	client, err := monitoring.NewMetricClient(ctx, clientOpts...)
-	if err != nil {
-		return nil, err
-	}
+	client := o.monitoringClient
+	if client == nil {
+		clientOpts := append([]option.ClientOption{option.WithGRPCDialOption(grpc.WithUserAgent(userAgent))}, o.monitoringClientOptions...)
+		ctx := o.context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		var err error
+		client, err = monitoring.NewMetricClient(ctx, clientOpts...)
+		if err != nil {
+			return nil, err
+		}
 
-	if o.compression == "gzip" {
-		client.CallOptions.GetMetricDescriptor = append(client.CallOptions.GetMetricDescriptor,
-			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
-		client.CallOptions.CreateMetricDescriptor = append(client.CallOptions.CreateMetricDescriptor,
-			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
-		client.CallOptions.CreateTimeSeries = append(client.CallOptions.CreateTimeSeries,
-			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
-		client.CallOptions.CreateServiceTimeSeries = append(client.CallOptions.CreateServiceTimeSeries,
-			gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+		if o.compression == "gzip" {
+			client.CallOptions.GetMetricDescriptor = append(client.CallOptions.GetMetricDescriptor,
+				gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+			client.CallOptions.CreateMetricDescriptor = append(client.CallOptions.CreateMetricDescriptor,
+				gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+			client.CallOptions.CreateTimeSeries = append(client.CallOptions.CreateTimeSeries,
+				gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+			client.CallOptions.CreateServiceTimeSeries = append(client.CallOptions.CreateServiceTimeSeries,
+				gax.WithGRPCOptions(grpc.UseCompressor(gzip.Name)))
+		}
 	}
 
 	cache := map[key]*googlemetricpb.MetricDescriptor{}

--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -21,8 +21,9 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	apioption "google.golang.org/api/option"
 )
 
@@ -69,8 +70,11 @@ type options struct {
 	projectID string
 	// compression enables gzip compression on gRPC calls.
 	compression string
+	// monitoringClient is used as the default client when not nil. If
+	// monitoringClient is nil, a client is created instead.
+	monitoringClient *monitoring.MetricClient
 	// monitoringClientOptions are additional options to be passed
-	// to the underlying Stackdriver Monitoring API client.
+	// to the underlying Cloud Monitoring API client.
 	// Optional.
 	monitoringClientOptions []apioption.ClientOption
 	// destinationProjectQuota sets whether the request should use quota from
@@ -105,6 +109,16 @@ func WithProjectID(id string) func(o *options) {
 func WithDestinationProjectQuota() func(o *options) {
 	return func(o *options) {
 		o.destinationProjectQuota = true
+	}
+}
+
+// WithMonitoringClient configures the client used by the exporter to write
+// metrics to Cloud Monitoring. This option is mutually exclusive with
+// WithMonitoringClientOptions. If both options are provided,
+// WithMonitoringClient is used and WithMonitoringClientOptions is ignored.
+func WithMonitoringClient(cl *monitoring.MetricClient) func(o *options) {
+	return func(o *options) {
+		o.monitoringClient = cl
 	}
 }
 


### PR DESCRIPTION
This commit allows callers to configure their own Cloud Monitoring client.

Fixes #1032