### PR TITLE
Update go version to ` 1.23.8` in all `go.mod` files.

### DIFF
--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp
 
-go 1.22
-
-toolchain go1.23.6
+go 1.23.8
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server/cloudfunctions
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/example/metric/collector/go.mod
+++ b/example/metric/collector/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric/collector
 
-go 1.22.0
-
-toolchain go1.23.4
+go 1.23.8
 
 require (
 	go.opentelemetry.io/otel v1.31.0

--- a/example/metric/exponential_histogram/go.mod
+++ b/example/metric/exponential_histogram/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric/exponential_histogram
 
-go 1.22.0
-
-toolchain go1.23.4
+go 1.23.8
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0

--- a/example/metric/otlpgrpc/go.mod
+++ b/example/metric/otlpgrpc/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric/otlpgrpc
 
-go 1.22.0
-
-toolchain go1.23.4
+go 1.23.8
 
 require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.31.0

--- a/example/metric/sdk/go.mod
+++ b/example/metric/sdk/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric/sdk
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/http
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0

--- a/example/trace/otlpgrpc/go.mod
+++ b/example/trace/otlpgrpc/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/otlpgrpc
 
-go 1.22.0
-
-toolchain go1.23.4
+go 1.23.8
 
 require (
 	go.opentelemetry.io/otel v1.31.0

--- a/example/trace/otlphttp/go.mod
+++ b/example/trace/otlphttp/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/otlphttp
 
-go 1.22.0
-
-toolchain go1.23.4
+go 1.23.8
 
 require (
 	go.opentelemetry.io/otel v1.31.0

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector
 
-go 1.23.0
+go 1.23.8
 
 toolchain go1.24.0
 

--- a/exporter/collector/googlemanagedprometheus/go.mod
+++ b/exporter/collector/googlemanagedprometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus
 
-go 1.23.0
+go 1.23.8
 
 toolchain go1.24.0
 

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/integrationtest
 
-go 1.23.0
+go 1.23.8
 
 toolchain go1.24.0
 

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	cloud.google.com/go/monitoring v1.22.1

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	cloud.google.com/go/trace v1.11.3

--- a/extension/googleclientauthextension/go.mod
+++ b/extension/googleclientauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/extension/googleclientauthextension
 
-go 1.23.0
+go 1.23.8
 
 toolchain go1.24.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go
 
-go 1.22
+go 1.23.8
 
 retract (
 	v1.8.0

--- a/internal/cloudmock/go.mod
+++ b/internal/cloudmock/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock
 
-go 1.22
-
-toolchain go1.23.4
+go 1.23.8
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/internal/resourcemapping/go.mod
+++ b/internal/resourcemapping/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	go.opentelemetry.io/otel v1.30.0

--- a/propagator/go.mod
+++ b/propagator/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.8
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/tools
 
-go 1.22.1
+go 1.23.8
 
 toolchain go1.24.0
 


### PR DESCRIPTION
Updating go version to `1.23.8` to fix vulnerability showing up in `lint` test in other PRs (see example https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/1031).

```
=== Symbol Results ===
Vulnerability #1: GO-2025-3563
    Request smuggling due to acceptance of invalid chunked data in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3563
  Standard library
    Found in: net/http/internal@go1.23.6
    Fixed in: net/http/internal@go1.23.8
    Example traces found:
Error:       #1: faas.go:101:42: gcp.Detector.FaaSCloudRegion calls metadata.Client.GetWithContext, which eventually calls internal.chunkedReader.Read
Your code is affected by 1 vulnerability from the Go standard library.
```