### PR TITLE
Prepare for v1.28.0/v0.52.0

### DIFF
--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -5,7 +5,7 @@ go 1.23.8
 require (
 	cloud.google.com/go/pubsub v1.45.3
 	github.com/GoogleCloudPlatform/functions-framework-go v1.9.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.52.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 )
 
@@ -17,9 +17,9 @@ require (
 	cloud.google.com/go/functions v1.19.3 // indirect
 	cloud.google.com/go/iam v1.3.1 // indirect
 	cloud.google.com/go/trace v1.11.3 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.28.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.28.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 require (
 	cloud.google.com/go/pubsub v1.45.3
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.28.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.31.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
@@ -19,8 +19,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/iam v1.3.1 // indirect
 	cloud.google.com/go/trace v1.11.3 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.28.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/example/metric/exponential_histogram/go.mod
+++ b/example/metric/exponential_histogram/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric
 go 1.23.8
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.52.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.31.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/metric v1.31.0
@@ -17,8 +17,8 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/monitoring v1.22.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.28.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/example/metric/otlpgrpc/go.mod
+++ b/example/metric/otlpgrpc/go.mod
@@ -14,7 +14,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.28.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/example/metric/sdk/go.mod
+++ b/example/metric/sdk/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/metric
 go 1.23.8
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.52.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.31.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/metric v1.31.0
@@ -16,8 +16,8 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/monitoring v1.22.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.28.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -3,8 +3,8 @@ module github.com/GoogleCloudPlatform/opentelemetry-operations-go/example/trace/
 go 1.23.8
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.28.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.52.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
@@ -16,7 +16,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/trace v1.11.3 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -6,8 +6,8 @@ require (
 	cloud.google.com/go/logging v1.13.0
 	cloud.google.com/go/monitoring v1.22.1
 	cloud.google.com/go/trace v1.11.3
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.28.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/go-cmp v0.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -6,11 +6,11 @@ require (
 	cloud.google.com/go/logging v1.13.0
 	cloud.google.com/go/monitoring v1.22.1
 	cloud.google.com/go/trace v1.11.3
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.51.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.51.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.51.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.52.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.52.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.52.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.52.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.120.1
@@ -38,7 +38,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/longrunning v0.6.4 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.28.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
@@ -452,7 +452,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
@@ -407,7 +407,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -457,7 +457,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
@@ -179,7 +179,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
@@ -27,7 +27,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
@@ -180,7 +180,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
@@ -44,7 +44,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -777,7 +777,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
@@ -772,7 +772,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
@@ -128,7 +128,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_user_agent_expected.json
@@ -128,7 +128,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "custom-user-agent 0.51.0 grpc-go/1.70.0",
+  "userAgent": "custom-user-agent 0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/batching_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/batching_expect.json
@@ -8884,5 +8884,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/bms_ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/bms_ops_agent_host_metrics_expect.json
@@ -3172,5 +3172,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/boolean_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/boolean_gauge_expect.json
@@ -703,5 +703,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_compressed_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_compressed_expect.json
@@ -645,5 +645,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_expect.json
@@ -645,5 +645,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_gmp_expect.json
@@ -657,5 +657,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_unknown_domain_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_unknown_domain_expect.json
@@ -645,5 +645,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_user_agent_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_user_agent_expect.json
@@ -653,5 +653,5 @@
       }
     ]
   },
-  "userAgent": "custom-user-agent grpc-go/1.70.0"
+  "userAgent": "custom-user-agent grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_deadline_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_deadline_expect.json
@@ -1063,5 +1063,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_expect.json
@@ -645,5 +645,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_unavailable_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_unavailable_expect.json
@@ -1063,5 +1063,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_workloadgoogleapis_prefix_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_workloadgoogleapis_prefix_expect.json
@@ -645,5 +645,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_expect.json
@@ -623,5 +623,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_wal_expect.json
@@ -623,5 +623,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_expect.json
@@ -645,5 +645,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_gmp_expect.json
@@ -657,5 +657,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
@@ -821,5 +821,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
@@ -827,5 +827,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_expect.json
@@ -673,5 +673,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_gmp_expect.json
@@ -687,5 +687,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_control_plane_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_control_plane_expect.json
@@ -1653,5 +1653,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_metrics_agent_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_metrics_agent_expect.json
@@ -4637,5 +4637,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -1565,5 +1565,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -925,5 +925,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -925,5 +925,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/multi_project_expected.json
@@ -1642,5 +1642,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_expect.json
@@ -644,5 +644,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_gmp_expect.json
@@ -656,5 +656,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_host_metrics_expect.json
@@ -3740,5 +3740,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_self_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_self_metrics_expect.json
@@ -647,5 +647,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
@@ -863,5 +863,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
@@ -1119,5 +1119,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
@@ -1119,5 +1119,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
@@ -1119,5 +1119,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_expect.json
@@ -804,5 +804,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_gmp_expect.json
@@ -785,5 +785,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
@@ -641,5 +641,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_gmp_expect.json
@@ -686,5 +686,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/with_resource_filter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/with_resource_filter_expect.json
@@ -665,5 +665,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/workload_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/workload_metrics_expect.json
@@ -6994,5 +6994,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0"
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -228,7 +228,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -412,7 +412,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -596,7 +596,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -765,7 +765,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -895,7 +895,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1025,7 +1025,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1155,7 +1155,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1271,7 +1271,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1372,7 +1372,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1473,7 +1473,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1574,7 +1574,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1704,7 +1704,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1888,7 +1888,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2072,7 +2072,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2241,7 +2241,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2376,7 +2376,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2511,7 +2511,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2646,7 +2646,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2767,7 +2767,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2859,7 +2859,7 @@
       ]
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.51.0 grpc-go/1.70.0",
+  "userAgent": "GoogleCloudExporter Integration Test/0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -228,7 +228,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -412,7 +412,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -596,7 +596,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -765,7 +765,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -895,7 +895,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1025,7 +1025,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1155,7 +1155,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1271,7 +1271,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1372,7 +1372,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1473,7 +1473,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1574,7 +1574,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1704,7 +1704,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1888,7 +1888,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2072,7 +2072,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2241,7 +2241,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2376,7 +2376,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2511,7 +2511,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2646,7 +2646,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2767,7 +2767,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.34.0; google-cloud-trace-exporter 1.27.0"
+                  "value": "opentelemetry-go 1.36.0; google-cloud-trace-exporter 1.28.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2859,7 +2859,7 @@
       ]
     }
   ],
-  "userAgent": "custom-user-agent 0.51.0 grpc-go/1.70.0",
+  "userAgent": "custom-user-agent 0.52.0 grpc-go/1.72.2",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/version.go
+++ b/exporter/collector/version.go
@@ -17,5 +17,5 @@ package collector
 // Version is the current release version of the OpenTelemetry
 // Operations Collector Exporter in use.
 func Version() string {
-	return "0.51.0"
+	return "0.52.0"
 }

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 require (
 	cloud.google.com/go/monitoring v1.22.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0
 	github.com/googleapis/gax-go/v2 v2.14.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.31.0
@@ -21,7 +21,7 @@ require (
 )
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.52.0
 	go.opentelemetry.io/otel/trace v1.31.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422
 )

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.51.0"
+	return "0.52.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -4,8 +4,8 @@ go 1.23.8
 
 require (
 	cloud.google.com/go/trace v1.11.3
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.51.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.52.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.27.0"
+	return "1.28.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.27.0"
-	unstable = "0.51.0"
+	stable   = "1.28.0"
+	unstable = "0.52.0"
 )
 
 var stableModules = map[string]struct{}{


### PR DESCRIPTION
Prepare for new release. Notable changes: 
 - The googleauthextension allows Project ID override using environment variable.