### PR TITLE
log project name when metric requests fail

### DIFF
--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -483,7 +483,10 @@ func (me *MetricsExporter) export(ctx context.Context, req *monitoringpb.CreateT
 			metricapi.WithAttributes(attribute.String("status", st)),
 		)
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to export metrics to %v: %w", req.Name, err)
+	}
+	return nil
 }
 
 func statusCodeToString(s *status.Status) string {


### PR DESCRIPTION
context: https://cloud-native.slack.com/archives/C043XTR0JHF/p1752179465718289

`req.Name` is `projects/<project name>`