### PR TITLE
Add feature gate to allow sending log trace context without a prefix

### DIFF
--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.120.0
 	go.opentelemetry.io/collector/confmap v1.42.0
 	go.opentelemetry.io/collector/exporter v1.42.0
+	go.opentelemetry.io/collector/featuregate v1.42.0
 	go.opentelemetry.io/collector/pdata v1.42.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0
@@ -67,7 +68,6 @@ require (
 	github.com/tidwall/tinylru v1.2.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/consumer v1.42.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.42.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.136.0 // indirect
 	go.opentelemetry.io/collector/pipeline v1.42.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.13.0 // indirect


### PR DESCRIPTION
Logging may support such a format in the future, so add this so it can be used if needed.