### PR TITLE
[exporter/collector/logs] Support `httpRequest.status` field as integer or string containing an integer.

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -598,7 +598,7 @@ func (f *IntOrString) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &str); err == nil {
 		integer, err := strconv.ParseInt(strings.TrimSpace(str), 10, 32)
 		if err != nil {
-			return fmt.Errorf("failed to convert quoted string to int: %w", err)
+			return fmt.Errorf("failed to convert string number to int32: %w", err)
 		}
 		*f = IntOrString(integer)
 		return nil

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -267,6 +267,46 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
+			name: "log with httpRequest attribute unsupported type",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyMap().PutStr("message", "hello!")
+				log.Attributes().PutBool(HTTPRequestAttributeKey, true)
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
+					}}},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with timestamp",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.SetTimestamp(pcommon.NewTimestampFromTime(testSampleTime))
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testSampleTime),
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
 			name: "log with empty timestamp, but set observed_time",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/1062 .