### PR TITLE
[chore] Pre-release steps for `opentelemetry-operations-go` repo release.

### DIFF
--- a/e2e-test-server/cloud_functions/go.mod
+++ b/e2e-test-server/cloud_functions/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	cloud.google.com/go/pubsub/v2 v2.0.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.9.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/e2e-test-server v0.55.0
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 )
 
@@ -19,9 +19,9 @@ require (
 	cloud.google.com/go/functions v1.19.7 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/trace v1.11.6 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.30.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/e2e-test-server/go.mod
+++ b/e2e-test-server/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.0.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.30.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0
@@ -21,8 +21,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/trace v1.11.6 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/example/log/slogbridge/go.mod
+++ b/example/log/slogbridge/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/example/metric/exponential_histogram/go.mod
+++ b/example/metric/exponential_histogram/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0
@@ -19,8 +19,8 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/example/metric/otlpgrpc/go.mod
+++ b/example/metric/otlpgrpc/go.mod
@@ -16,7 +16,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/example/metric/sdk/go.mod
+++ b/example/metric/sdk/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0
@@ -18,8 +18,8 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/example/trace/http/go.mod
+++ b/example/trace/http/go.mod
@@ -5,8 +5,8 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.30.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.55.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0
@@ -18,7 +18,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/trace v1.11.6 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -8,8 +8,8 @@ require (
 	cloud.google.com/go/logging v1.13.0
 	cloud.google.com/go/monitoring v1.24.2
 	cloud.google.com/go/trace v1.11.6
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.30.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-cmp v0.7.0
 	github.com/googleapis/gax-go/v2 v2.15.0

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -8,11 +8,11 @@ require (
 	cloud.google.com/go/logging v1.13.0
 	cloud.google.com/go/monitoring v1.24.2
 	cloud.google.com/go/trace v1.11.6
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.54.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.54.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.54.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.55.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.55.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/otlptranslator v1.0.0
@@ -40,7 +40,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.30.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
@@ -452,7 +452,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
@@ -407,7 +407,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -457,7 +457,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
@@ -179,7 +179,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
@@ -27,7 +27,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
@@ -180,7 +180,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
@@ -44,7 +44,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -777,7 +777,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
@@ -772,7 +772,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
@@ -128,7 +128,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_user_agent_expected.json
@@ -128,7 +128,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "custom-user-agent 0.54.0 grpc-go/1.75.1",
+  "userAgent": "custom-user-agent 0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/batching_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/batching_expect.json
@@ -9095,5 +9095,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/bms_ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/bms_ops_agent_host_metrics_expect.json
@@ -3241,5 +3241,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/boolean_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/boolean_gauge_expect.json
@@ -709,5 +709,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_compressed_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_compressed_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_gmp_expect.json
@@ -664,5 +664,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_unknown_domain_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_unknown_domain_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_deadline_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_deadline_expect.json
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_unavailable_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_unavailable_expect.json
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_workloadgoogleapis_prefix_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_workloadgoogleapis_prefix_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_expect.json
@@ -630,5 +630,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_wal_expect.json
@@ -630,5 +630,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_gmp_expect.json
@@ -664,5 +664,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
@@ -829,5 +829,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
@@ -835,5 +835,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_expect.json
@@ -679,5 +679,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_gmp_expect.json
@@ -693,5 +693,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_control_plane_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_control_plane_expect.json
@@ -1694,5 +1694,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_metrics_agent_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_metrics_agent_expect.json
@@ -4786,5 +4786,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -1584,5 +1584,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -931,5 +931,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -931,5 +931,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/multi_project_expected.json
@@ -1658,5 +1658,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_expect.json
@@ -651,5 +651,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_gmp_expect.json
@@ -663,5 +663,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_host_metrics_expect.json
@@ -3852,5 +3852,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_self_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_self_metrics_expect.json
@@ -655,5 +655,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
@@ -874,5 +874,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
@@ -1130,5 +1130,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
@@ -1130,5 +1130,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
@@ -1130,5 +1130,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_expect.json
@@ -815,5 +815,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_gmp_expect.json
@@ -796,5 +796,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
@@ -647,5 +647,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_gmp_expect.json
@@ -692,5 +692,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/with_resource_filter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/with_resource_filter_expect.json
@@ -672,5 +672,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/workload_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/workload_metrics_expect.json
@@ -7202,5 +7202,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -228,7 +228,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -412,7 +412,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -596,7 +596,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -765,7 +765,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -895,7 +895,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1025,7 +1025,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1155,7 +1155,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1271,7 +1271,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1372,7 +1372,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1473,7 +1473,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1574,7 +1574,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1704,7 +1704,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1888,7 +1888,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2072,7 +2072,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2241,7 +2241,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2376,7 +2376,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2511,7 +2511,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2646,7 +2646,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2767,7 +2767,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2859,7 +2859,7 @@
       ]
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.54.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -44,7 +44,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -228,7 +228,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -412,7 +412,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -596,7 +596,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -765,7 +765,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -895,7 +895,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1025,7 +1025,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1155,7 +1155,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1271,7 +1271,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1372,7 +1372,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1473,7 +1473,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1574,7 +1574,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1704,7 +1704,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -1888,7 +1888,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2072,7 +2072,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2241,7 +2241,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2376,7 +2376,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2511,7 +2511,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2646,7 +2646,7 @@
               },
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2767,7 +2767,7 @@
             "attributeMap": {
               "g.co/agent": {
                 "stringValue": {
-                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.30.0"
+                  "value": "opentelemetry-go 1.38.0; google-cloud-trace-exporter 1.31.0"
                 }
               },
               "g.co/r/generic_node/location": {
@@ -2859,7 +2859,7 @@
       ]
     }
   ],
-  "userAgent": "custom-user-agent 0.54.0 grpc-go/1.75.1",
+  "userAgent": "custom-user-agent 0.55.0 grpc-go/1.75.1",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/version.go
+++ b/exporter/collector/version.go
@@ -17,5 +17,5 @@ package collector
 // Version is the current release version of the OpenTelemetry
 // Operations Collector Exporter in use.
 func Version() string {
-	return "0.54.0"
+	return "0.55.0"
 }

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	cloud.google.com/go/monitoring v1.24.2
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0
 	github.com/googleapis/gax-go/v2 v2.15.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
@@ -23,7 +23,7 @@ require (
 )
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0
 	go.opentelemetry.io/otel/trace v1.38.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250922171735-9219d122eba9
 )

--- a/exporter/metric/version.go
+++ b/exporter/metric/version.go
@@ -17,5 +17,5 @@ package metric
 // Version is the current release version of the OpenTelemetry
 // Operations Metric Exporter in use.
 func Version() string {
-	return "0.54.0"
+	return "0.55.0"
 }

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -6,8 +6,8 @@ toolchain go1.24.2
 
 require (
 	cloud.google.com/go/trace v1.11.6
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.54.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0

--- a/exporter/trace/version.go
+++ b/exporter/trace/version.go
@@ -17,5 +17,5 @@ package trace
 // Version is the current release version of the OpenTelemetry
 // Operations Trace Exporter in use.
 func Version() string {
-	return "1.30.0"
+	return "1.31.0"
 }

--- a/tools/release.go
+++ b/tools/release.go
@@ -29,8 +29,8 @@ import (
 const (
 	prefix = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
 
-	stable   = "1.30.0"
-	unstable = "0.54.0"
+	stable   = "1.31.0"
+	unstable = "0.55.0"
 )
 
 var stableModules = map[string]struct{}{


### PR DESCRIPTION
Set `v1.31.0/v0.55.0` version numbers.

Followed https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/RELEASING.md .