### PR TITLE
Allow providing a context to create the monitoring client

### DIFF
--- a/exporter/metric/option.go
+++ b/exporter/metric/option.go
@@ -43,8 +43,8 @@ type Option func(*options)
 type options struct {
 	// context allows you to provide a custom context for API calls.
 	//
-	// This context will be used several times: first, to create Cloud Monitoring
-	// clients, and then every time a new batch of metrics needs to be uploaded.
+	// This context will be used to create Cloud Monitoring clients, and to get
+	// application default credentials.
 	//
 	// If unset, context.Background() will be used.
 	context context.Context
@@ -211,5 +211,13 @@ func WithMonitoredResourceDescription(mrType string, mrLabels []string) func(o *
 			mrType:   mrType,
 			mrLabels: mrLabelSet,
 		}
+	}
+}
+
+// WithContext allows callers to provide a context to create clients and fetch
+// application default credentials with.
+func WithContext(ctx context.Context) func(o *options) {
+	return func(o *options) {
+		o.context = ctx
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/1095

cc @tbpg