### PR TITLE
Don't pass credentials fetched using FindDefaultCredentials

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -328,18 +328,16 @@ func generateClientOptions(ctx context.Context, clientCfg *ClientConfig, cfg *Co
 			return nil, err
 		}
 		copts = append(copts, option.WithTokenSource(tokenSource))
-	} else if !clientCfg.UseInsecure && (clientCfg.GetClientOptions == nil || len(clientCfg.GetClientOptions()) == 0) {
-		// Only add default credentials if GetClientOptions does not
-		// provide additional options since GetClientOptions could pass
-		// credentials which conflict with the default creds.
+	} else if cfg.ProjectID == "" && !clientCfg.UseInsecure && (clientCfg.GetClientOptions == nil || len(clientCfg.GetClientOptions()) == 0) {
+		// Only use the project from default credentials if
+		// GetClientOptions does not provide additional options since
+		// GetClientOptions could pass credentials which conflict with the
+		// default creds.
 		creds, err := google.FindDefaultCredentials(ctx, scopes...)
 		if err != nil {
 			return nil, fmt.Errorf("error finding default application credentials: %v", err)
 		}
-		copts = append(copts, option.WithCredentials(creds))
-		if cfg.ProjectID == "" {
-			cfg.ProjectID = creds.ProjectID
-		}
+		cfg.ProjectID = creds.ProjectID
 	}
 	if clientCfg.GRPCPoolSize > 0 {
 		copts = append(copts, option.WithGRPCConnectionPool(clientCfg.GRPCPoolSize))


### PR DESCRIPTION
We should be using https://github.com/googleapis/google-cloud-go/tree/main/auth/credentials#L141 to detect credentials, but usage of that library seems very complex, and it has a ton of options that are more geared towards client libraries.

So instead, we just stop passing the credentials we obtain from FindDefaultCredentials to the client libraries.  They will use the correct function for auth. We now only use FindDefaultCredentials as a convenience to help users that don't set a project in their configuration.  Setting the project in configuration will skip all calls to google.FindDefaultCredentials.