### PR TITLE
Add support for go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 env:
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "~1.25.5"
+  DEFAULT_GO_VERSION: "~1.26.0"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -108,7 +108,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.24.11", "1.25.5"]
+        go-version: ["1.24.11", "1.25.7", "1.26.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         arch: ["386", amd64]
         exclude:


### PR DESCRIPTION
Also, bumping the go version will fix the govulncheck CI: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/actions/runs/22316024266/job/64561050388?pr=1106