### PR TITLE
Add support for cloud run worker pools

### DIFF
--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -39,6 +39,7 @@ const (
 	GCE
 	CloudRun
 	CloudRunJob
+	CloudRunWorkerPool
 	CloudFunctions
 	AppEngineStandard
 	AppEngineFlex
@@ -58,6 +59,8 @@ func (d *Detector) CloudPlatform() Platform {
 		return CloudRun
 	case d.onCloudRunJob():
 		return CloudRunJob
+	case d.onCloudRunWorkerPool():
+		return CloudRunWorkerPool
 	case d.onAppEngineStandard():
 		return AppEngineStandard
 	case d.onAppEngine():

--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -102,6 +102,16 @@ func TestCloudPlatformCloudRunJobs(t *testing.T) {
 	assert.Equal(t, CloudRunJob, platform)
 }
 
+func TestCloudPlatformCloudRunWorkerPool(t *testing.T) {
+	d := NewTestDetector(newFakeMetadataTransport(t), &FakeOSProvider{
+		Vars: map[string]string{
+			cloudRunWorkerPoolEnv: "foo",
+		},
+	})
+	platform := d.CloudPlatform()
+	assert.Equal(t, CloudRunWorkerPool, platform)
+}
+
 func TestCloudPlatformCloudFunctions(t *testing.T) {
 	d := NewTestDetector(newFakeMetadataTransport(t), &FakeOSProvider{
 		Vars: map[string]string{

--- a/detectors/gcp/faas.go
+++ b/detectors/gcp/faas.go
@@ -28,14 +28,19 @@ const (
 	//
 	// Cloud Run jobs env vars:
 	// https://cloud.google.com/run/docs/container-contract#jobs-env-vars
-	cloudFunctionsTargetEnv  = "FUNCTION_TARGET"
-	cloudRunConfigurationEnv = "K_CONFIGURATION"
-	cloudRunJobsEnv          = "CLOUD_RUN_JOB"
-	faasServiceEnv           = "K_SERVICE"
-	faasRevisionEnv          = "K_REVISION"
-	cloudRunJobExecutionEnv  = "CLOUD_RUN_EXECUTION"
-	cloudRunJobTaskIndexEnv  = "CLOUD_RUN_TASK_INDEX"
-	regionMetadataAttr       = "instance/region"
+	//
+	// Cloud Run worker pool env vars:
+	// https://cloud.google.com/run/docs/container-contract#worker-pools-env-vars
+	cloudFunctionsTargetEnv    = "FUNCTION_TARGET"
+	cloudRunConfigurationEnv   = "K_CONFIGURATION"
+	cloudRunJobsEnv            = "CLOUD_RUN_JOB"
+	faasServiceEnv             = "K_SERVICE"
+	faasRevisionEnv            = "K_REVISION"
+	cloudRunJobExecutionEnv    = "CLOUD_RUN_EXECUTION"
+	cloudRunJobTaskIndexEnv    = "CLOUD_RUN_TASK_INDEX"
+	cloudRunWorkerPoolEnv      = "CLOUD_RUN_WORKER_POOL"
+	cloudRunWorkerPoolRevision = "CLOUD_RUN_WORKER_POOL_REVISION"
+	regionMetadataAttr         = "instance/region"
 )
 
 func (d *Detector) onCloudFunctions() bool {
@@ -53,6 +58,11 @@ func (d *Detector) onCloudRunJob() bool {
 	return found
 }
 
+func (d *Detector) onCloudRunWorkerPool() bool {
+	_, found := d.os.LookupEnv(cloudRunWorkerPoolEnv)
+	return found
+}
+
 // FaaSName returns the name of the Cloud Run, Cloud Run jobs or Cloud Functions service.
 func (d *Detector) FaaSName() (string, error) {
 	if name, found := d.os.LookupEnv(faasServiceEnv); found {
@@ -61,12 +71,18 @@ func (d *Detector) FaaSName() (string, error) {
 	if name, found := d.os.LookupEnv(cloudRunJobsEnv); found {
 		return name, nil
 	}
+	if name, found := d.os.LookupEnv(cloudRunWorkerPoolEnv); found {
+		return name, nil
+	}
 	return "", errEnvVarNotFound
 }
 
 // FaaSVersion returns the revision of the Cloud Run or Cloud Functions service.
 func (d *Detector) FaaSVersion() (string, error) {
 	if version, found := d.os.LookupEnv(faasRevisionEnv); found {
+		return version, nil
+	}
+	if version, found := d.os.LookupEnv(cloudRunWorkerPoolRevision); found {
 		return version, nil
 	}
 	return "", errEnvVarNotFound

--- a/detectors/gcp/faas.go
+++ b/detectors/gcp/faas.go
@@ -36,11 +36,11 @@ const (
 	cloudRunJobsEnv            = "CLOUD_RUN_JOB"
 	faasServiceEnv             = "K_SERVICE"
 	faasRevisionEnv            = "K_REVISION"
-	cloudRunJobExecutionEnv    = "CLOUD_RUN_EXECUTION"
-	cloudRunJobTaskIndexEnv    = "CLOUD_RUN_TASK_INDEX"
-	cloudRunWorkerPoolEnv      = "CLOUD_RUN_WORKER_POOL"
-	cloudRunWorkerPoolRevision = "CLOUD_RUN_WORKER_POOL_REVISION"
-	regionMetadataAttr         = "instance/region"
+	cloudRunJobExecutionEnv = "CLOUD_RUN_EXECUTION"
+	cloudRunJobTaskIndexEnv = "CLOUD_RUN_TASK_INDEX"
+	cloudRunWorkerPoolEnv   = "CLOUD_RUN_WORKER_POOL"
+	cloudRunRevisionEnv     = "CLOUD_RUN_REVISION"
+	regionMetadataAttr      = "instance/region"
 )
 
 func (d *Detector) onCloudFunctions() bool {
@@ -79,10 +79,12 @@ func (d *Detector) FaaSName() (string, error) {
 
 // FaaSVersion returns the revision of the Cloud Run or Cloud Functions service.
 func (d *Detector) FaaSVersion() (string, error) {
-	if version, found := d.os.LookupEnv(faasRevisionEnv); found {
-		return version, nil
+	if d.onCloudRunWorkerPool() {
+		if version, found := d.os.LookupEnv(cloudRunRevisionEnv); found {
+			return version, nil
+		}
 	}
-	if version, found := d.os.LookupEnv(cloudRunWorkerPoolRevision); found {
+	if version, found := d.os.LookupEnv(faasRevisionEnv); found {
 		return version, nil
 	}
 	return "", errEnvVarNotFound

--- a/detectors/gcp/faas.go
+++ b/detectors/gcp/faas.go
@@ -79,10 +79,8 @@ func (d *Detector) FaaSName() (string, error) {
 
 // FaaSVersion returns the revision of the Cloud Run or Cloud Functions service.
 func (d *Detector) FaaSVersion() (string, error) {
-	if d.onCloudRunWorkerPool() {
-		if version, found := d.os.LookupEnv(cloudRunRevisionEnv); found {
-			return version, nil
-		}
+	if version, found := d.os.LookupEnv(cloudRunRevisionEnv); found {
+		return version, nil
 	}
 	if version, found := d.os.LookupEnv(faasRevisionEnv); found {
 		return version, nil

--- a/detectors/gcp/faas_test.go
+++ b/detectors/gcp/faas_test.go
@@ -43,6 +43,17 @@ func TestFaaSJobsName(t *testing.T) {
 	assert.Equal(t, "my-service", name)
 }
 
+func TestFaaSWorkerPoolName(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataTransport{}, &FakeOSProvider{
+		Vars: map[string]string{
+			cloudRunWorkerPoolEnv: "my-service",
+		},
+	})
+	name, err := d.FaaSName()
+	assert.NoError(t, err)
+	assert.Equal(t, "my-service", name)
+}
+
 func TestFaaSNameErr(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataTransport{}, &FakeOSProvider{
 		Vars: map[string]string{},
@@ -56,6 +67,17 @@ func TestFaaSVersion(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataTransport{}, &FakeOSProvider{
 		Vars: map[string]string{
 			faasRevisionEnv: "version-123",
+		},
+	})
+	version, err := d.FaaSVersion()
+	assert.NoError(t, err)
+	assert.Equal(t, "version-123", version)
+}
+
+func TestFaaSWorkerPoolVersion(t *testing.T) {
+	d := NewTestDetector(&FakeMetadataTransport{}, &FakeOSProvider{
+		Vars: map[string]string{
+			cloudRunWorkerPoolRevision: "version-123",
 		},
 	})
 	version, err := d.FaaSVersion()

--- a/detectors/gcp/faas_test.go
+++ b/detectors/gcp/faas_test.go
@@ -77,7 +77,8 @@ func TestFaaSVersion(t *testing.T) {
 func TestFaaSWorkerPoolVersion(t *testing.T) {
 	d := NewTestDetector(&FakeMetadataTransport{}, &FakeOSProvider{
 		Vars: map[string]string{
-			cloudRunWorkerPoolRevision: "version-123",
+			cloudRunWorkerPoolEnv: "my-pool",
+			cloudRunRevisionEnv:   "version-123",
 		},
 	})
 	version, err := d.FaaSVersion()


### PR DESCRIPTION
https://docs.cloud.google.com/run/docs/container-contract#worker-pools-env-vars

* CLOUD_RUN_WORKER_POOL -> faas.name
* CLOUD_RUN_REVISION -> faas.version
* instance id from metadata server -> faas.instance
* region from metadata server -> cloud.region

This is similar to the standard cloud run service, except CLOUD_RUN_WORKER_POOL instead of K_SERVICE and CLOUD_RUN_REVISION instead of K_REVISION.

### Verification
Deployed a test workload to Cloud Run worker pools and verified the environment variables:
* `CLOUD_RUN_WORKER_POOL` is set to the worker pool name.
* `CLOUD_RUN_REVISION` is set to the revision name.
* `CLOUD_RUN_WORKER_POOL_REVISION` is NOT set.