### PR TITLE
Ignore versions in the user agent header when comparing fixtures

### DIFF
--- a/exporter/collector/integrationtest/testcases/exporter_settings.go
+++ b/exporter/collector/integrationtest/testcases/exporter_settings.go
@@ -16,6 +16,7 @@ package testcases
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -26,6 +27,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 )
+
+var versionRegex = regexp.MustCompile(`\b\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?\b`)
 
 func NewTestExporterSettings(logger *zap.Logger, meterProvider metric.MeterProvider) exporter.Settings {
 	return exporter.Settings{
@@ -47,5 +50,6 @@ func SetTestUserAgent(cfg *collector.Config, buildInfo component.BuildInfo) {
 
 func UserAgentRemoveRuntimeInfo(userAgent string) string {
 	runtimeInfo := fmt.Sprintf(" (%s/%s)", runtime.GOOS, runtime.GOARCH)
-	return strings.ReplaceAll(userAgent, runtimeInfo, "")
+	ua := strings.ReplaceAll(userAgent, runtimeInfo, "")
+	return versionRegex.ReplaceAllString(ua, "{{version}}")
 }

--- a/exporter/collector/integrationtest/testcases/testcase.go
+++ b/exporter/collector/integrationtest/testcases/testcase.go
@@ -155,6 +155,7 @@ func (tc *TestCase) SaveRecordedTraceFixtures(
 }
 
 func NormalizeTraceFixture(t testing.TB, fixture *protos.TraceExpectFixture) {
+	fixture.UserAgent = UserAgentRemoveRuntimeInfo(fixture.UserAgent)
 	normalizeSelfObs(t, fixture.SelfObservabilityMetrics)
 	for _, req := range fixture.BatchWriteSpansRequest {
 		for _, span := range req.Spans {
@@ -252,6 +253,7 @@ func (tc *TestCase) SaveRecordedLogFixtures(
 // Normalizes timestamps which create noise in the fixture because they can
 // vary each test run.
 func NormalizeLogFixture(t testing.TB, fixture *protos.LogExpectFixture) {
+	fixture.UserAgent = UserAgentRemoveRuntimeInfo(fixture.UserAgent)
 	normalizeSelfObs(t, fixture.SelfObservabilityMetrics)
 	for listIndex, req := range fixture.WriteLogEntriesRequests {
 		// sort the entries in each request
@@ -419,6 +421,7 @@ func (tc *TestCase) SaveRecordedMetricFixtures(
 // Normalizes timestamps which create noise in the fixture because they can
 // vary each test run.
 func NormalizeMetricFixture(t testing.TB, fixture *protos.MetricExpectFixture) {
+	fixture.UserAgent = UserAgentRemoveRuntimeInfo(fixture.UserAgent)
 	normalizeTimeSeriesReqs(t, fixture.CreateTimeSeriesRequests...)
 	normalizeTimeSeriesReqs(t, fixture.CreateServiceTimeSeriesRequests...)
 	normalizeMetricDescriptorReqs(t, fixture.CreateMetricDescriptorRequests...)

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_batches_expected.json
@@ -452,7 +452,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_expected.json
@@ -407,7 +407,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_access_resource_attributes_expected.json
@@ -457,7 +457,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_expected.json
@@ -179,7 +179,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_error_scope_expected.json
@@ -27,7 +27,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_json_error_reporting_expected.json
@@ -180,7 +180,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_apache_text_error_reporting_expected.json
@@ -44,7 +44,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_destination_quota_expected.json
@@ -777,7 +777,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_multi_project_expected.json
@@ -772,7 +772,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_span_trace_id_expected.json
@@ -128,7 +128,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/logs/logs_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/logs/logs_user_agent_expected.json
@@ -128,7 +128,7 @@
       "partialSuccess": true
     }
   ],
-  "userAgent": "custom-user-agent 0.55.0 grpc-go/1.75.1",
+  "userAgent": "custom-user-agent {{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/batching_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/batching_expect.json
@@ -9095,5 +9095,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/bms_ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/bms_ops_agent_host_metrics_expect.json
@@ -3241,5 +3241,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/boolean_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/boolean_gauge_expect.json
@@ -709,5 +709,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_compressed_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_compressed_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_gmp_expect.json
@@ -664,5 +664,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_unknown_domain_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_unknown_domain_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_user_agent_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_user_agent_expect.json
@@ -660,5 +660,5 @@
       }
     ]
   },
-  "userAgent": "custom-user-agent grpc-go/1.75.1"
+  "userAgent": "custom-user-agent grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_deadline_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_deadline_expect.json
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_unavailable_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_wal_unavailable_expect.json
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_workloadgoogleapis_prefix_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/counter_workloadgoogleapis_prefix_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_expect.json
@@ -630,5 +630,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/create_service_timeseries_wal_expect.json
@@ -630,5 +630,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_expect.json
@@ -652,5 +652,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/delta_counter_gmp_expect.json
@@ -664,5 +664,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_expect.json
@@ -829,5 +829,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/exponential_histogram_gmp_expect.json
@@ -835,5 +835,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_expect.json
@@ -679,5 +679,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gauge_gmp_expect.json
@@ -693,5 +693,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_control_plane_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_control_plane_expect.json
@@ -1694,5 +1694,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_metrics_agent_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/gke_metrics_agent_expect.json
@@ -4786,5 +4786,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/google_managed_prometheus_expect.json
@@ -1584,5 +1584,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_expect.json
@@ -931,5 +931,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/histogram_gmp_expect.json
@@ -931,5 +931,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/multi_project_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/multi_project_expected.json
@@ -1658,5 +1658,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_expect.json
@@ -651,5 +651,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/nonmonotonic_counter_gmp_expect.json
@@ -663,5 +663,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_host_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_host_metrics_expect.json
@@ -3852,5 +3852,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_self_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/ops_agent_self_metrics_expect.json
@@ -655,5 +655,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_empty_buckets_expected.json
@@ -874,5 +874,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_expect.json
@@ -1130,5 +1130,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_stale_expect.json
@@ -1130,5 +1130,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/prometheus_wal_expect.json
@@ -1130,5 +1130,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_expect.json
@@ -815,5 +815,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/summary_gmp_expect.json
@@ -796,5 +796,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_expect.json
@@ -647,5 +647,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_gmp_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/untyped_gauge_gmp_expect.json
@@ -692,5 +692,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/with_resource_filter_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/with_resource_filter_expect.json
@@ -672,5 +672,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/metrics/workload_metrics_expect.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/metrics/workload_metrics_expect.json
@@ -7202,5 +7202,5 @@
       }
     ]
   },
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1"
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}"
 }

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_basic_expected.json
@@ -2859,7 +2859,7 @@
       ]
     }
   ],
-  "userAgent": "GoogleCloudExporter Integration Test/0.55.0 grpc-go/1.75.1",
+  "userAgent": "GoogleCloudExporter Integration Test/{{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {

--- a/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
+++ b/exporter/collector/integrationtest/testdata/fixtures/traces/traces_user_agent_expected.json
@@ -2859,7 +2859,7 @@
       ]
     }
   ],
-  "userAgent": "custom-user-agent 0.55.0 grpc-go/1.75.1",
+  "userAgent": "custom-user-agent {{version}} grpc-go/{{version}}",
   "selfObservabilityMetrics": {
     "createTimeSeriesRequests": [
       {


### PR DESCRIPTION
This should allow version bumps for libraries (e.g. grpc, or this exporter) to not need fixtures regenerated, and make renovate PRs more likely to pass.