### PR TITLE
Combine dependency bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,26 +21,8 @@
         "enabled": false
       },
       {
-        "matchPackageNames": ["google.golang.org/**"],
-        "groupName": "google.golang.org"
-      },
-      {
-        "matchPackageNames": ["golang.org/x/**"],
-        "groupName": "golang.org/x"
-      },
-      {
-        "matchPackageNames": ["cloud.google.com/**"],
-        "groupName": "cloud.google.com"
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/collector/**", "github.com/open-telemetry/opentelemetry-collector-contrib/**"],
-        "groupName": "go.opentelemetry.io/collector"
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchPackageNames": ["go.opentelemetry.io/otel", "go.opentelemetry.io/otel/**", "go.opentelemetry.io/contrib/**"],
-        "groupName": "go.opentelemetry.io/otel"
+        "matchPackageNames": ["*"],
+        "groupName": "All Dependencies"
       }
     ]
   }


### PR DESCRIPTION
It is too much work to manage individual updates with testing and rebasing.  Instead, make renovate generate one giant update PR each week. I can use gemini to fix that if it gets stuck.