### PR TITLE
Fix CodeQL permissions to allow uploading results

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,8 @@
 name: "CodeQL Analysis"
-permissions: read-all
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Example failure shows it doesn't have permissions to upload: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/actions/runs/26172320948