### PR TITLE
Migrate impersonate to use cloud.google.com/go/auth

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/impersonate"
+	"cloud.google.com/go/auth/credentials/impersonate"
 	"google.golang.org/api/option"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
@@ -318,16 +318,17 @@ func generateClientOptions(ctx context.Context, clientCfg *ClientConfig, cfg *Co
 			}
 			cfg.ProjectID = creds.ProjectID
 		}
-		tokenSource, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		creds, err := impersonate.NewCredentials(&impersonate.CredentialsOptions{
 			TargetPrincipal: cfg.ImpersonateConfig.TargetPrincipal,
 			Delegates:       cfg.ImpersonateConfig.Delegates,
 			Subject:         cfg.ImpersonateConfig.Subject,
 			Scopes:          scopes,
+			UniverseDomain:  clientCfg.UniverseDomain,
 		})
 		if err != nil {
 			return nil, err
 		}
-		copts = append(copts, option.WithTokenSource(tokenSource))
+		copts = append(copts, option.WithAuthCredentials(creds))
 	} else if cfg.ProjectID == "" && !clientCfg.UseInsecure && (clientCfg.GetClientOptions == nil || len(clientCfg.GetClientOptions()) == 0) {
 		// Only use the project from default credentials if
 		// GetClientOptions does not provide additional options since

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.26.3
 
 require (
+	cloud.google.com/go/auth v0.20.0
 	cloud.google.com/go/logging v1.18.0
 	cloud.google.com/go/monitoring v1.29.0
 	cloud.google.com/go/trace v1.16.0
@@ -38,7 +39,6 @@ require (
 
 require (
 	cloud.google.com/go v0.123.0 // indirect
-	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/longrunning v1.0.0 // indirect


### PR DESCRIPTION
## Summary
Migrates the impersonation logic in `exporter/collector` to use `cloud.google.com/go/auth/credentials/impersonate`. This supports universe domains correctly.
Fixes #1168

## Testing
Manual verification was performed as follows:
1. Created a service account with restricted permissions (e.g., `Monitoring Metric Writer`).
2. Granted `Service Account Token Creator` role to the calling user on that service account.
3. Created a test that calls `generateClientOptions` with impersonation config.
4. Verified that a call made with the resulting client failed with `PermissionDenied` for a read operation (e.g., `ListMetricDescriptors`), confirming the restricted identity was used.
Unit tests and integration tests in `exporter/collector` were also run and passed.