### PR TITLE
chore: update E2E tests to use centralized async cleanup 0.22.0

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -30,14 +30,19 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-cloudfunction
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - cloud-functions-gen2
       - --runtime=go123
       - --functionsource=/workspace/e2e-test-server/cloud_functions/function-source.zip
       - --entrypoint=HandleCloudFunction
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -27,12 +27,17 @@ steps:
     id: run-tests-cloudrun
     dir: /
     timeout: 10m
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - cloud-run
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -30,12 +30,17 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gae-standard
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gae-standard
       - --runtime=go125
       - --appsource=/workspace/e2e-test-server/appsource.zip
+      - --skip-cleanup
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -26,13 +26,18 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gae
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gae
       - --image=$_TEST_SERVER_IMAGE
       - --runtime=go125
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -26,12 +26,17 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gce
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -25,12 +25,17 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gke
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gke
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -32,13 +32,18 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-local
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - local
       - --image=$_TEST_SERVER_IMAGE
       - --network=cloudbuild
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.21.0
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-go-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup


### PR DESCRIPTION
Updates E2E test configurations to use the new centralized async cleanup mechanism introduced in e2e-testing 0.22.0. See https://github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/pull/109 for details.