### PR TITLE
Adds support for resolving OpenTelemetry authentication extensions

### DIFF
--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -15,28 +15,28 @@
 package collector
 
 import (
-	"cloud.google.com/go/auth/credentials/impersonate"
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"cloud.google.com/go/auth/credentials/impersonate"
 	"google.golang.org/api/option"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 	otelgrpc "google.golang.org/grpc/stats/opentelemetry"
-	"regexp"
-	"runtime"
-	"strings"
-	"time"
-
-	"google3/third_party/golang/grpc/credentials/credentials"
-	"google3/third_party/golang/oauth2/oauth2"
 )
 
 const (
@@ -60,16 +60,20 @@ type Config struct {
 	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
 }
 
-type tokenSourceProvider interface {
-	TokenSource() oauth2.TokenSource
-}
-
 type clientOptionProvider interface {
 	ClientOptions() []option.ClientOption
 }
 
-type perRPCCredentialsProvider interface {
-	PerRPCCredentials() (credentials.PerRPCCredentials, error)
+type contextTokenSourceProvider interface {
+	Token(context.Context) (*oauth2.Token, error)
+}
+
+type googleApiContextSourceWrapper struct {
+	ts contextTokenSourceProvider
+}
+
+func (w *googleApiContextSourceWrapper) Token() (*oauth2.Token, error) {
+	return w.ts.Token(context.Background())
 }
 
 // getAuthenticatorClientOptions resolves an authentication extension in host.GetExtensions() by name
@@ -94,13 +98,13 @@ func getAuthenticatorClientOptions(host component.Host, authenticatorName string
 	if cop, ok := ext.(clientOptionProvider); ok && len(cop.ClientOptions()) > 0 {
 		return cop.ClientOptions(), nil
 	}
-	if tsProv, ok := ext.(tokenSourceProvider); ok && tsProv.TokenSource() != nil {
-		return []option.ClientOption{option.WithTokenSource(tsProv.TokenSource())}, nil
+	if ctxTS, ok := ext.(contextTokenSourceProvider); ok {
+		return []option.ClientOption{option.WithTokenSource(&googleApiContextSourceWrapper{ts: ctxTS})}, nil
 	}
 	if directTS, ok := ext.(oauth2.TokenSource); ok {
 		return []option.ClientOption{option.WithTokenSource(directTS)}, nil
 	}
-	if grpcProv, ok := ext.(perRPCCredentialsProvider); ok {
+	if grpcProv, ok := ext.(extensionauth.GRPCClient); ok {
 		creds, err := grpcProv.PerRPCCredentials()
 		if err != nil {
 			return nil, fmt.Errorf("authenticator extension %q failed to produce PerRPCCredentials: %w", authenticatorName, err)

--- a/exporter/collector/config.go
+++ b/exporter/collector/config.go
@@ -15,26 +15,28 @@
 package collector
 
 import (
+	"cloud.google.com/go/auth/credentials/impersonate"
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
-	"runtime"
-	"strings"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/oauth2/google"
-	"cloud.google.com/go/auth/credentials/impersonate"
 	"google.golang.org/api/option"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 	otelgrpc "google.golang.org/grpc/stats/opentelemetry"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"google3/third_party/golang/grpc/credentials/credentials"
+	"google3/third_party/golang/oauth2/oauth2"
 )
 
 const (
@@ -43,6 +45,9 @@ const (
 
 // Config defines configuration for Google Cloud exporter.
 type Config struct {
+	// Authenticator specifies an extension name to obtain client options from.
+	Authenticator string `mapstructure:"authenticator"`
+
 	// ProjectID is the project telemetry is sent to if the gcp.project.id
 	// resource attribute is not set. If unspecified, this is determined using
 	// application default credentials.
@@ -53,6 +58,56 @@ type Config struct {
 	LogConfig               LogConfig         `mapstructure:"log"`
 	MetricConfig            MetricConfig      `mapstructure:"metric"`
 	DestinationProjectQuota bool              `mapstructure:"destination_project_quota"`
+}
+
+type tokenSourceProvider interface {
+	TokenSource() oauth2.TokenSource
+}
+
+type clientOptionProvider interface {
+	ClientOptions() []option.ClientOption
+}
+
+type perRPCCredentialsProvider interface {
+	PerRPCCredentials() (credentials.PerRPCCredentials, error)
+}
+
+// getAuthenticatorClientOptions resolves an authentication extension in host.GetExtensions() by name
+// and converts its credentials into GCP option.ClientOption values.
+func getAuthenticatorClientOptions(host component.Host, authenticatorName string) ([]option.ClientOption, error) {
+	if authenticatorName == "" || host == nil {
+		return nil, nil
+	}
+	var extID component.ID
+	if err := extID.UnmarshalText([]byte(authenticatorName)); err != nil {
+		return nil, fmt.Errorf("invalid authenticator extension ID %q: %w", authenticatorName, err)
+	}
+	ext, ok := host.GetExtensions()[extID]
+	if !ok {
+		var avail []string
+		for k := range host.GetExtensions() {
+			avail = append(avail, fmt.Sprintf("%q", k.String()))
+		}
+		return nil, fmt.Errorf("authenticator extension %q (looking for ID %q) not found in host extensions; available extensions in host: [%s]", authenticatorName, extID.String(), strings.Join(avail, ", "))
+	}
+
+	if cop, ok := ext.(clientOptionProvider); ok && len(cop.ClientOptions()) > 0 {
+		return cop.ClientOptions(), nil
+	}
+	if tsProv, ok := ext.(tokenSourceProvider); ok && tsProv.TokenSource() != nil {
+		return []option.ClientOption{option.WithTokenSource(tsProv.TokenSource())}, nil
+	}
+	if directTS, ok := ext.(oauth2.TokenSource); ok {
+		return []option.ClientOption{option.WithTokenSource(directTS)}, nil
+	}
+	if grpcProv, ok := ext.(perRPCCredentialsProvider); ok {
+		creds, err := grpcProv.PerRPCCredentials()
+		if err != nil {
+			return nil, fmt.Errorf("authenticator extension %q failed to produce PerRPCCredentials: %w", authenticatorName, err)
+		}
+		return []option.ClientOption{option.WithGRPCDialOption(grpc.WithPerRPCCredentials(creds))}, nil
+	}
+	return nil, fmt.Errorf("authenticator extension %q does not implement a recognized authentication interface", authenticatorName)
 }
 
 type ClientConfig struct {

--- a/exporter/collector/config_test.go
+++ b/exporter/collector/config_test.go
@@ -15,12 +15,18 @@
 package collector
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc/credentials"
 	"gopkg.in/yaml.v3"
 )
 
@@ -128,3 +134,238 @@ func TestBuildInfoUserAgentFallback(t *testing.T) {
 		t.Fatalf("expected user agent to be %s, was %s", expectedUserAgent, config.UserAgent)
 	}
 }
+
+type mockHost struct {
+	component.Host
+	extensions map[component.ID]component.Component
+}
+
+func (m *mockHost) GetExtensions() map[component.ID]component.Component {
+	return m.extensions
+}
+
+type mockComponent struct {
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+type mockClientOptionProvider struct {
+	mockComponent
+	opts []option.ClientOption
+}
+
+func (m *mockClientOptionProvider) ClientOptions() []option.ClientOption {
+	return m.opts
+}
+
+
+type mockContextTokenSourceProvider struct {
+	mockComponent
+	ts func(context.Context) (*oauth2.Token, error)
+}
+
+func (m *mockContextTokenSourceProvider) Token(ctx context.Context) (*oauth2.Token, error) {
+	return m.ts(ctx)
+}
+
+type mockDirectTokenSource struct {
+	mockComponent
+	token *oauth2.Token
+	err   error
+}
+
+func (m *mockDirectTokenSource) Token() (*oauth2.Token, error) {
+	return m.token, m.err
+}
+
+type mockGRPCClient struct {
+	mockComponent
+	creds credentials.PerRPCCredentials
+	err   error
+}
+
+func (m *mockGRPCClient) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+	return m.creds, m.err
+}
+
+type mockUnrecognized struct {
+	mockComponent
+}
+
+type fakeCredentials struct {
+	credentials.PerRPCCredentials
+}
+
+func TestGetAuthenticatorClientOptions(t *testing.T) {
+	extID := component.MustNewID("testauth")
+	invalidID := "/testauth"
+
+	tests := []struct {
+		desc      string
+		host      component.Host
+		authName  string
+		wantCount int
+		wantErr   string
+	}{
+		{
+			desc:     "Empty auth name",
+			host:     &mockHost{},
+			authName: "",
+		},
+		{
+			desc:     "Nil host",
+			host:     nil,
+			authName: "testauth",
+		},
+		{
+			desc:     "Invalid component ID format",
+			host:     &mockHost{},
+			authName: invalidID,
+			wantErr:  "invalid authenticator extension ID",
+		},
+		{
+			desc:     "Extension not found",
+			host:     &mockHost{extensions: map[component.ID]component.Component{}},
+			authName: "testauth",
+			wantErr:  `authenticator extension "testauth" (looking for ID "testauth") not found`,
+		},
+		{
+			desc: "clientOptionProvider resolution",
+			host: &mockHost{
+				extensions: map[component.ID]component.Component{
+					extID: &mockClientOptionProvider{
+						opts: []option.ClientOption{option.WithAPIKey("fake-api-key")},
+					},
+				},
+			},
+			authName:  "testauth",
+			wantCount: 1,
+		},
+		{
+			desc: "contextTokenSourceProvider resolution",
+			host: &mockHost{
+				extensions: map[component.ID]component.Component{
+					extID: &mockContextTokenSourceProvider{
+						ts: func(ctx context.Context) (*oauth2.Token, error) {
+							return &oauth2.Token{AccessToken: "token2"}, nil
+						},
+					},
+				},
+			},
+			authName:  "testauth",
+			wantCount: 1,
+		},
+		{
+			desc: "Direct oauth2.TokenSource resolution",
+			host: &mockHost{
+				extensions: map[component.ID]component.Component{
+					extID: &mockDirectTokenSource{
+						token: &oauth2.Token{AccessToken: "token3"},
+					},
+				},
+			},
+			authName:  "testauth",
+			wantCount: 1,
+		},
+		{
+			desc: "extensionauth.GRPCClient resolution",
+			host: &mockHost{
+				extensions: map[component.ID]component.Component{
+					extID: &mockGRPCClient{
+						creds: fakeCredentials{},
+					},
+				},
+			},
+			authName:  "testauth",
+			wantCount: 1,
+		},
+		{
+			desc: "GRPCClient resolution error path",
+			host: &mockHost{
+				extensions: map[component.ID]component.Component{
+					extID: &mockGRPCClient{
+						err: errors.New("grpc failure"),
+					},
+				},
+			},
+			authName: "testauth",
+			wantErr:  "failed to produce PerRPCCredentials: grpc failure",
+		},
+		{
+			desc: "Unrecognized interface error path",
+			host: &mockHost{
+				extensions: map[component.ID]component.Component{
+					extID: &mockUnrecognized{},
+				},
+			},
+			authName: "testauth",
+			wantErr:  "does not implement a recognized authentication interface",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			opts, err := getAuthenticatorClientOptions(tt.host, tt.authName)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(opts) != tt.wantCount {
+				t.Fatalf("expected %d options, got %d", tt.wantCount, len(opts))
+			}
+		})
+	}
+}
+
+func TestGoogleApiContextSourceWrapper(t *testing.T) {
+	expectedToken := &oauth2.Token{AccessToken: "wrapped-token-value"}
+	expectedErr := errors.New("token retrieval error")
+
+	tests := []struct {
+		desc      string
+		ts        contextTokenSourceProvider
+		wantToken *oauth2.Token
+		wantErr   error
+	}{
+		{
+			desc: "successful token retrieval",
+			ts: &mockContextTokenSourceProvider{
+				ts: func(ctx context.Context) (*oauth2.Token, error) {
+					return expectedToken, nil
+				},
+			},
+			wantToken: expectedToken,
+		},
+		{
+			desc: "failed token retrieval",
+			ts: &mockContextTokenSourceProvider{
+				ts: func(ctx context.Context) (*oauth2.Token, error) {
+					return nil, expectedErr
+				},
+			},
+			wantErr: expectedErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			w := &googleApiContextSourceWrapper{ts: tt.ts}
+			tok, err := w.Token()
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+			if tok != tt.wantToken {
+				t.Fatalf("expected token %v, got %v", tt.wantToken, tok)
+			}
+		})
+	}
+}
+

--- a/exporter/collector/go.mod
+++ b/exporter/collector/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.152.1
 	go.opentelemetry.io/collector/confmap v1.58.0
 	go.opentelemetry.io/collector/exporter v1.58.0
+	go.opentelemetry.io/collector/extension/extensionauth v1.62.0
 	go.opentelemetry.io/collector/featuregate v1.58.0
 	go.opentelemetry.io/collector/pdata v1.58.0
 	go.opentelemetry.io/otel v1.43.0
@@ -32,7 +33,7 @@ require (
 	google.golang.org/api v0.280.0
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94
 	google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/exporter/collector/go.sum
+++ b/exporter/collector/go.sum
@@ -149,6 +149,8 @@ go.opentelemetry.io/collector/exporter/exporterhelper v0.152.0 h1:CK4FPzhC7rtGxM
 go.opentelemetry.io/collector/exporter/exporterhelper v0.152.0/go.mod h1:PGtEq/XO0jAZ4uUOLO1xY4xh95ZoBj5uzCIjCZaGe34=
 go.opentelemetry.io/collector/extension v1.58.0 h1:dEndHFvE9XJ+A+9hpxD6cUEJxgtP9DRWgNPZVkzf2QM=
 go.opentelemetry.io/collector/extension v1.58.0/go.mod h1:eiWWL+MwUOUMD18mo01sNLic9RZlRBbQqyRs3URbh3U=
+go.opentelemetry.io/collector/extension/extensionauth v1.62.0 h1:2yhRG9OFxUSCrc+0GqgON+WKVciV65s+rrnOoWLR4V4=
+go.opentelemetry.io/collector/extension/extensionauth v1.62.0/go.mod h1:bJV7oxY/JWRDXrZDbjuv9DjU0NNNs6r+YQcYkWVzf7o=
 go.opentelemetry.io/collector/extension/xextension v0.152.0 h1:/4mPxKkxz94ntbi1Lo15BVump3iYVOXwB3z3JAKVRyM=
 go.opentelemetry.io/collector/extension/xextension v0.152.0/go.mod h1:TTmnzlfHWe9Xr5VnEdOYozGTR8wJFuZoV88LJvBTbDg=
 go.opentelemetry.io/collector/featuregate v1.58.0 h1:Kh6Dpgbxywv/Q3D6qPehaSxNCxvr/U/ki7CL4y3udCo=
@@ -221,8 +223,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:1dCETSCY2YKZNXQE3h4fun3TYwF5p8jejRKZgfWAgAY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 h1:eZCjr/aAF8c5ccm5pb6T4EXgIei5MlAAPWPJk+5ArfY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
+google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/exporter/collector/integrationtest/go.mod
+++ b/exporter/collector/integrationtest/go.mod
@@ -30,7 +30,7 @@ require (
 	go.uber.org/zap v1.28.0
 	google.golang.org/api v0.280.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -105,6 +105,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exportertest v0.152.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.152.1 // indirect
 	go.opentelemetry.io/collector/extension v1.58.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.62.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.152.1 // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.152.1 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.152.1 // indirect

--- a/exporter/collector/integrationtest/go.sum
+++ b/exporter/collector/integrationtest/go.sum
@@ -239,8 +239,8 @@ go.opentelemetry.io/collector/exporter/xexporter v0.152.1 h1:bZKtVix0xifDPcetGyC
 go.opentelemetry.io/collector/exporter/xexporter v0.152.1/go.mod h1:7jVIcYM7OL9FQAQQoJksaPpJQEJ/3lUnGGyrQf2PMfI=
 go.opentelemetry.io/collector/extension v1.58.0 h1:dEndHFvE9XJ+A+9hpxD6cUEJxgtP9DRWgNPZVkzf2QM=
 go.opentelemetry.io/collector/extension v1.58.0/go.mod h1:eiWWL+MwUOUMD18mo01sNLic9RZlRBbQqyRs3URbh3U=
-go.opentelemetry.io/collector/extension/extensionauth v1.58.0 h1:G+sYoC2yshjfAF1hdthi9xfv3kDFFAC1G1WkgYe8af0=
-go.opentelemetry.io/collector/extension/extensionauth v1.58.0/go.mod h1:1jwgMpThKn842SSTWSOti0JA+IwInkbMUJrBKhx/lW8=
+go.opentelemetry.io/collector/extension/extensionauth v1.62.0 h1:2yhRG9OFxUSCrc+0GqgON+WKVciV65s+rrnOoWLR4V4=
+go.opentelemetry.io/collector/extension/extensionauth v1.62.0/go.mod h1:bJV7oxY/JWRDXrZDbjuv9DjU0NNNs6r+YQcYkWVzf7o=
 go.opentelemetry.io/collector/extension/extensioncapabilities v0.152.1 h1:uwdodJhMFpJGQ9D3ufj0b/tWO8sniAWOyVi/vdMX4tk=
 go.opentelemetry.io/collector/extension/extensioncapabilities v0.152.1/go.mod h1:5OcuPhOc35Qe3M+3OFCDnRvv7Wcpqm307Zc6XIYhBe0=
 go.opentelemetry.io/collector/extension/extensionmiddleware v0.152.1 h1:xGpHhQhkLlVNlqTydNgWo3fn4JZECbSlNc0UulCRFK4=
@@ -390,8 +390,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:1dCETSCY2YKZNXQE3h4fun3TYwF5p8jejRKZgfWAgAY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 h1:eZCjr/aAF8c5ccm5pb6T4EXgIei5MlAAPWPJk+5ArfY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
+google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -32,6 +32,7 @@ import (
 	logpb "cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/googleapis/gax-go/v2"
 	"go.uber.org/zap"
+	"google.golang.org/api/option"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	logtypepb "google.golang.org/genproto/googleapis/logging/type"
 	"google.golang.org/grpc"
@@ -215,7 +216,7 @@ func (l *LogsExporter) ConfigureExporter(config *logsutil.ExporterConfig) {
 }
 
 func (l *LogsExporter) Start(ctx context.Context, host component.Host) error {
-	if l.cfg.Authenticator != "" {
+	if l.cfg.Authenticator != "" && l.cfg.LogConfig.ClientConfig.GetClientOptions == nil {
 		authOpts, err := getAuthenticatorClientOptions(host, l.cfg.Authenticator)
 		if err != nil {
 			return err

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -214,7 +214,16 @@ func (l *LogsExporter) ConfigureExporter(config *logsutil.ExporterConfig) {
 	}
 }
 
-func (l *LogsExporter) Start(ctx context.Context, _ component.Host) error {
+func (l *LogsExporter) Start(ctx context.Context, host component.Host) error {
+	if l.cfg.Authenticator != "" {
+		authOpts, err := getAuthenticatorClientOptions(host, l.cfg.Authenticator)
+		if err != nil {
+			return err
+		}
+		l.cfg.LogConfig.ClientConfig.GetClientOptions = func() []option.ClientOption {
+			return authOpts
+		}
+	}
 	clientOpts, err := generateClientOptions(ctx, &l.cfg.LogConfig.ClientConfig, &l.cfg, loggingv2.DefaultAuthScopes(), l.obs.meterProvider)
 	if err != nil {
 		return err

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -237,10 +237,19 @@ func NewGoogleCloudMetricsExporter(
 	return mExp, nil
 }
 
-func (me *MetricsExporter) Start(ctx context.Context, _ component.Host) error {
+func (me *MetricsExporter) Start(ctx context.Context, host component.Host) error {
 	me.shutdownC = make(chan struct{})
 	if me.cfg.MetricConfig.CumulativeNormalization {
 		me.mapper.normalizer = normalization.NewStandardNormalizer(me.shutdownC, me.obs.log)
+	}
+	if me.cfg.Authenticator != "" {
+		authOpts, err := getAuthenticatorClientOptions(host, me.cfg.Authenticator)
+		if err != nil {
+			return err
+		}
+		me.cfg.MetricConfig.ClientConfig.GetClientOptions = func() []option.ClientOption {
+			return authOpts
+		}
 	}
 	clientOpts, err := generateClientOptions(ctx, &me.cfg.MetricConfig.ClientConfig, &me.cfg, monitoring.DefaultAuthScopes(), me.obs.meterProvider)
 	if err != nil {

--- a/exporter/collector/metrics.go
+++ b/exporter/collector/metrics.go
@@ -36,6 +36,7 @@ import (
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/api/option"
 	"google.golang.org/genproto/googleapis/api/distribution"
 	"google.golang.org/genproto/googleapis/api/label"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
@@ -242,7 +243,7 @@ func (me *MetricsExporter) Start(ctx context.Context, host component.Host) error
 	if me.cfg.MetricConfig.CumulativeNormalization {
 		me.mapper.normalizer = normalization.NewStandardNormalizer(me.shutdownC, me.obs.log)
 	}
-	if me.cfg.Authenticator != "" {
+	if me.cfg.Authenticator != "" && me.cfg.MetricConfig.ClientConfig.GetClientOptions == nil {
 		authOpts, err := getAuthenticatorClientOptions(host, me.cfg.Authenticator)
 		if err != nil {
 			return err

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -61,7 +61,16 @@ func NewGoogleCloudTracesExporter(
 	return &TraceExporter{cfg: cfg, timeout: timeout, obs: obs}, nil
 }
 
-func (te *TraceExporter) Start(ctx context.Context, _ component.Host) error {
+func (te *TraceExporter) Start(ctx context.Context, host component.Host) error {
+	if te.cfg.Authenticator != "" {
+		authOpts, err := getAuthenticatorClientOptions(host, te.cfg.Authenticator)
+		if err != nil {
+			return err
+		}
+		te.cfg.TraceConfig.ClientConfig.GetClientOptions = func() []option.ClientOption {
+			return authOpts
+		}
+	}
 	topts := []texporter.Option{
 		texporter.WithProjectID(te.cfg.ProjectID),
 		texporter.WithTimeout(te.timeout),

--- a/exporter/collector/traces.go
+++ b/exporter/collector/traces.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/api/option"
 
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 )
@@ -62,7 +63,7 @@ func NewGoogleCloudTracesExporter(
 }
 
 func (te *TraceExporter) Start(ctx context.Context, host component.Host) error {
-	if te.cfg.Authenticator != "" {
+	if te.cfg.Authenticator != "" && te.cfg.TraceConfig.ClientConfig.GetClientOptions == nil {
 		authOpts, err := getAuthenticatorClientOptions(host, te.cfg.Authenticator)
 		if err != nil {
 			return err


### PR DESCRIPTION
Adds support for resolving OpenTelemetry authentication extensions in 
`opentelemetry-operations-go/exporter/collector`.

This allows `googlecloudexporter` (Metrics, Logs, and Traces) to authenticate 
against Google Cloud APIs using extensions registered in `host.GetExtensions()` 
(such as custom OAuth extensions) instead of 
relying solely on Application Default Credentials.

Key changes:
1. `Config`: Added `authenticator` string config option (`Authenticator string mapstructure:"authenticator"`).
2. Added `getAuthenticatorClientOptions` to inspect host extensions dynamically in priority order:
   - `clientOptionProvider` (`ClientOptions() []option.ClientOption`)
   - `tokenSourceProvider` (`TokenSource() oauth2.TokenSource`)
   - `oauth2.TokenSource` (`Token() (*oauth2.Token, error)`)
   - `perRPCCredentialsProvider` (`PerRPCCredentials() (credentials.PerRPCCredentials, error)`)
3. Updated `MetricsExporter.Start`, `LogsExporter.Start`, and `TraceExporter.Start` to invoke `getAuthenticatorClientOptions` before building GCP client options.