### PR TITLE
Deprecate extension/googleclientauthextension module

### DIFF
--- a/extension/googleclientauthextension/README.md
+++ b/extension/googleclientauthextension/README.md
@@ -1,10 +1,13 @@
-# Authenticator - Google Client Credentials
+# Authenticator - Google Client Credentials (Deprecated)
+
+> **Deprecated**: This module has moved to [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension).
+> Please use [`github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension) instead.
 
 | Status        |           |
 | ------------- |-----------|
-| Stability     | [alpha]  |
+| Stability     | [deprecated]  |
 
-[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
+[deprecated]: https://github.com/open-telemetry/opentelemetry-collector#deprecated
 
 This extension provides Google OAuth2 Client Credentials and Metadata for gRPC and http based exporters.
 
@@ -46,5 +49,5 @@ Following are the configuration fields:
   - `id_token`: Google-signed [ID token](https://cloud.google.com/docs/authentication/token-types#id) will be generated.
 - **token_header** - The HTTP header used to carry the token. Default: `authorization`
   - `authorization`: Token is sent in the standard `Authorization` header.
-  - `proxy-authorization`: Token is sent in the `Proxy-Authorization` header (useful for [IAP-protected endpoints](https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_proxy-authorization_header)).
+  - `proxy-authorization`: Token is sent in the `Proxy-Authorization` header (useful for [IAP-protected endpoints](https://cloud.google.com/iap/docs/authentication-howto#authenticating_from-proxy-authorization_header)).
 - **audience** - The audience claim used for generating ID token

--- a/extension/googleclientauthextension/README.md
+++ b/extension/googleclientauthextension/README.md
@@ -7,7 +7,7 @@
 | ------------- |-----------|
 | Stability     | [deprecated]  |
 
-[deprecated]: https://github.com/open-telemetry/opentelemetry-collector#deprecated
+[deprecated]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#deprecated
 
 This extension provides Google OAuth2 Client Credentials and Metadata for gRPC and http based exporters.
 

--- a/extension/googleclientauthextension/README.md
+++ b/extension/googleclientauthextension/README.md
@@ -49,5 +49,5 @@ Following are the configuration fields:
   - `id_token`: Google-signed [ID token](https://cloud.google.com/docs/authentication/token-types#id) will be generated.
 - **token_header** - The HTTP header used to carry the token. Default: `authorization`
   - `authorization`: Token is sent in the standard `Authorization` header.
-  - `proxy-authorization`: Token is sent in the `Proxy-Authorization` header (useful for [IAP-protected endpoints](https://cloud.google.com/iap/docs/authentication-howto#authenticating_from-proxy-authorization_header)).
+  - `proxy-authorization`: Token is sent in the `Proxy-Authorization` header (useful for [IAP-protected endpoints](https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_proxy-authorization_header)).
 - **audience** - The audience claim used for generating ID token

--- a/extension/googleclientauthextension/config.go
+++ b/extension/googleclientauthextension/config.go
@@ -78,6 +78,8 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the extension configuration is valid.
+//
+// Deprecated: Use github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension instead.
 func (cfg *Config) Validate() error {
 	if _, ok := tokenTypes[cfg.TokenType]; !ok {
 		return errors.New("invalid token_type")

--- a/extension/googleclientauthextension/config.go
+++ b/extension/googleclientauthextension/config.go
@@ -42,6 +42,8 @@ var tokenHeaders = map[string]struct{}{
 }
 
 // Config stores the configuration for GCP Client Credentials.
+//
+// Deprecated: Use github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension instead.
 type Config struct {
 	// Project is the project telemetry is sent to if the gcp.project.id
 	// resource attribute is not set. If unspecified, this is determined using
@@ -92,6 +94,9 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
+// CreateDefaultConfig returns the default configuration for the extension.
+//
+// Deprecated: Use github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension instead.
 func CreateDefaultConfig() component.Config {
 	return &Config{
 		Scopes: []string{

--- a/extension/googleclientauthextension/doc.go
+++ b/extension/googleclientauthextension/doc.go
@@ -14,4 +14,6 @@
 
 // Package googleclientauthextension provides gRPC and HTTP credentials and metadata
 // using Application Default Credentials: https://cloud.google.com/docs/authentication#adc
+//
+// Deprecated: Use github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension instead.
 package googleclientauthextension // import "github.com/GoogleCloudPlatform/opentelemetry-operations-go/extension/googleclientauthextension"

--- a/extension/googleclientauthextension/factory.go
+++ b/extension/googleclientauthextension/factory.go
@@ -38,6 +38,9 @@ const (
 	envProjectID = "GOOGLE_CLOUD_PROJECT"
 )
 
+// CreateExtension creates a new instance of the extension based on the given configuration.
+//
+// Deprecated: Use github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension instead.
 func CreateExtension(ctx context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
 	config := cfg.(*Config)
 	ca := &clientAuthenticator{

--- a/extension/googleclientauthextension/go.mod
+++ b/extension/googleclientauthextension/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension instead.
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/extension/googleclientauthextension
 
 go 1.26.0


### PR DESCRIPTION
It is being moved upstream.  I'll wait to merge until after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50212 merges.