### PR TITLE
detectors/gcp: deprecate GCP resource detection package

### DIFF
--- a/detectors/gcp/README.md
+++ b/detectors/gcp/README.md
@@ -1,3 +1,6 @@
-# GCP Resource detection library
+# GCP Resource detection library (DEPRECATED)
+
+> [!WARNING]
+> This package is deprecated and will no longer be maintained. Please use upstream [`go.opentelemetry.io/contrib/detectors/gcp`](https://pkg.go.dev/go.opentelemetry.io/contrib/detectors/gcp) instead.
 
 This is a library intended to be used by Upstream OpenTelemetry resource detectors.  It exists within this repository to allow for integration testing of the detection functions in real GCP environments.

--- a/detectors/gcp/app_engine.go
+++ b/detectors/gcp/app_engine.go
@@ -38,6 +38,8 @@ func (d *Detector) onAppEngine() bool {
 }
 
 // AppEngineServiceName returns the service name of the app engine service.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) AppEngineServiceName() (string, error) {
 	if name, found := d.os.LookupEnv(gaeServiceEnv); found {
 		return name, nil
@@ -46,6 +48,8 @@ func (d *Detector) AppEngineServiceName() (string, error) {
 }
 
 // AppEngineServiceVersion returns the service version of the app engine service.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) AppEngineServiceVersion() (string, error) {
 	if version, found := d.os.LookupEnv(gaeVersionEnv); found {
 		return version, nil
@@ -54,6 +58,8 @@ func (d *Detector) AppEngineServiceVersion() (string, error) {
 }
 
 // AppEngineServiceInstance returns the service instance of the app engine service.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) AppEngineServiceInstance() (string, error) {
 	if instanceID, found := d.os.LookupEnv(gaeInstanceEnv); found {
 		return instanceID, nil
@@ -62,17 +68,23 @@ func (d *Detector) AppEngineServiceInstance() (string, error) {
 }
 
 // AppEngineFlexAvailabilityZoneAndRegion returns the zone and region in which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) AppEngineFlexAvailabilityZoneAndRegion() (string, string, error) {
 	// The GCE metadata server is available on App Engine Flex.
 	return d.GCEAvailabilityZoneAndRegion()
 }
 
 // AppEngineStandardAvailabilityZone returns the zone the app engine service is running in.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) AppEngineStandardAvailabilityZone() (string, error) {
 	return d.metadata.ZoneWithContext(context.TODO())
 }
 
 // AppEngineStandardCloudRegion returns the region the app engine service is running in.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) AppEngineStandardCloudRegion() (string, error) {
 	return d.FaaSCloudRegion()
 }

--- a/detectors/gcp/bms.go
+++ b/detectors/gcp/bms.go
@@ -31,6 +31,8 @@ func (d *Detector) onBareMetalSolution() bool {
 }
 
 // BareMetalSolutionInstanceID returns the instance ID from the BMS_INSTANCE_ID environment variable.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) BareMetalSolutionInstanceID() (string, error) {
 	if instanceID, found := d.os.LookupEnv(bmsInstanceIDEnv); found {
 		return instanceID, nil
@@ -39,6 +41,8 @@ func (d *Detector) BareMetalSolutionInstanceID() (string, error) {
 }
 
 // BareMetalSolutionCloudRegion returns the region from the BMS_REGION environment variable.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) BareMetalSolutionCloudRegion() (string, error) {
 	if region, found := d.os.LookupEnv(bmsRegionEnv); found {
 		return region, nil
@@ -47,6 +51,8 @@ func (d *Detector) BareMetalSolutionCloudRegion() (string, error) {
 }
 
 // BareMetalSolutionProjectID returns the project ID from the BMS_PROJECT_ID environment variable.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) BareMetalSolutionProjectID() (string, error) {
 	if project, found := d.os.LookupEnv(bmsProjectIDEnv); found {
 		return project, nil

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package gcp provides functions for detecting the GCP platform and resources.
+//
+// Deprecated: This package is deprecated and will no longer be maintained.
+// Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 package gcp
 
 import (
@@ -28,12 +32,18 @@ var errEnvVarNotFound = errors.New("environment variable not found")
 
 // NewDetector returns a *Detector which can get detect the platform,
 // and fetch attributes of the platform on which it is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func NewDetector() *Detector {
 	return &Detector{metadata: metadata.NewClient(nil), os: realOSProvider{}}
 }
 
+// Platform represents a Google Cloud platform type.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 type Platform int64
 
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 const (
 	UnknownPlatform Platform = iota
 	GKE
@@ -48,6 +58,8 @@ const (
 )
 
 // CloudPlatform returns the platform on which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) CloudPlatform() Platform {
 	switch {
 	case d.onBareMetalSolution():
@@ -73,6 +85,8 @@ func (d *Detector) CloudPlatform() Platform {
 }
 
 // ProjectID returns the ID of the project in which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) ProjectID() (string, error) {
 	// N.B. d.metadata.ProjectIDWithContext(context.TODO()) is cached globally, so if we use it here it's untestable.
 	s, err := d.metadata.GetWithContext(context.TODO(), "project/project-id")
@@ -87,6 +101,8 @@ func (d *Detector) instanceID() (string, error) {
 }
 
 // Detector collects resource information for all GCP platforms.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 type Detector struct {
 	metadata       *metadata.Client
 	os             osProvider

--- a/detectors/gcp/faas.go
+++ b/detectors/gcp/faas.go
@@ -64,6 +64,8 @@ func (d *Detector) onCloudRunWorkerPool() bool {
 }
 
 // FaaSName returns the name of the Cloud Run, Cloud Run jobs or Cloud Functions service.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) FaaSName() (string, error) {
 	if name, found := d.os.LookupEnv(faasServiceEnv); found {
 		return name, nil
@@ -78,6 +80,8 @@ func (d *Detector) FaaSName() (string, error) {
 }
 
 // FaaSVersion returns the revision of the Cloud Run or Cloud Functions service.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) FaaSVersion() (string, error) {
 	if version, found := d.os.LookupEnv(cloudRunRevisionEnv); found {
 		return version, nil
@@ -89,6 +93,8 @@ func (d *Detector) FaaSVersion() (string, error) {
 }
 
 // CloudRunJobExecution returns the execution id of the Cloud Run jobs.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) CloudRunJobExecution() (string, error) {
 	if eid, found := d.os.LookupEnv(cloudRunJobExecutionEnv); found {
 		return eid, nil
@@ -97,6 +103,8 @@ func (d *Detector) CloudRunJobExecution() (string, error) {
 }
 
 // CloudRunJobTaskIndex returns the task index for the execution of the Cloud Run jobs.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) CloudRunJobTaskIndex() (string, error) {
 	if tidx, found := d.os.LookupEnv(cloudRunJobTaskIndexEnv); found {
 		return tidx, nil
@@ -105,6 +113,8 @@ func (d *Detector) CloudRunJobTaskIndex() (string, error) {
 }
 
 // FaaSID returns the instance id of the Cloud Run or Cloud Function.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) FaaSID() (string, error) {
 	return d.instanceID()
 }
@@ -113,6 +123,8 @@ func (d *Detector) FaaSID() (string, error) {
 // It is in the format /projects/<project_number>/regions/<region>.
 //
 // https://cloud.google.com/run/docs/reference/container-contract#metadata-server
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) FaaSCloudRegion() (string, error) {
 	region, err := d.metadata.GetWithContext(context.TODO(), regionMetadataAttr)
 	if err != nil {

--- a/detectors/gcp/gce.go
+++ b/detectors/gcp/gce.go
@@ -36,11 +36,15 @@ func (d *Detector) onGCE() bool {
 }
 
 // GCEHostType returns the machine type of the instance on which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEHostType() (string, error) {
 	return d.metadata.GetWithContext(context.TODO(), machineTypeMetadataAttr)
 }
 
 // GCEHostID returns the instance ID of the instance on which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEHostID() (string, error) {
 	return d.instanceID()
 }
@@ -48,6 +52,8 @@ func (d *Detector) GCEHostID() (string, error) {
 // GCEHostName returns the instance name of the instance on which this program is running.
 // Recommended to use GCEInstanceName() or GCEInstanceHostname() to more accurately reflect which
 // value is returned.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEHostName() (string, error) {
 	return d.metadata.InstanceNameWithContext(context.TODO())
 }
@@ -55,17 +61,23 @@ func (d *Detector) GCEHostName() (string, error) {
 // GCEInstanceName returns the instance name of the instance on which this program is running.
 // This is the value visible in the Cloud Console UI, and the prefix for the default hostname
 // of the instance as defined by the default internal DNS name (see https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names).
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEInstanceName() (string, error) {
 	return d.metadata.InstanceNameWithContext(context.TODO())
 }
 
 // GCEInstanceHostname returns the full value of the default or custom hostname of the instance
 // on which this program is running. See https://cloud.google.com/compute/docs/instances/custom-hostname-vm.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEInstanceHostname() (string, error) {
 	return d.metadata.HostnameWithContext(context.TODO())
 }
 
 // GCEAvailabilityZoneAndRegion returns the zone and region in which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEAvailabilityZoneAndRegion() (string, string, error) {
 	zone, err := d.metadata.ZoneWithContext(context.TODO())
 	if err != nil {
@@ -81,6 +93,9 @@ func (d *Detector) GCEAvailabilityZoneAndRegion() (string, string, error) {
 	return zone, strings.Join(splitZone[0:2], "-"), nil
 }
 
+// ManagedInstanceGroup describes a Google Compute Engine Managed Instance Group.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 type ManagedInstanceGroup struct {
 	Name     string
 	Location string
@@ -89,6 +104,9 @@ type ManagedInstanceGroup struct {
 
 var createdByMIGRE = regexp.MustCompile(`^projects/[^/]+/(zones|regions)/([^/]+)/instanceGroupManagers/([^/]+)$`)
 
+// GCEManagedInstanceGroup returns the managed instance group that created this VM, if any.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GCEManagedInstanceGroup() (ManagedInstanceGroup, error) {
 	createdBy, err := d.metadata.InstanceAttributeValueWithContext(context.TODO(), createdByInstanceAttr)
 	if _, ok := err.(metadata.NotDefinedError); ok {

--- a/detectors/gcp/gke.go
+++ b/detectors/gcp/gke.go
@@ -51,16 +51,22 @@ func (d *Detector) onGKE() bool {
 }
 
 // GKEHostID returns the instance ID of the instance on which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GKEHostID() (string, error) {
 	return d.GCEHostID()
 }
 
 // GKEClusterName returns the name if the GKE cluster in which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GKEClusterName() (string, error) {
 	return d.metadata.InstanceAttributeValueWithContext(context.TODO(), clusterNameMetadataAttr)
 }
 
 // GKEHostType returns the machine type of the instance on which this program is running.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GKEHostType() (string, error) {
 	ctx := context.TODO()
 	projectID, err := d.ProjectID()
@@ -137,8 +143,12 @@ func lastPathSegment(s string) string {
 	return s
 }
 
+// LocationType represents the location type (Zone or Region).
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 type LocationType int64
 
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 const (
 	UndefinedLocation LocationType = iota
 	Zone
@@ -146,6 +156,8 @@ const (
 )
 
 // GKEAvailabilityZoneOrRegion returns the location of the cluster and whether the cluster is zonal or regional.
+//
+// Deprecated: Use [go.opentelemetry.io/contrib/detectors/gcp] instead.
 func (d *Detector) GKEAvailabilityZoneOrRegion() (string, LocationType, error) {
 	clusterLocation, err := d.metadata.InstanceAttributeValueWithContext(context.TODO(), clusterLocationMetadataAttr)
 	if err != nil {


### PR DESCRIPTION
Deprecate github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp in favor of go.opentelemetry.io/contrib/detectors/gcp.

This is being moved upstream in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/9581, and the OTel collector will be rebased on the contrib detector in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50211. It won't be removed until those PRs are complete.