### PR TITLE
propagator: deprecate package and add missing module-level deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,14 @@ OpenTelemetry Google Cloud Monitoring Exporter allows the user to send collected
 
 See [README.md](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/metric/README.md) for setup and usage information.
 
+## OpenTelemetry Google Cloud Trace Propagators
+
+> [!WARNING]
+> Deprecated: Please migrate to the standard W3C Trace Context propagator (`go.opentelemetry.io/otel/propagation.TraceContext`).
+
+OpenTelemetry Google Cloud Trace Propagators provides trace context propagators for Google Cloud Trace format (`X-Cloud-Trace-Context`).
+
+See [README.md](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/propagator/README.md) for setup and usage information.
+
 [circleci-image]: https://circleci.com/gh/GoogleCloudPlatform/opentelemetry-operations-go.svg?style=shield 
 [circleci-url]: https://circleci.com/gh/GoogleCloudPlatform/opentelemetry-operations-go

--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use go.opentelemetry.io/contrib/detectors/gcp instead.
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp
 
 go 1.26.0

--- a/exporter/metric/go.mod
+++ b/exporter/metric/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use the standard OpenTelemetry OTLP metric exporter (go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc) instead.
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric
 
 go 1.26.0

--- a/exporter/trace/go.mod
+++ b/exporter/trace/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use the standard OpenTelemetry OTLP trace exporter (go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc) instead.
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace
 
 go 1.26.0

--- a/propagator/README.md
+++ b/propagator/README.md
@@ -1,6 +1,8 @@
-# OpenTelemetry Google Cloud Trace Propagators
+# OpenTelemetry Google Cloud Trace Propagators (Deprecated)
 
-[![Docs](https://godoc.org/github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator?status.svg)](https://pkg.go.dev/github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator)
+> [!WARNING]
+> The OpenTelemetry Google Cloud Trace Propagators for Go are deprecated and will be archived after January 1st, 2027.
+> Please migrate to the standard W3C Trace Context propagator (`go.opentelemetry.io/otel/propagation.TraceContext`).
 
 This package contains Trace Context Propagators for use with [Google Cloud
 Trace](https://cloud.google.com/trace) that make it compatible with

--- a/propagator/go.mod
+++ b/propagator/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use the standard W3C Trace Context propagator (go.opentelemetry.io/otel/propagation.TraceContext) instead.
 module github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator
 
 go 1.26.0

--- a/propagator/propagator.go
+++ b/propagator/propagator.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package propagator provides trace context propagators for Google Cloud Trace format.
+//
+// Deprecated: Google Cloud OpenTelemetry Trace Propagators for Go are deprecated.
+// Use the standard W3C Trace Context propagator (go.opentelemetry.io/otel/propagation.TraceContext) instead.
 package propagator
 
 import (
@@ -30,6 +34,8 @@ import (
 
 // TraceContextHeaderName is the HTTP header field for Google Cloud Trace
 // https://cloud.google.com/trace/docs/setup#force-trace
+//
+// Deprecated: Use the standard W3C Trace Context propagator (go.opentelemetry.io/otel/propagation.TraceContext) instead.
 const TraceContextHeaderName = "x-cloud-trace-context"
 
 // traceContextHeaderFormat is the regular expression pattern for valid Cloud Trace header value.
@@ -60,6 +66,8 @@ func (e errInvalidHeader) Error() string {
 // This is the preferred mechanism of propagation as X-Cloud-Trace-Context sampling flag
 // behaves subtly different from expectations in both w3c traceparent *and* opentelemetry
 // propagation.
+//
+// Deprecated: Use the standard W3C Trace Context propagator (go.opentelemetry.io/otel/propagation.TraceContext) instead.
 type CloudTraceOneWayPropagator struct {
 	CloudTraceFormatPropagator
 }
@@ -77,6 +85,8 @@ var _ propagation.TextMapPropagator = CloudTraceOneWayPropagator{}
 
 // CloudTraceFormatPropagator is a TextMapPropagator that injects/extracts a context to/from the carrier
 // following Google Cloud Trace format.
+//
+// Deprecated: Use the standard W3C Trace Context propagator (go.opentelemetry.io/otel/propagation.TraceContext) instead.
 type CloudTraceFormatPropagator struct{}
 
 func (p CloudTraceFormatPropagator) getHeaderValue(carrier propagation.TextMapCarrier) string {
@@ -166,6 +176,8 @@ func spanContextFromXCTCHeader(header string) (trace.SpanContext, error) {
 
 // SpanContextFromRequest extracts a trace.SpanContext from the HTTP request req.
 // In this method, SpanID is expected to be stored in big endian.
+//
+// Deprecated: Use the standard W3C Trace Context propagator (go.opentelemetry.io/otel/propagation.TraceContext) instead.
 func SpanContextFromRequest(req *http.Request) (trace.SpanContext, error) {
 	h := req.Header.Get(TraceContextHeaderName)
 	return spanContextFromXCTCHeader(h)


### PR DESCRIPTION
- Mark github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator and its exported symbols as deprecated in favor of standard W3C Trace Context (go.opentelemetry.io/otel/propagation.TraceContext).
- Add module-level // Deprecated: directives in go.mod for propagator, detectors/gcp, exporter/metric, and exporter/trace.
- Update README.md with propagators deprecation notice.