### PR TITLE
ci: checkout repo for codecov and fix action configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,15 +134,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-coverage]
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-artifacts-${{ env.DEFAULT_GO_VERSION }}
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.txt
+          fail_ci_if_error: true
+          files: ./coverage.txt
           verbose: true
 
   compatibility-test:


### PR DESCRIPTION
## Summary

Fixes the failing `codecov/project` status check on pull requests.

### Root Cause
When the `codecov` job was decoupled from `test-coverage`, it downloaded `coverage.txt` via `actions/download-artifact` but did not checkout the repository with `actions/checkout`. `codecov-action` (via `codecov-cli`) requires the repository files to be present on disk in order to map coverage report paths to source files. Without the checkout, Codecov reported 0 lines covered across 0 files (0% project coverage), causing the `codecov/project` status check to fail on every PR.

### Changes
- Added `actions/checkout` step to the `codecov` job.
- Updated `codecov-action` configuration to match `open-telemetry/opentelemetry-go`:
  - Replaced deprecated `file` input with `files`.
  - Added `fail_ci_if_error: true`.
  - Removed redundant `CODECOV_TOKEN` env setting (tokenless upload is supported for public repos).