### PR TITLE
exporter/collector/logs: Add support for the `gcp.operation` attribute

### DIFF
--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -677,15 +677,8 @@ func (f *BoolOrString) UnmarshalJSON(data []byte) error {
 
 	var str string
 	if err := json.Unmarshal(data, &str); err == nil {
-		switch str {
-		case "true":
-			*f = true
-			return nil
-		case "false":
-			*f = false
-			return nil
-		}
-		return fmt.Errorf("failed to convert string to boolean: %w", err)
+		*f = str == "true"
+		return nil
 	}
 
 	return fmt.Errorf("field must be a JSON boolean or a string containing a boolean: %s", string(data))

--- a/exporter/collector/logs.go
+++ b/exporter/collector/logs.go
@@ -59,6 +59,7 @@ const (
 
 	HTTPRequestAttributeKey    = "gcp.http_request"
 	LogNameAttributeKey        = "gcp.log_name"
+	OperationAttributeKey      = "gcp.operation"
 	SourceLocationAttributeKey = "gcp.source_location"
 	TraceSampledAttributeKey   = "gcp.trace_sampled"
 
@@ -499,6 +500,15 @@ func (l logMapper) logToSplitEntries(
 		delete(attrsMap, HTTPRequestAttributeKey)
 	}
 
+	if operationAttr, ok := attrsMap[OperationAttributeKey]; ok {
+		operation, err := l.parseOperation(operationAttr)
+		if err != nil {
+			l.obs.log.Debug("Unable to parse operation", zap.Error(err))
+		}
+		entry.Operation = operation
+		delete(attrsMap, OperationAttributeKey)
+	}
+
 	if logRecord.SeverityNumber() < 0 || int(logRecord.SeverityNumber()) > len(severityMapping)-1 {
 		return nil, fmt.Errorf("unknown SeverityNumber %v", logRecord.SeverityNumber())
 	}
@@ -653,6 +663,34 @@ func (f *Int64OrString) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type BoolOrString bool
+
+// Used to unmarshal JSON fields that can either be provided as a bool or
+// a string containing a bool.
+// https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/otlp-log-record-to-log-entry#operation documents support for strings.
+func (f *BoolOrString) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		*f = BoolOrString(b)
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		switch str {
+		case "true":
+			*f = true
+			return nil
+		case "false":
+			*f = false
+			return nil
+		}
+		return fmt.Errorf("failed to convert string to boolean: %w", err)
+	}
+
+	return fmt.Errorf("field must be a JSON boolean or a string containing a boolean: %s", string(data))
+}
+
 // sourceLocationLog is an intermediate representation of
 // logging.googleapis.com/sourceLocation that accepts the "line" field as
 // either a JSON number or a quoted string, matching what various log
@@ -716,6 +754,31 @@ func (l logMapper) parseHTTPRequest(httpRequestAttr pcommon.Value) (*logtypepb.H
 		}
 	}
 	return pb, nil
+}
+
+// JSON keys derived from:
+// https://docs.cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logentryoperation
+// https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/otlp-log-record-to-log-entry#operation
+type operationLog struct {
+	ID       string       `json:"id"`
+	Producer string       `json:"producer"`
+	First    BoolOrString `json:"first"`
+	Last     BoolOrString `json:"last"`
+}
+
+func (l logMapper) parseOperation(operationAttr pcommon.Value) (*logpb.LogEntryOperation, error) {
+	var parsedOperation operationLog
+	err := unmarshalAttribute(operationAttr, &parsedOperation)
+	if err != nil {
+		return nil, &attributeProcessingError{Key: OperationAttributeKey, Err: err}
+	}
+
+	return &logpb.LogEntryOperation{
+		Id:       parsedOperation.ID,
+		Producer: parsedOperation.Producer,
+		First:    bool(parsedOperation.First),
+		Last:     bool(parsedOperation.Last),
+	}, nil
 }
 
 // toProtoStruct converts v, which must marshal into a JSON object,

--- a/exporter/collector/logs_test.go
+++ b/exporter/collector/logs_test.go
@@ -169,7 +169,7 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
-			name: "log with json and httpRequest with string status, empty monitoredresource",
+			name: "log with json httpRequest with string status, empty monitoredresource",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
 				log.Body().SetEmptyMap().PutStr("message", "hello!")
@@ -221,7 +221,7 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
-			name: "log with json and httpRequest with integer status, empty monitoredresource",
+			name: "log with json httpRequest with integer status, empty monitoredresource",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
 				log.Body().SetEmptyMap().PutStr("message", "hello!")
@@ -273,7 +273,7 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
-			name: "log with json and httpRequest with integer values, empty monitoredresource",
+			name: "log with map httpRequest with integer values, empty monitoredresource",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
 				log.Body().SetEmptyMap().PutStr("message", "hello!")
@@ -324,7 +324,7 @@ func TestLogMapping(t *testing.T) {
 			maxEntrySize: defaultMaxEntrySize,
 		},
 		{
-			name: "log with json and httpRequest with string values, empty monitoredresource",
+			name: "log with map httpRequest with string values, empty monitoredresource",
 			log: func() plog.LogRecord {
 				log := plog.NewLogRecord()
 				log.Body().SetEmptyMap().PutStr("message", "hello!")
@@ -392,6 +392,136 @@ func TestLogMapping(t *testing.T) {
 					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
 						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
 					}}},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with json operation with bool bools, empty monitoredresource",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyMap().PutStr("message", "hello!")
+				log.Attributes().PutEmptyBytes(OperationAttributeKey).FromRaw([]byte(`{
+						"id": "abc123",
+						"producer": "my_producer",
+						"first": true,
+						"last": true
+					}`))
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
+					}}},
+					Operation: &logpb.LogEntryOperation{
+						Id:       "abc123",
+						Producer: "my_producer",
+						First:    true,
+						Last:     true,
+					},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with json operation with string bools, empty monitoredresource",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyMap().PutStr("message", "hello!")
+				log.Attributes().PutEmptyBytes(OperationAttributeKey).FromRaw([]byte(`{
+						"id": "abc123",
+						"producer": "my_producer",
+						"first": "true",
+						"last": "true"
+					}`))
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
+					}}},
+					Operation: &logpb.LogEntryOperation{
+						Id:       "abc123",
+						Producer: "my_producer",
+						First:    true,
+						Last:     true,
+					},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with map operation with bool bools, empty monitoredresource",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyMap().PutStr("message", "hello!")
+				o := log.Attributes().PutEmptyMap(OperationAttributeKey)
+				o.PutStr("id", "abc123")
+				o.PutStr("producer", "my_producer")
+				o.PutBool("first", true)
+				o.PutBool("last", true)
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
+					}}},
+					Operation: &logpb.LogEntryOperation{
+						Id:       "abc123",
+						Producer: "my_producer",
+						First:    true,
+						Last:     true,
+					},
+				},
+			},
+			maxEntrySize: defaultMaxEntrySize,
+		},
+		{
+			name: "log with map operation with string bools, empty monitoredresource",
+			log: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetEmptyMap().PutStr("message", "hello!")
+				o := log.Attributes().PutEmptyMap(OperationAttributeKey)
+				o.PutStr("id", "abc123")
+				o.PutStr("producer", "my_producer")
+				o.PutStr("first", "true")
+				o.PutStr("last", "true")
+				return log
+			},
+			mr: func() *monitoredrespb.MonitoredResource {
+				return nil
+			},
+			expectedEntries: []*logpb.LogEntry{
+				{
+					LogName:   logName,
+					Timestamp: timestamppb.New(testObservedTime),
+					Payload: &logpb.LogEntry_JsonPayload{JsonPayload: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"message": {Kind: &structpb.Value_StringValue{StringValue: "hello!"}},
+					}}},
+					Operation: &logpb.LogEntryOperation{
+						Id:       "abc123",
+						Producer: "my_producer",
+						First:    true,
+						Last:     true,
+					},
 				},
 			},
 			maxEntrySize: defaultMaxEntrySize,


### PR DESCRIPTION
This mirrors the [support from the Telemetry
API](https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/otlp-log-record-to-log-entry#operation) and is needed to unblock migration off Fluent Bit.