### PR TITLE
perf(exporter/metric): fix O(N^2) label scan in recordToMpb when WithDisableCreateMetricDescriptors is enabled

### DIFF
--- a/exporter/metric/metric.go
+++ b/exporter/metric/metric.go
@@ -431,12 +431,18 @@ func recordToMdpbKindType(a metricdata.Aggregation) (googlemetricpb.MetricDescri
 
 // recordToMpb converts data from records to Metric proto type for Cloud Monitoring.
 func (me *metricExporter) recordToMpb(metrics metricdata.Metrics, attributes attribute.Set, library instrumentation.Scope, extraLabels *attribute.Set) *googlemetricpb.Metric {
-	me.mdLock.RLock()
-	defer me.mdLock.RUnlock()
+	var metricType string
 	k := keyOf(metrics, library)
-	md, ok := me.mdCache[k]
-	if !ok {
-		md = me.recordToMdpb(metrics, extraLabels)
+	me.mdLock.RLock()
+	if md, ok := me.mdCache[k]; ok {
+		metricType = md.Type
+	}
+	me.mdLock.RUnlock()
+
+	if metricType == "" {
+		// Avoid calling recordToMdpb (which scans all datapoints in metrics.Data
+		// to build LabelDescriptors) when we only need the metric type string.
+		metricType = me.descToMetricType(metrics)
 	}
 
 	labels := make(map[string]string)
@@ -451,7 +457,7 @@ func (me *metricExporter) recordToMpb(metrics metricdata.Metrics, attributes att
 	addAttributes(&attributes)
 
 	return &googlemetricpb.Metric{
-		Type:   md.Type,
+		Type:   metricType,
 		Labels: labels,
 	}
 }

--- a/exporter/metric/metric_test.go
+++ b/exporter/metric/metric_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/genproto/googleapis/api/label"
 	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
@@ -315,56 +316,68 @@ func TestMonitoredResourceDescriptionDeduplicatesLabels(t *testing.T) {
 
 func TestRecordToMpb(t *testing.T) {
 	metricName := "testing"
-
-	md := &googlemetricpb.MetricDescriptor{
-		Name:        metricName,
-		Type:        fmt.Sprintf(cloudMonitoringMetricDescriptorNameFormat, metricName),
-		MetricKind:  googlemetricpb.MetricDescriptor_GAUGE,
-		ValueType:   googlemetricpb.MetricDescriptor_DOUBLE,
-		Description: "test",
-	}
-
-	mdkey := key{
-		name:        md.Name,
-		libraryname: "",
-	}
-	me := &metricExporter{
-		o: &options{},
-		mdCache: map[key]*googlemetricpb.MetricDescriptor{
-			mdkey: md,
-		},
-	}
-
 	inputLibrary := instrumentation.Scope{Name: "workload.googleapis.com"}
+	inputMetrics := metricdata.Metrics{
+		Name: metricName,
+	}
 	inputAttributes := attribute.NewSet(
 		attribute.Key("a").String("A"),
 		attribute.Key("b?b").String("B"),
 		attribute.Key("8foo").Int64(100),
 	)
-	inputMetrics := metricdata.Metrics{
-		Name: metricName,
-	}
 	inputExtraLabels := attribute.NewSet(
 		attribute.Key("service.name").String("servicename"),
 		attribute.Key("service.namespace").String("servicenamespace"),
 		attribute.Key("service.instance.id").String("23490238490235gfdg87g"),
 	)
+	wantLabels := map[string]string{
+		"a":                   "A",
+		"b_b":                 "B",
+		"key_8foo":            "100",
+		"service_instance_id": "23490238490235gfdg87g",
+		"service_name":        "servicename",
+		"service_namespace":   "servicenamespace",
+	}
 
-	want := &googlemetricpb.Metric{
-		Type: md.Type,
-		Labels: map[string]string{
-			"a":                   "A",
-			"b_b":                 "B",
-			"key_8foo":            "100",
-			"service_instance_id": "23490238490235gfdg87g",
-			"service_name":        "servicename",
-			"service_namespace":   "servicenamespace",
-		},
-	}
-	out := me.recordToMpb(inputMetrics, inputAttributes, inputLibrary, &inputExtraLabels)
-	if !reflect.DeepEqual(want, out) {
-		t.Errorf("expected: %v, actual: %v", want, out)
-	}
+	t.Run("cache hit uses cached descriptor type", func(t *testing.T) {
+		cachedType := "custom.googleapis.com/cached_testing"
+		md := &googlemetricpb.MetricDescriptor{
+			Name:        metricName,
+			Type:        cachedType,
+			MetricKind:  googlemetricpb.MetricDescriptor_GAUGE,
+			ValueType:   googlemetricpb.MetricDescriptor_DOUBLE,
+			Description: "test",
+		}
+		me := &metricExporter{
+			o: &options{},
+			mdCache: map[key]*googlemetricpb.MetricDescriptor{
+				keyOf(inputMetrics, inputLibrary): md,
+			},
+		}
+		want := &googlemetricpb.Metric{
+			Type:   cachedType,
+			Labels: wantLabels,
+		}
+		out := me.recordToMpb(inputMetrics, inputAttributes, inputLibrary, &inputExtraLabels)
+		if !reflect.DeepEqual(want, out) {
+			t.Errorf("expected: %v, actual: %v", want, out)
+		}
+	})
+
+	t.Run("cache miss computes metric type directly", func(t *testing.T) {
+		me := &metricExporter{
+			o:       &options{disableCreateMetricDescriptors: true},
+			mdCache: map[key]*googlemetricpb.MetricDescriptor{},
+		}
+		want := &googlemetricpb.Metric{
+			Type:   fmt.Sprintf(cloudMonitoringMetricDescriptorNameFormat, metricName),
+			Labels: wantLabels,
+		}
+		out := me.recordToMpb(inputMetrics, inputAttributes, inputLibrary, &inputExtraLabels)
+		if !reflect.DeepEqual(want, out) {
+			t.Errorf("expected: %v, actual: %v", want, out)
+		}
+	})
 }
 
 func TestExtraLabelsFromResource(t *testing.T) {
@@ -1468,3 +1481,39 @@ func TestBatchingExport(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkRecordToTspbDisableCreateMetricDescriptors(b *testing.B) {
+	me := &metricExporter{
+		o: &options{
+			disableCreateMetricDescriptors: true,
+		},
+		mdCache: make(map[key]*googlemetricpb.MetricDescriptor),
+	}
+	const numPoints = 2000
+	points := make([]metricdata.DataPoint[int64], numPoints)
+	for i := range points {
+		points[i] = metricdata.DataPoint[int64]{
+			Attributes: attribute.NewSet(
+				attribute.String("partition_id", "p-0"),
+				attribute.String("state", "OCCUPIED"),
+				attribute.String("node_pool_name", "pool-1"),
+			),
+			Value: int64(i),
+		}
+	}
+	m := metricdata.Metrics{
+		Name: "kubernetes.io/internal/addons/partition_tree/occupancy",
+		Data: metricdata.Gauge[int64]{DataPoints: points},
+	}
+	mr := &monitoredrespb.MonitoredResource{Type: "k8s_entity"}
+	extra := attribute.EmptySet()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tss, err := me.recordToTspb(m, mr, instrumentation.Scope{Name: "test"}, extra)
+		if err != nil || len(tss) != numPoints {
+			b.Fatalf("unexpected result: err=%v, len=%d", err, len(tss))
+		}
+	}
+}
+


### PR DESCRIPTION
### Problem

When `WithDisableCreateMetricDescriptors()` is enabled on the Google Cloud Monitoring exporter, `exportMetricDescriptor` returns early and leaves `me.mdCache` unpopulated.

During `recordToTspb`, `recordToMpb` is called once per data point and checks `me.mdCache[k]` under `me.mdLock.RLock()`. On every cache miss (`!ok`), it previously called `me.recordToMdpb(metrics, extraLabels)`:

```go
md, ok := me.mdCache[k]
if !ok {
    md = me.recordToMdpb(metrics, extraLabels)
}
```

`recordToMdpb` invokes `labelDescriptors(metrics, extraLabels)`, which iterates over all $N$ data points in `metrics.Data.DataPoints` to compute the union of label keys. Because `recordToMpb` is executed for every data point in `metrics`, this causes an $O(N^2)$ label scan per metric instrument, even though `recordToMpb` only reads `md.Type` (and discards the rest of the constructed `MetricDescriptor`).

### Solution

1. On an `mdCache` miss in `recordToMpb`, compute `metricType := me.descToMetricType(metrics)` directly instead of calling `recordToMdpb(metrics, extraLabels)`.
2. Release `me.mdLock.RUnlock()` immediately after the cache lookup rather than holding the read lock through `attribute.NewSet` and map allocation.

### Benchmark Results

Added `BenchmarkRecordToTspbDisableCreateMetricDescriptors` ($N = 2000$ data points):

| Version | Time / op | Bytes / op | Allocs / op |
| :--- | :--- | :--- | :--- |
| **Before** | `875.71 ms/op` | `3,340,336 B/op` | `44,018 allocs/op` |
| **After** | **`2.36 ms/op`** | **`1,846,070 B/op`** | **`24,013 allocs/op`** |
| **Improvement** | **~370x speedup** | **-44.7% memory** | **-45.4% allocations** |
